### PR TITLE
fix: Vercel RewriteでサードパーティCookie問題を解決

### DIFF
--- a/frontend/lib/api-config.ts
+++ b/frontend/lib/api-config.ts
@@ -36,8 +36,9 @@ export function getApiUrl(): string {
         window.location.hostname.includes("vercel.app"));
 
     if (process.env.NODE_ENV === "production" && isVercel) {
-      // Vercel本番環境: 直接Renderに接続
-      return "https://dreamjournal-app.onrender.com";
+      // Vercel本番環境: Vercel Rewriteを使用（サードパーティCookie問題を回避）
+      // /api/* へのリクエストはnext.config.mjsのrewritesでRenderに転送される
+      return "/api";
     }
     return "http://localhost:3001";
   }


### PR DESCRIPTION
## 概要
クロスドメイン環境（Vercel × Render）でサードパーティCookieがブロックされる問題を、Vercel Rewriteを使用して解決しました。

## 変更内容
- [api-config.ts](cci:7://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/frontend/lib/api-config.ts:0:0-0:0)を修正: Vercel本番環境で直接RenderにアクセスせずVercel Rewriteを使用
- `/api/*`へのリクエストは[next.config.mjs](cci:7://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/frontend/next.config.mjs:0:0-0:0)のrewritesでRenderに転送される
- ブラウザから見ると同一ドメイン扱いになり、Cookieが正しく送信される

## 背景
- クロスドメイン環境（vercel.app → onrender.com）ではサードパーティCookieとして扱われる
- 現代ブラウザ（Chrome/Safari/Firefox）はサードパーティCookieをブロック
- `credentials: "include"`を設定しても、Cookieが送信されなかった

## 解決策
- Vercel Rewriteを使用して、ブラウザからは同一ドメインに見えるようにする
- これによりCookieがファーストパーティ扱いになり、正しく送信される

## 6つのAIが同じ結論
- Codex、ChatGPT、Gemini、Antigravityが全て「Vercel Rewrite」を推奨