### PR TITLE
feat: お試しモードをローカルのみに変更

### DIFF
--- a/frontend/app/trial/page.tsx
+++ b/frontend/app/trial/page.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import apiClient from "@/lib/apiClient";
-import { useState, useEffect } from "react";
-import { useAuth } from "../../context/AuthContext";
-import { useRouter } from "next/navigation";
-import { User } from "@/app/types";
+import { useState } from "react";
+import Link from "next/link";
 
 export default function TrialPage() {
   const [dreams, setDreams] = useState<
@@ -12,47 +9,6 @@ export default function TrialPage() {
   >([]);
   const [title, setTitle] = useState<string>("");
   const [description, setDescription] = useState<string>("");
-  const [errorMessage, setErrorMessage] = useState<string | null>(null); // エラーメッセージ用の状態
-  const { isLoggedIn, login, userId } = useAuth();
-  const router = useRouter();
-
-  // トライアルユーザーの作成
-  const createTrialUser = async () => {
-    try {
-      const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
-      if (!apiUrl) {
-        throw new Error("NEXT_PUBLIC_API_URL is not defined");
-      }
-
-      // トライアルユーザーのデータを送信
-      const response = await apiClient.post<{ user: User }>(
-        "/auth/trial_login",
-        {
-          trial_user: {
-            username: `Test User ${Date.now()}`,
-            email: `test${Date.now()}@example.com`,
-            password: "password123",
-            password_confirmation: "password123",
-          },
-        }
-      );
-      const userData = response.user;
-      if (userData) {
-        // login関数はidがstringであることを期待しているため、変換します
-        login({
-          ...userData,
-          id: String(userData.id),
-        });
-      } else {
-        throw new Error(
-          "トライアルユーザー作成時のレスポンスに必要なデータが含まれていません。"
-        );
-      }
-      setErrorMessage(null);
-    } catch (error) {
-      setErrorMessage("トライアルユーザーの作成に失敗しました。");
-    }
-  };
 
   // 夢の記録を追加する
   const addDream = () => {
@@ -74,78 +30,79 @@ export default function TrialPage() {
     setDescription("");
   };
 
-  useEffect(() => {
-    if (isLoggedIn === true) {
-      router.push("/home");
-    }
-  }, [isLoggedIn, router]);
-
   return (
     <div className="container mx-auto p-4 bg-background text-foreground">
-      <button
-        onClick={createTrialUser}
-        className="bg-primary text-primary-foreground py-2 px-4 rounded hover:bg-primary/90"
-      >
-        Create Trial User
-      </button>
+      <div className="mb-6 p-4 bg-card border border-border rounded-lg">
+        <h1 className="text-2xl font-bold mb-2 text-foreground">
+          お試し体験モード
+        </h1>
+        <p className="text-muted-foreground mb-4">
+          登録不要で夢の記録を体験できます。ただし、ページをリロードするとデータは消えます。
+        </p>
+        <div className="p-3 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded">
+          <p className="text-sm text-yellow-800 dark:text-yellow-200">
+            💡 夢を永続的に保存したい場合は、ユーザー登録が必要です
+          </p>
+        </div>
+      </div>
 
-      {/* エラーメッセージがある場合は表示 */}
-      {errorMessage && <p className="text-destructive mt-4">{errorMessage}</p>}
-
-      {/* ユーザーが作成された場合 */}
-      {userId && (
-        <div className="mt-6">
-          <h2 className="text-2xl font-bold mb-4 text-foreground">夢の記録</h2>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              addDream();
-            }}
-            className="mb-6 bg-card p-6 rounded-lg border border-border"
-          >
-            <div className="mb-4">
-              <label
-                htmlFor="title"
-                className="block text-sm font-medium text-card-foreground"
-              >
-                夢のタイトル:
-              </label>
-              <input
-                id="title"
-                name="title"
-                type="text"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                className="mt-1 block w-full px-3 py-2 border border-input bg-background text-foreground rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring sm:text-sm"
-              />
-            </div>
-            <div className="mb-4">
-              <label
-                htmlFor="description"
-                className="block text-sm font-medium text-card-foreground"
-              >
-                夢の内容:
-              </label>
-              <textarea
-                id="description"
-                name="description"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                className="w-full h-32 border border-input bg-background text-foreground px-3 py-2 rounded-md focus:ring-2 focus:ring-ring"
-              />
-            </div>
-            <button
-              type="submit"
-              className="bg-primary text-primary-foreground py-2 px-4 rounded hover:bg-primary/90"
+      <div className="mb-6">
+        <h2 className="text-2xl font-bold mb-4 text-foreground">夢の記録</h2>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            addDream();
+          }}
+          className="mb-6 bg-card p-6 rounded-lg border border-border"
+        >
+          <div className="mb-4">
+            <label
+              htmlFor="title"
+              className="block text-sm font-medium text-card-foreground"
             >
-              夢を記録する
-            </button>
-          </form>
+              夢のタイトル:
+            </label>
+            <input
+              id="title"
+              name="title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="mt-1 block w-full px-3 py-2 border border-input bg-background text-foreground rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring sm:text-sm"
+            />
+          </div>
+          <div className="mb-4">
+            <label
+              htmlFor="description"
+              className="block text-sm font-medium text-card-foreground"
+            >
+              夢の内容:
+            </label>
+            <textarea
+              id="description"
+              name="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="w-full h-32 border border-input bg-background text-foreground px-3 py-2 rounded-md focus:ring-2 focus:ring-ring"
+            />
+          </div>
+          <button
+            type="submit"
+            className="bg-primary text-primary-foreground py-2 px-4 rounded hover:bg-primary/90"
+          >
+            夢を記録する
+          </button>
+        </form>
 
-          <h3 className="text-xl font-semibold mb-2 text-foreground">
-            記録された夢
-          </h3>
-          <ul className="list-disc pl-5">
+        <h3 className="text-xl font-semibold mb-2 text-foreground">
+          記録された夢 ({dreams.length}/7)
+        </h3>
+        {dreams.length === 0 ? (
+          <p className="text-muted-foreground">
+            まだ夢が記録されていません。上のフォームから記録してみましょう。
+          </p>
+        ) : (
+          <ul className="list-disc pl-5 mb-6">
             {dreams.map((dream, index) => (
               <li key={index} className="mb-2">
                 <h4 className="text-lg font-bold text-foreground">
@@ -155,8 +112,20 @@ export default function TrialPage() {
               </li>
             ))}
           </ul>
+        )}
+
+        <div className="mt-6 p-4 bg-card border border-border rounded-lg text-center">
+          <p className="text-foreground mb-4">
+            夢を永続的に保存して、いつでも振り返りたいですか？
+          </p>
+          <Link
+            href="/register"
+            className="inline-block bg-primary text-primary-foreground py-2 px-6 rounded hover:bg-primary/90"
+          >
+            ユーザー登録して保存する
+          </Link>
         </div>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 変更内容
- バックエンドへのリクエストを削除（データベースに保存しない）
- 夢の記録をReact stateのみで管理
- 採用担当者が登録不要で即座に体験可能に
- ユーザー登録を促すUIを追加

## 確認方法
1. /trialページを開く
2. 夢を記録
3. リロードでデータが消えることを確認