### PR TITLE
fix: トライアルログインのパスを/auth/trial_loginに統一

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -41,4 +41,6 @@ Rails.application.routes.draw do
   if Rails.env.development? || ENV['ENABLE_DEV_ENDPOINTS'] == 'true'
     get '/dev/password_resets/token', to: 'password_resets#dev_token'
   end
+
+  post 'trial_users', to: 'trial_users#create'
 end

--- a/frontend/app/trial/page.tsx
+++ b/frontend/app/trial/page.tsx
@@ -25,14 +25,17 @@ export default function TrialPage() {
       }
 
       // トライアルユーザーのデータを送信
-      const response = await apiClient.post<{ user: User }>("/trial_users", {
-        trial_user: {
-          name: "Test User",
-          email: "test@example.com",
-          password: "password123",
-          password_confirmation: "password123",
-        },
-      });
+      const response = await apiClient.post<{ user: User }>(
+        "/auth/trial_login",
+        {
+          trial_user: {
+            name: "Test User",
+            email: "test@example.com",
+            password: "password123",
+            password_confirmation: "password123",
+          },
+        }
+      );
       const userData = response.user;
       if (userData) {
         // login関数はidがstringであることを期待しているため、変換します


### PR DESCRIPTION
## 変更内容
- フロントエンドのトライアルログインパスを `/trial_users` から `/auth/trial_login` に変更
- バックエンドに `/trial_users` ルートを追加（互換性確保）

## 確認方法
1. Vercel URLにアクセス
2. Create Trial User ボタンをクリック
3. 404エラーが出ないことを確認