### PR TITLE
fix: 夢分析完了時にホームページを自動更新

### DIFF
--- a/frontend/app/components/PendingDreamsMonitor.tsx
+++ b/frontend/app/components/PendingDreamsMonitor.tsx
@@ -159,6 +159,8 @@ export default function PendingDreamsMonitor() {
           setTimeout(() => {
             router.refresh();
             console.log("[PendingDreamsMonitor] router.refresh() executed");
+
+            window.dispatchEvent(new Event("dream-analysis-completed"));
           }, 2000); // DB書き込みとAPI反映のラグを考慮して2秒待機
 
           setPollInterval(5000);

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -110,6 +110,24 @@ export default function HomePage() {
     };
   }, [fetchDreams]);
 
+  // dream-analysis-completedイベントをリッスン（夢分析完了時にリストを更新）
+  useEffect(() => {
+    const handleDreamAnalysisCompleted = () => {
+      fetchDreams();
+    };
+
+    window.addEventListener(
+      "dream-analysis-completed",
+      handleDreamAnalysisCompleted
+    );
+    return () => {
+      window.removeEventListener(
+        "dream-analysis-completed",
+        handleDreamAnalysisCompleted
+      );
+    };
+  }, [fetchDreams]);
+
   // 認証確認中
   if (authStatus === "checking") {
     return <Loading />;


### PR DESCRIPTION
## 問題
音声入力後、ホームページの「かんがえ中」ステータスがリロードしないと更新されない。

## 原因
- [PendingDreamsMonitor](cci:1://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/frontend/app/components/PendingDreamsMonitor.tsx:7:0-197:1)が`router.refresh()`を呼んでいるが、
  [home/page.tsx](cci:7://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/frontend/app/home/page.tsx:0:0-0:0)は`"use client"`なので`router.refresh()`ではstateが更新されない

## 解決策
- [PendingDreamsMonitor](cci:1://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/frontend/app/components/PendingDreamsMonitor.tsx:7:0-197:1)が分析完了時に`dream-analysis-completed`イベントを発火
- [home/page.tsx](cci:7://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/frontend/app/home/page.tsx:0:0-0:0)がイベントをリッスンして`fetchDreams()`を再実行
- 既存の`dream-created`イベントと同じパターンで実装

## 変更ファイル
- [PendingDreamsMonitor.tsx](cci:7://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/frontend/app/components/PendingDreamsMonitor.tsx:0:0-0:0): `dream-analysis-completed`イベント発火を追加
- [home/page.tsx](cci:7://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/frontend/app/home/page.tsx:0:0-0:0): イベントリスナーを追加