### PR TITLE
fix: OpenAI APIのnil応答に対するエラーハンドリング追加

### DIFF
--- a/backend/app/services/dream_analysis_service.rb
+++ b/backend/app/services/dream_analysis_service.rb
@@ -32,6 +32,12 @@ class DreamAnalysisService
       })
 
       content = response.dig("choices", 0, "message", "content")
+
+      if content.nil?
+        Rails.logger.error "OpenAI API returned nil content. Response: #{response.to_json}"
+        return { error: "AIからの応答が空でした。APIキーを確認してください。" }
+      end
+
       parsed = JSON.parse(content)
 
       unless parsed.is_a?(Hash)


### PR DESCRIPTION

## 解決策

### コード修正
- `content` が `nil` の場合に明確なエラーメッセージを返すように修正
- デバッグ用にレスポンス全体をログに出力

### 環境変数修正
- Renderの `OPENAI_API_KEY` を正しい値に更新済み ✅

## 変更内容
- [backend/app/services/dream_analysis_service.rb](cci:7://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/backend/app/services/dream_analysis_service.rb:0:0-0:0)
  - OpenAI APIのレスポンスが `nil` の場合のチェックを追加
  - エラー時のログにレスポンス全体を出力するように変更

## 動作確認
- ✅ 本番環境で「モルペウスに きく」が正常に動作することを確認
- ✅ 夢分析結果とemotion_tagsが正しく表示される

## 今後の効果
- 同様のAPIキー設定ミスがあった場合に、原因を素早く特定可能
- `TypeError` ではなく、わかりやすいエラーメッセージが返される