### PR TITLE
fix: Server Componentのまま認証判定をClient側に委譲

### DIFF
--- a/frontend/app/components/IndexRedirectClient.tsx
+++ b/frontend/app/components/IndexRedirectClient.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/context/AuthContext";
+
+export default function IndexRedirectClient() {
+  const router = useRouter();
+  const { authStatus } = useAuth();
+
+  useEffect(() => {
+    if (authStatus === "authenticated") {
+      router.replace("/home");
+    } else if (authStatus === "unauthenticated") {
+      router.replace("/trial");
+    }
+  }, [authStatus, router]);
+
+  return (
+    <div className="flex min-h-[40vh] items-center justify-center text-muted-foreground">
+      認証状態を確認しています…
+    </div>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,14 +1,6 @@
-// app/page.tsx
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
+import IndexRedirectClient from "./components/IndexRedirectClient";
 
-export default async function IndexPage() {
-  const cookieStore = await cookies();
-  const token = cookieStore.get("access_token")?.value;
-
-  if (token) {
-    redirect("/home");
-  } else {
-    redirect("/trial");
-  }
+export default function IndexPage() {
+  // Server Componentのまま、認証判定はClient側に委譲
+  return <IndexRedirectClient />;
 }


### PR DESCRIPTION
- 新規作成: IndexRedirectClient.tsx（Client Component）
  - AuthContextのauthStatusを使用して認証判定
  - router.replace()でリダイレクト
  - 認証確認中はローディング表示
- 更新: page.tsx（Server Component）
  - IndexRedirectClientを呼び出すだけ
  - クロスドメイン環境（Vercel × Render）でも動作
