### PR TITLE
fix: クロスドメイン環境でMiddlewareの認証チェックをスキップ

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -3,6 +3,13 @@ import type { NextRequest } from "next/server";
 import { createApiUrl } from "./lib/api-config";
 
 export async function middleware(request: NextRequest) {
+  // クロスドメイン環境ではCookieがVercel Edgeから見えないため、
+  // 認証判定はClient側に委譲する（将来の同一ドメイン運用で復活可能）
+  const authMode = process.env.NEXT_PUBLIC_AUTH_MODE;
+  if (authMode === "client") {
+    return NextResponse.next();
+  }
+
   // E2Eテスト実行時は、認証チェックをバイパスして後続の処理に進む
   // 1) 環境変数 (PlaywrightがwebServer起動時に設定)
   // 2) クッキー __e2e__=1 （既存サーバー再利用時のためのフォールバック）


### PR DESCRIPTION
## 概要
クロスドメイン環境（Vercel × Render）でMiddlewareの認証チェックをスキップし、Client側（AuthContext）に委譲する修正です。

## 変更内容
- 環境変数`NEXT_PUBLIC_AUTH_MODE=client`でMiddlewareの認証チェックをスキップ
- 認証判定はClient側（AuthContext）に委譲
- 将来の同一ドメイン化時に環境変数を削除するだけでMiddlewareを復活可能

## 解決した問題
- クロスドメイン環境では、MiddlewareでCookieを読めないため、常に未ログインと誤判定されていた
- ログイン後に/homeにアクセスすると、/loginにリダイレクトされる問題を解決

## 環境変数の設定
Vercelに以下の環境変数を設定する必要があります：
- **Key**: `NEXT_PUBLIC_AUTH_MODE`
- **Value**: [client](cci:1://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/frontend/lib/apiClient.ts:150:0-160:1)

