### PR TITLE
fix(infra): Supabase移行に伴いpg_isreadyによるDB接続待機を削除

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -76,37 +76,30 @@ fi
 
 echo "🔌 データベース接続待機中..."
 echo "🔌 データベース接続待機中..."
-# Render Free Tier対策: DATABASE_URLがあっても必ず接続確認を行う
-# 特にコールドスタート時はDB接続確立まで時間がかかるため(最大3分待機)
-max_attempts=90
-attempt=1
+# Render(Supabase)の場合、pg_isreadyが外部接続(SSL)に対応しきれず失敗することがあるため、
+# DATABASE_URLがある場合はチェックをスキップしてRailsに接続を任せる
+if [ -n "$DATABASE_URL" ]; then
+    echo "✅ DATABASE_URLを検出 - 外部DB(Supabase等)のため、entrypointでの接続確認をスキップします"
+else
+    # ローカルDocker環境向け: 開発用DBが起きるのを待つ
+    max_attempts=30
+    attempt=1
 
-while [ $attempt -le $max_attempts ]; do
-    if [ -n "$DATABASE_URL" ]; then
-        # pg_isready は接続文字列を受け取れる
-        # 失敗時の理由を知るために stderr を表示する
-        if pg_isready -d "$DATABASE_URL"; then
-             echo "✅ データベース接続成功 (${attempt}回目の試行)"
-             break
-        else
-             echo "⚠️  接続トライ ${attempt}: pg_isready が失敗しました"
-        fi
-    else
-        # ローカルDocker環境向け
+    while [ $attempt -le $max_attempts ]; do
         if PGPASSWORD="$POSTGRES_PASSWORD" psql -h db -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT 1;" >/dev/null 2>&1; then
             echo "✅ データベース接続成功 (${attempt}回目の試行)"
             break
         fi
-    fi
-    
-    echo "⏳ データベース接続待機... (${attempt}/${max_attempts})"
-    sleep 2 
-    attempt=$((attempt + 1))
-done
+        
+        echo "⏳ データベース接続待機... (${attempt}/${max_attempts})"
+        sleep 1
+        attempt=$((attempt + 1))
+    done
 
-if [ $attempt -gt $max_attempts ]; then
-    echo "❌ データベース接続タイムアウト - 接続できませんでした"
-    exit 1
+    if [ $attempt -gt $max_attempts ]; then
+        echo "❌ データベース接続タイムアウト - 30秒以内に接続できませんでした"
+        exit 1
+    fi
 fi
 
 # ========================================


### PR DESCRIPTION
## 概要
Renderデプロイ時の `entrypoint.sh` における `pg_isready` によるデータベース接続待機ロジックを削除（またはスキップ）するように修正しました。

## 変更の背景・理由
* **Supabaseへの移行:** Render Free DBからSupabase（常時稼働）へ移行したため、コールドスタート対策の待機ループが不要になりました。
* **ヘルスチェックの誤検知:** Supabase（外部DB/SSL接続）に対し、コンテナ内の `pg_isready` が正しく接続確認できず、実際には接続可能なのに「タイムアウト」としてデプロイを失敗させる事象（False Positive）が発生していました。
* **Railsへの委譲:** DB接続の確立とリトライは、インフラ側のシェルスクリプトではなく、アプリケーション（Rails/Puma）側の接続ロジックに任せる方針に変更します。

## 変更内容
* `backend/entrypoint.sh`: `pg_isready` ループによるブロッキング処理を削除。

## 動作確認
* Renderでのデプロイログにて、待機ループに入らず即座にRailsサーバー（Puma）の起動シーケンスへ移行することを確認します。
