### PR TITLE
fix: ページ側をauthStatusベースの判定に移行してchecking中の早期リダイレクトを防ぐ

### DIFF
--- a/frontend/app/dream/month/[yearMonth]/page.tsx
+++ b/frontend/app/dream/month/[yearMonth]/page.tsx
@@ -13,9 +13,9 @@ export default function DreamByMonthPage() {
   const yearMonth = params.yearMonth; // URLのパラメータからyearMonthを取得
   const [dreams, setDreams] = useState<Dream[]>([]); // 夢データを保存するための変数
   const [errorMessage, setErrorMessage] = useState<string | null>(null); // エラーメッセージの状態管理
-  const { isLoggedIn } = useAuth();
+  const { authStatus } = useAuth();
   const fetchDreamsByMonth = useCallback(async () => {
-    if (yearMonth && isLoggedIn) {
+    if (yearMonth && authStatus === "authenticated") {
       try {
         const response = await apiClient.get<Dream[]>(
           `/dreams/month/${yearMonth}`
@@ -27,18 +27,18 @@ export default function DreamByMonthPage() {
         setErrorMessage("夢の取得に失敗しました");
       }
     }
-  }, [yearMonth, isLoggedIn]);
+  }, [yearMonth, authStatus]);
 
   useEffect(() => {
-    if (isLoggedIn === true) {
+    if (authStatus === "authenticated") {
       fetchDreamsByMonth();
     }
-  }, [isLoggedIn, fetchDreamsByMonth]);
+  }, [authStatus, fetchDreamsByMonth]);
 
-  if (isLoggedIn === null) {
+  if (authStatus === "checking") {
     return <Loading />;
   }
-  if (!isLoggedIn) {
+  if (authStatus === "unauthenticated") {
     return (
       <div className="container mx-auto p-5 bg-background text-foreground">
         <p>このページを表示するにはログインが必要です。</p>

--- a/frontend/app/dream/new/page.tsx
+++ b/frontend/app/dream/new/page.tsx
@@ -12,15 +12,15 @@ import { triggerDreamConfetti } from "@/lib/confetti";
 
 export default function NewDreamPage() {
   const router = useRouter();
-  const { isLoggedIn } = useAuth();
+  const { authStatus } = useAuth();
   const [isSaving, setIsSaving] = useState(false);
 
-  if (isLoggedIn === null) {
+  if (authStatus === "checking") {
     return <Loading />;
   }
 
   const handleCreateSubmit = async (formData: DreamInput) => {
-    if (!isLoggedIn) {
+    if (authStatus === "unauthenticated") {
       alert("ログインが必要です。");
       router.push("/login");
       return;
@@ -40,7 +40,7 @@ export default function NewDreamPage() {
     }
   };
 
-  if (!isLoggedIn) {
+  if (authStatus === "unauthenticated") {
     return (
       <div className="min-h-screen py-8 px-4 md:px-12 max-w-3xl mx-auto">
         <p>このページを表示するにはログインが必要です。</p>

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -15,15 +15,15 @@ export default function Register() {
   const [agreedToTerms, setAgreedToTerms] = useState(false);
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const { login, isLoggedIn } = useAuth();
+  const { login, authStatus } = useAuth();
   const router = useRouter();
 
   // 1. 既にログインしているユーザーをホームページに案内する機能
   useEffect(() => {
-    if (isLoggedIn) {
+    if (authStatus === "authenticated") {
       router.push("/home");
     }
-  }, [isLoggedIn, router]);
+  }, [authStatus, router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -18,7 +18,7 @@ const generateMathProblem = () => {
 };
 
 const SettingsPage = () => {
-  const { isLoggedIn, userId, logout, deleteUser } = useAuth();
+  const { authStatus, userId, logout, deleteUser } = useAuth();
   const router = useRouter();
 
   // モーダルとロックの状態
@@ -72,7 +72,7 @@ const SettingsPage = () => {
     }
   };
 
-  if (isLoggedIn === null) {
+  if (authStatus === "checking") {
     return <Loading />;
   }
 


### PR DESCRIPTION
## 📋 概要

PR #54でAuthContextを3状態管理に修正しましたが、ページ側はまだ`isLoggedIn`前提のままでした。

このPRでは、各ページを`authStatus`ベースの判定に移行し、`checking`中の早期リダイレクトを防ぎます。

---

## 🔍 問題

### **症状**

- PR #54マージ後も、ログイン成功後にお試しページにリダイレクトされる

### **原因**

- AuthContextを3状態管理に修正したが、ページ側は`isLoggedIn`前提のまま
- `authStatus === "checking"`の間、`isLoggedIn === false`となり、未認証と誤判定される
- 結果、`/auth/verify`が完了する前にリダイレクトされる

---

## ✅ 解決策

### **修正内容**

各ページで`isLoggedIn`の代わりに`authStatus`を使用：

- `authStatus === "checking"` → Loadingを表示
- `authStatus === "authenticated"` → ページを表示
- `authStatus === "unauthenticated"` → リダイレクト

### **変更前**

```typescript
const { isLoggedIn } = useAuth();

if (isLoggedIn === null) {
  return <Loading />;
}

if (!isLoggedIn) {
  router.push("/");
  return null;
}