### PR TITLE
fix: ログインページで既にログイン済みのユーザーを/homeにリダイレクト

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -11,8 +11,15 @@ export default function Login() {
   const [password, setPassword] = useState("");
   const [pageError, setPageError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const { login, error: authError } = useAuth();
+  const { login, authStatus, error: authError } = useAuth();
   const router = useRouter();
+
+  // 既にログインしているユーザーをホームページに案内する
+  useEffect(() => {
+    if (authStatus === "authenticated") {
+      router.push("/home");
+    }
+  }, [authStatus, router]);
 
   useEffect(() => {
     if (authError) {


### PR DESCRIPTION
## 📋 概要

ログイン成功後、お試しページ（`/`）にリダイレクトされる問題を修正しました。

---

## 🔍 問題

### **症状**

- ログイン成功後、`/home`にリダイレクトされるが、`/home`ページでCookieチェックが行われ、`/login`にリダイレクトされる
- その後、`/login`ページでは既にログイン済みの場合のリダイレクト処理がないため、お試しページ（`/`）に遷移してしまう

### **原因**

- `/login/page.tsx`に既にログイン済みの場合のリダイレクト処理がなかった

---

## ✅ 解決策

### **修正内容**

`authStatus === "authenticated"`の場合、`/home`にリダイレクトする処理を追加

### **変更前**

```typescript
const { login, error: authError } = useAuth();
const router = useRouter();

useEffect(() => {
  if (authError) {
    setPageError(authError);
  }
}, [authError]);