### PR TITLE
fix(apiClient): increase timeout to 30s in development environment

### DIFF
--- a/frontend/lib/apiClient.ts
+++ b/frontend/lib/apiClient.ts
@@ -75,8 +75,10 @@ export async function apiFetch<T>(
   // Always disable cache to ensure fresh data (Fix Stale Data Issue)
   finalOptions.cache = "no-store";
 
-  // ③ Renderコールドスタート対策: 15秒でタイムアウト（無限ハングを防止）
-  const TIMEOUT_MS = 15_000;
+  // ③ Renderコールドスタート対策: タイムアウト（無限ハングを防止）
+  // 開発環境: 30秒（Turbopack初回コンパイル待ちを考慮）
+  // 本番環境: 15秒（Renderコールドスタート対策）
+  const TIMEOUT_MS = process.env.NODE_ENV === "development" ? 30_000 : 15_000;
   const timeoutController = new AbortController();
   const timeoutId = setTimeout(() => timeoutController.abort(), TIMEOUT_MS);
 


### PR DESCRIPTION
## 概要
開発環境のAPIタイムアウトを30秒に延長

## 問題
Turbopack初回コンパイル中にログインAPIが15秒タイムアウトになっていた

## 原因
- /login ページの初回コンパイル中にAPIリクエストが走る
- コンパイル完了まで応答が遅れ、15秒タイムアウトに引っかかる
- バックエンド自体は正常（curl で0.4秒で応答）

## 解決策
環境によってタイムアウトを切り替え：
- 開発環境: 30秒（Turbopack初回コンパイル待ちを考慮）
- 本番環境: 15秒（Renderコールドスタート対策、変更なし）

## 影響
- 本番環境のタイムアウトは変更なし（15秒のまま）
- 開発時のみ30秒に延長
