### PR TITLE
fix: Vercel Rewritesで同一オリジン化、Cookie認証を安定化

### DIFF
--- a/frontend/lib/api-config.ts
+++ b/frontend/lib/api-config.ts
@@ -1,12 +1,12 @@
 /**
  * API URL configuration for different environments
- * Handles client-side vs server-side API communication in Docker environment
+ * Handles client-side vs server-side API communication
  */
 
 /**
  * Get the appropriate API URL based on the environment
- * - Server-side (Next.js container): Uses Docker service name 'backend:3001'
- * - Client-side (browser): Uses localhost:3001
+ * - Server-side (Next.js container): Direct connection to the backend (Render or Docker service)
+ * - Client-side (browser): Uses relative path for Vercel Rewrites
  */
 export function getApiUrl(): string {
   const API_PREFIX_PATTERN = /\/api\/v1\/?$/;
@@ -17,15 +17,18 @@ export function getApiUrl(): string {
 
   // Check if we're running on the server side
   if (typeof window === "undefined") {
-    // Server-side: Use Docker internal network
+    // Server-side: Use the full backend URL.
+    // In production (Vercel), this will be the Render URL.
+    // In local Docker, this will be the internal service name.
     return normalizeBaseUrl(
-      process.env.INTERNAL_API_URL || "http://backend:3001"
+      process.env.INTERNAL_API_URL || "https://dreamjournal-app.onrender.com"
     );
   } else {
-    // Client-side: Use localhost (accessible from browser)
-    return normalizeBaseUrl(
-      process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001"
-    );
+    // Client-side: Use a relative path to leverage Vercel Rewrites.
+    // This makes the browser request to the same origin, solving cookie issues.
+    // In local dev, next.config.js rewrites this to http://localhost:3001.
+    // In production, Vercel rewrites this to the Render URL.
+    return "/api";
   }
 }
 

--- a/frontend/lib/apiClient.ts
+++ b/frontend/lib/apiClient.ts
@@ -5,7 +5,8 @@
  * For server-side, the token must be passed explicitly in the options.
  *
  * @param endpoint APIエンドポイント (例: '/dreams')
- * @param options 追加のfetchオプション。サーバーサイドで認証が必要な場合は `token` を含める。
+
+* @param options 追加のfetchオプション。サーバーサイドで認証が必要な場合は `token` を含める。
  * @returns APIからのJSONレスポンス
  */
 import { createApiUrl } from "./api-config";

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -10,6 +10,16 @@ const nextConfig = {
   experimental: {
     optimizePackageImports: ["lucide-react"],
   },
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: "https://dreamjournal-app.onrender.com/:path*",
+      },
+    ];
+  }, 
 };
+
+
 
 export default nextConfig;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2192,11 +2192,6 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-date-fns@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
-  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
-
 debounce@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"


### PR DESCRIPTION
## 変更内容
- next.config.mjsにRewrites設定を追加
- api-config.tsのクライアントサイドを/apiに変更
- Cookie認証が正常に動作するよう修正

## 確認方法
1. Create Trial Userをクリック
2. /homeへ正常遷移