### PR TITLE
Fix: 起動時の db:prepare を廃止し、Render Pre-Deploy でマイグレーションを実行

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -109,11 +109,17 @@ fi
 # - 初回起動でも再起動でも同じコマンドで対応可能
 
 echo "🗄️ データベース準備中..."
-if bundle exec rails db:prepare; then
-    echo "✅ データベース準備完了"
+# 本番環境(Render)では Pre-Deploy Command でマイグレーションを行うため、
+# ここでは開発環境のみ実行するように変更（起動時の競合・タイムアウト回避）
+if [ "$RAILS_ENV" = "development" ]; then
+    if bundle exec rails db:prepare; then
+        echo "✅ [開発環境] データベース準備完了"
+    else
+        echo "❌ [開発環境] データベース準備エラー"
+        exit 1
+    fi
 else
-    echo "❌ データベース準備エラー"
-    exit 1
+    echo "ℹ️  [本番環境] entrypointでのdb:prepareをスキップします (Pre-Deploy Commandに委譲)"
 fi
 
 # ========================================


### PR DESCRIPTION
## 概要
Render 本番環境の起動時に `db:prepare` を実行していたため、
DB 接続が不安定なタイミングで起動に失敗する問題が発生していました。

起動処理とデータベース操作の責務を分離し、
本番運用に適した構成へ修正します。

## 変更内容
- `entrypoint.sh` から `bundle exec rails db:prepare` を削除
- アプリ起動時に DB を操作しない構成へ変更
- DB マイグレーションは Render の Pre-Deploy Command で実行する前提に整理

## 目的・背景
- 起動時に DB 接続が確立していない状態で `db:prepare` が実行され、デプロイが失敗していた
- 本番環境では「起動処理」と「DB マイグレーション」を分離する方が安全なため

## 確認方法
- Render にて Manual Deploy を実行
- Pre-Deploy で `db:migrate` が正常に完了すること
- Puma が正常に起動し、アプリが起動することを確認

## 影響範囲
- バックエンド起動フローのみ
- アプリの機能仕様・ユーザー影響なし