### PR TITLE
fix: トライアルユーザー名をユニークに変更

### DIFF
--- a/frontend/app/trial/page.tsx
+++ b/frontend/app/trial/page.tsx
@@ -29,7 +29,7 @@ export default function TrialPage() {
         "/auth/trial_login",
         {
           trial_user: {
-            username: "Test User",
+            username: `Test User ${Date.now()}`,
             email: "test@example.com",
             password: "password123",
             password_confirmation: "password123",


### PR DESCRIPTION
## 変更内容
- トライアルユーザーのusernameにタイムスタンプを追加
- 重複エラーを回避し、毎回異なるユーザーを作成可能に

## 確認方法
1. Vercel URLでCreate Trial Userを複数回クリック
2. 毎回Status 201で成功することを確認
3. 重複エラーが発生しないことを確認