### PR TITLE
feat(backend): Sentry導入でエラー監視を追加

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -50,6 +50,10 @@ gem 'net-http'
 gem 'uri'
 gem 'event_stream_parser'
 
+# Error monitoring
+gem "sentry-ruby"
+gem "sentry-rails"
+
 group :development, :test do
   # Debugging
   gem "debug", platforms: [:mri, :mingw, :x64_mingw]

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -304,6 +304,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    sentry-rails (6.2.0)
+      railties (>= 5.2.0)
+      sentry-ruby (~> 6.2.0)
+    sentry-ruby (6.2.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     sprockets (4.2.2)
@@ -376,6 +382,8 @@ DEPENDENCIES
   rspec-rails (~> 6.1.0)
   ruby-openai (~> 5.0)
   selenium-webdriver
+  sentry-rails
+  sentry-ruby
   shoulda-matchers (~> 5.3.0)
   sprockets-rails
   stimulus-rails

--- a/backend/config/initializers/sentry.rb
+++ b/backend/config/initializers/sentry.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+Sentry.init do |config|
+  # DSNは環境変数から取得（Render/本番環境で設定）
+  config.dsn = ENV["SENTRY_DSN"]
+
+  # 現在の環境（development, test, production）を設定
+  config.environment = Rails.env
+
+  # Breadcrumbs（パンくずリスト）を無効化する場合は以下をアンコメント
+  # config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+
+  # トレースサンプルレート（パフォーマンス監視）
+  # 開発/検証時は100%、本番では10%程度に下げることを推奨
+  config.traces_sample_rate = Rails.env.production? ? 0.1 : 1.0
+
+  # プロファイリング（任意）
+  # config.profiles_sample_rate = 1.0
+
+  # 本番環境でのみ有効化する場合（テスト完了後にコメントを外す）
+  # config.enabled_environments = %w[production staging]
+
+  # 送信前にイベントを加工・フィルタリングする場合
+  config.before_send = lambda do |event, hint|
+    # パスワードなどセンシティブな情報をフィルタリング
+    event
+  end
+end


### PR DESCRIPTION
## 概要
Rails API に Sentry を導入し、バックエンドのエラー監視体制を構築しました。
これにより、本番・開発環境における例外や異常を即時検知できるようになります。

## 変更内容
- `sentry-ruby` / `sentry-rails` gem を追加
- `config/initializers/sentry.rb` を新規作成
- DSN を環境変数 `SENTRY_DSN` から取得する構成に変更

## 設定詳細
- 開発環境：トレースサンプルレート 100%
- 本番環境：トレースサンプルレート 10%
- 環境識別は `Rails.env` を使用
- センシティブ情報送信防止のため `before_send` フックを用意（現状は通過のみ）

## テスト結果
- ✅ Docker 環境の Rails console から `Sentry.capture_message` を実行し、イベント送信を確認
- ✅ Sentry ダッシュボード上で `dream-journal-backend` プロジェクトへの着弾を確認

## 必要な環境変数（Render）

