### PR TITLE
fix: API RouteにバックエンドURLのフォールバックを追加

### DIFF
--- a/frontend/app/api/analyze_audio_dream/route.ts
+++ b/frontend/app/api/analyze_audio_dream/route.ts
@@ -2,11 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 
 // サーバーサイド（コンテナ間通信）ではINTERNAL_BACKEND_URLを優先し、
 // 未設定の場合はNEXT_PUBLIC_BACKEND_URL（ホストマシンからのアクセス用）を使用する
-// Vercel本番環境ではどちらも未設定の場合、RenderのURLをフォールバックとして使用する
+// Vercel本番環境（NODE_ENV=production）でのみRenderのURLをフォールバックとして使用する
+const PRODUCTION_FALLBACK =
+  process.env.NODE_ENV === "production"
+    ? "https://dreamjournal-app.onrender.com"
+    : undefined;
+
 const BACKEND_URL =
   process.env.INTERNAL_BACKEND_URL ||
   process.env.NEXT_PUBLIC_BACKEND_URL ||
-  "https://dreamjournal-app.onrender.com";
+  PRODUCTION_FALLBACK;
 
 export async function POST(req: NextRequest) {
   try {

--- a/frontend/app/api/dreams/statuses/route.ts
+++ b/frontend/app/api/dreams/statuses/route.ts
@@ -1,10 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 
-// Vercel本番環境ではどちらも未設定の場合、RenderのURLをフォールバックとして使用する
+// Vercel本番環境（NODE_ENV=production）でのみRenderのURLをフォールバックとして使用する
+const PRODUCTION_FALLBACK =
+  process.env.NODE_ENV === "production"
+    ? "https://dreamjournal-app.onrender.com"
+    : undefined;
+
 const BACKEND_URL =
   process.env.INTERNAL_BACKEND_URL ||
   process.env.NEXT_PUBLIC_BACKEND_URL ||
-  "https://dreamjournal-app.onrender.com";
+  PRODUCTION_FALLBACK;
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);


### PR DESCRIPTION
## 問題
Safariで音声入力すると「バックエンドの接続先が設定されていません」エラーが発生する。

## 原因
- `analyze_audio_dream` と `dreams/statuses` の API Route が
  `INTERNAL_BACKEND_URL` または `NEXT_PUBLIC_BACKEND_URL` 環境変数を参照
- Docker開発環境では [.env.local](cci:7://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/frontend/.env.local:0:0-0:0) で設定済みだが、Vercel本番環境では未設定
- Vercel の rewrite (`/api/*`) は物理的に存在する API Route よりも優先度が低いため、
  rewrite は適用されず、API Route 内で直接バックエンドに接続する必要がある

## 解決策
- 環境変数のフォールバックとして `https://dreamjournal-app.onrender.com` を追加
- 優先順位: `INTERNAL_BACKEND_URL` > `NEXT_PUBLIC_BACKEND_URL` > Render URL

## 変更ファイル
- [frontend/app/api/analyze_audio_dream/route.ts](cci:7://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/frontend/app/api/analyze_audio_dream/route.ts:0:0-0:0)
- `frontend/app/api/dreams/statuses/route.ts`