### PR TITLE
ログイン後の即時UI更新を修正

### DIFF
--- a/frontend/app/Header.tsx
+++ b/frontend/app/Header.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Moon, Sparkles } from "lucide-react";
 import { getServerAuth } from "@/lib/server-auth";
 import AuthNav from "./components/AuthNav";
 
@@ -9,8 +10,13 @@ export default async function Header() {
     <header className="py-5 px-4 sm:px-6 md:px-10 border-b border-border bg-background text-foreground flex flex-col sm:flex-row justify-between items-center">
       <div className="mb-4 sm:mb-0">
         <h1 className="text-2xl md:text-4xl font-extrabold">
-          <Link href="/" className="text-primary hover:text-primary/90">
+          <Link
+            href="/"
+            className="flex items-center gap-2 text-primary hover:text-primary/90"
+          >
+            <Moon className="text-blue-300" size={28} />
             ユメログ
+            <Sparkles className="text-yellow-300" size={20} />
           </Link>
         </h1>
       </div>

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -11,7 +11,7 @@ export default function Login() {
   const [password, setPassword] = useState("");
   const [pageError, setPageError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const { login, isLoggedIn, error: authError } = useAuth();
+  const { login, error: authError } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
@@ -19,12 +19,6 @@ export default function Login() {
       setPageError(authError);
     }
   }, [authError]);
-
-  useEffect(() => {
-    if (isLoggedIn) {
-      router.push("/");
-    }
-  }, [isLoggedIn, router]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -41,8 +35,9 @@ export default function Login() {
       const { user } = await clientLogin({ email, password });
       // 成功したら、取得したユーザー情報でログイン処理を呼び出します。
       login(user);
-      // ログイン状態の更新を待ってからリダイレクトするため、useEffectに任せます
-      // router.push("/home"); // ここで直接呼ぶ代わりにuseEffectを使う
+      // ログイン成功後、直接リダイレクト＋refresh
+      router.push("/");
+      router.refresh(); // サーバーコンポーネントを再取得してUIを更新
     } catch (apiError: any) {
       console.error("ログインAPI呼び出しエラー:", apiError);
       // 以前: エラーメッセージは深い階層にありました (apiError.response.data.error)。


### PR DESCRIPTION
## 変更内容
### Header.tsx
- lucide-reactからMoonとSparklesをimport
- ロゴの左に月（青色・28px）、右に星（黄色・20px）を配置

### login/page.tsx
- useEffectを削除してrouter.push()とrouter.refresh()を直接呼び出し
- ログイン後の即座のボタン切り替えを実現

## 家族フィードバック対応
✅ 「アイコンを夢のイメージに（月・夜・星）」

## 技術的改善
✅ Server Componentを維持しながらUX向上
✅ Next.js公式推奨の方法を採用

## スクリーンショット
🌙 ユメログ ✨  [ログアウト]
（ログイン後、リロード不要で即座に切り替わる）