### PR TITLE
fix: ヘッダーの認証状態をAuthContextから取得

### DIFF
--- a/frontend/app/components/AuthNav.tsx
+++ b/frontend/app/components/AuthNav.tsx
@@ -1,32 +1,38 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter, usePathname } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { Button } from "./ui/button";
-import { clientLogout } from "@/lib/apiClient";
 import { toast } from "@/lib/toast";
+import { useAuth } from "@/context/AuthContext";
 import {
   House,
   Pencil,
-  Book,
   Settings,
   LogOut,
   LogIn,
   UserPlus,
+  Loader2,
 } from "lucide-react";
 
+// propsは互換性のために残すが、AuthContextを優先使用
 interface AuthNavProps {
-  isAuthenticated: boolean;
+  isAuthenticated?: boolean;
 }
 
-export default function AuthNav({ isAuthenticated }: AuthNavProps) {
-  const router = useRouter();
+export default function AuthNav(_props: AuthNavProps) {
   const pathname = usePathname();
+
+  // クロスドメイン環境ではServer側でCookieを読めないため、
+  // AuthContextで認証状態を取得する
+  const { authStatus, isLoggedIn, logout } = useAuth();
+
+  // AuthContextの状態を優先使用
+  const isAuthenticated = isLoggedIn;
 
   const handleLogout = async () => {
     try {
-      await clientLogout();
-      router.refresh();
+      await logout();
     } catch (error: any) {
       toast.error(error.message || "おしまいに できませんでした。");
     }
@@ -71,6 +77,18 @@ export default function AuthNav({ isAuthenticated }: AuthNavProps) {
       </Link>
     );
   };
+
+  // 認証確認中はローディング表示
+  if (authStatus === "checking") {
+    return (
+      <nav className="flex justify-center md:justify-end gap-3 w-full">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="animate-spin" size={18} />
+          <span className="text-sm">かくにんちゅう…</span>
+        </div>
+      </nav>
+    );
+  }
 
   if (!isAuthenticated) {
     return (

--- a/frontend/app/components/DreamCard.tsx
+++ b/frontend/app/components/DreamCard.tsx
@@ -8,7 +8,6 @@ function formatDate(dateInput: string | number | Date | undefined): string {
   if (!dateInput) return "";
   const date = new Date(dateInput);
   if (Number.isNaN(date.getTime())) return "";
-  const year = date.getFullYear();
   const month = date.getMonth() + 1;
   const day = date.getDate();
   return `${month}月${day}日`;

--- a/frontend/app/components/DreamForm.tsx
+++ b/frontend/app/components/DreamForm.tsx
@@ -5,7 +5,6 @@ import React, { useState, useEffect } from "react";
 import { Dream, Emotion, DreamDraftData } from "../types";
 import { getEmotions, previewAnalysis } from "@/lib/apiClient";
 import { toast } from "@/lib/toast";
-import { getEmotionColors } from "@/lib/emotionUtils";
 import { getChildFriendlyEmotionLabel } from "./EmotionTag";
 
 interface DreamFormData {
@@ -142,13 +141,7 @@ export default function DreamForm({
     });
   }, [emotions, isDraftApplied, suggestedEmotionNames]);
 
-  const handleEmotionChange = (emotionId: number) => {
-    setSelectedEmotionIds((prevIds) =>
-      prevIds.includes(emotionId)
-        ? prevIds.filter((id) => id !== emotionId)
-        : [...prevIds, emotionId]
-    );
-  };
+  // handleEmotionChange は新しいUIで直接使用されなくなったため削除
 
   const handleAnalyze = async () => {
     if (!content.trim()) {

--- a/frontend/app/components/DreamList.tsx
+++ b/frontend/app/components/DreamList.tsx
@@ -3,7 +3,7 @@
 import { Dream } from "@/app/types";
 import React from "react";
 import DreamCard from "./DreamCard";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 
 interface DreamListProps {
   dreams: Dream[];

--- a/frontend/app/components/DreamRecorderFloating.tsx
+++ b/frontend/app/components/DreamRecorderFloating.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "@/lib/toast";
 import useVoiceRecorder from "@/hooks/useVoiceRecorder";
 import { uploadAndAnalyzeAudio } from "@/lib/audioAnalysis";
-import type { AnalysisResult, DreamDraftData } from "@/app/types";
+import type { AnalysisResult } from "@/app/types";
 import { motion, AnimatePresence } from "framer-motion";
 import { Mic, Square, Loader2 } from "lucide-react";
 

--- a/frontend/app/dream/[id]/page.tsx
+++ b/frontend/app/dream/[id]/page.tsx
@@ -5,7 +5,6 @@ import DeleteButton from "../../components/DeleteButton";
 import { useDream, type DreamInput } from "../../../hooks/useDream";
 import { useRouter } from "next/navigation";
 import { useState, useEffect, use } from "react";
-import dynamic from "next/dynamic";
 import {
   AlertDialog,
   AlertDialogAction,

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -5,7 +5,6 @@ import { Dream } from "@/app/types";
 import { cookies } from "next/headers";
 import { getMyDreams, getMe } from "@/lib/apiClient";
 import type { User } from "@/app/types";
-import { redirect } from "next/navigation";
 import MorpheusAssistant from "./MorpheusAssistant";
 import VoiceRecorderClient from "./VoiceRecorderClient";
 


### PR DESCRIPTION
## 概要
ヘッダーの認証状態をServer側のpropsではなく、AuthContextから取得するように修正しました。

## 変更内容
- [AuthNav.tsx](cci:7://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/frontend/app/components/AuthNav.tsx:0:0-0:0)を修正
- Server側のpropsではなくAuthContextから認証状態を取得
- 認証確認中（checking）はローディング表示を追加
- ログアウト処理もAuthContextのlogout関数に統一

## 解決した問題
- クロスドメイン環境（Vercel × Render）では、Server側でCookieを読めないため、ヘッダーが常に未ログイン状態になっていた
- この修正により、ログイン後にヘッダーが正しく切り替わるようになった

## テスト
- [ ] ローカル環境でビルド成功
- [ ] 本番環境でログイン後にヘッダーが切り替わることを確認