### PR TITLE
fix(infra): Render FreeのDBコールドスタート対策で接続待機を180秒に延長

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -77,16 +77,19 @@ fi
 echo "🔌 データベース接続待機中..."
 echo "🔌 データベース接続待機中..."
 # Render Free Tier対策: DATABASE_URLがあっても必ず接続確認を行う
-# 特にコールドスタート時はDB接続確立まで時間がかかるため
-max_attempts=30
+# 特にコールドスタート時はDB接続確立まで時間がかかるため(最大3分待機)
+max_attempts=90
 attempt=1
 
 while [ $attempt -le $max_attempts ]; do
     if [ -n "$DATABASE_URL" ]; then
         # pg_isready は接続文字列を受け取れる
-        if pg_isready -d "$DATABASE_URL" >/dev/null 2>&1; then
+        # 失敗時の理由を知るために stderr を表示する
+        if pg_isready -d "$DATABASE_URL"; then
              echo "✅ データベース接続成功 (${attempt}回目の試行)"
              break
+        else
+             echo "⚠️  接続トライ ${attempt}: pg_isready が失敗しました"
         fi
     else
         # ローカルDocker環境向け


### PR DESCRIPTION
## 概要
Render FreeプランのDBがスリープ状態から復帰するまでに時間がかかり、
起動時のDB接続が間に合わずデプロイが失敗する問題が発生していました。

## 対応内容
- DB接続待機時間を 60秒 → 180秒 に延長
- pg_isready による接続待機ロジックを強化

## 目的
- Render Freeプラン特有のコールドスタートに耐えられる起動フローの実現
- 本番デプロイの安定性向上

## 確認
- ローカルで entrypoint.sh の構文確認済み
- Renderでの再デプロイ後、接続待機ログと起動成功を確認予定
## 概要
Render FreeプランのDBがスリープ状態から復帰するまでに時間がかかり、
起動時のDB接続が間に合わずデプロイが失敗する問題が発生していました。


