### PR TITLE
fix: クロスドメイン対策のためServerSideの認証チェックを削除

### DIFF
--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -54,12 +54,10 @@ export default async function HomePage({
 
   console.log("[HomePage] Rendering at", new Date().toISOString());
 
+  // クロスドメイン環境（Vercel × Render）では、Server側でCookieをチェックできない
+  // AuthContextで認証を管理するため、ここではチェックしない
   const cookieStore = await cookies();
-  const token = cookieStore.get("access_token")?.value;
-
-  if (!token) {
-    redirect("/login");
-  }
+  const token = cookieStore.get("access_token")?.value || "";
 
   const resolvedSearchParams = await searchParams;
 
@@ -91,11 +89,8 @@ export default async function HomePage({
       getMe(token),
     ]);
   } catch (error) {
-    // fetch に失敗した場合、特にトークンが無効(401)な場合は、
-    // ログインページにリダイレクトするのが安全。
-    if (error instanceof Error && error.message.includes("401")) {
-      redirect("/login");
-    }
+    // クロスドメイン環境では、Server側でリダイレクトせず、
+    // AuthContextに任せる
     console.error("Error fetching data on server:", error);
     errorMessage =
       "データの取得に失敗しました。ページを再読み込みしてください。";


### PR DESCRIPTION
## 📋 概要

Vercel × Render のクロスドメイン環境で発生していた無限リダイレクトループを修正しました。

---

## 🔍 問題

### **症状**

- ログイン成功後、`/home`にリダイレクトされるが、無限リダイレクトループが発生
- ブラウザのコンソールに`307 Temporary Redirect`が繰り返し表示される
- 画面遷移が完了しない

### **原因**

**クロスドメイン環境（Vercel × Render）での認証チェックの二重化**

1. **Client Component**（`/login/page.tsx`）：`AuthContext`の`authStatus`を使用
2. **Server Component**（`/home/page.tsx`）：Cookieを直接チェック

この2つの認証チェックがズレた瞬間に、無限ループが発生：
