### PR TITLE
feat: implement stripe webhook signature verification

### DIFF
--- a/backend/app/controllers/webhooks_controller.rb
+++ b/backend/app/controllers/webhooks_controller.rb
@@ -1,20 +1,39 @@
 class WebhooksController < ApplicationController
-  # StripeはブラウザのフォームではなくサーバーサイドからPOSTするため、
-  # CSRF保護・JWT認証の両方をスキップする必要がある。
-  # （JWT認証をスキップしないと、Stripeが叩いた瞬間に401 Unauthorizedになる）
-  skip_before_action :verify_authenticity_token, only: [:stripe]
+  # Rails API モードでは CSRF保護はデフォルトで無効のため、
+  # verify_authenticity_token のスキップは不要。
+  # JWT認証のみスキップする（WebhookはStripeサーバーが叩くため）
   skip_before_action :authorize_request, only: [:stripe]
 
   # POST /webhooks/stripe
-  # 今日のゴール：「入口がある状態」
-  # 次回実装：Stripe署名検証（Stripe-Signature header）+ イベント種別のハンドリング
-  #
-  # ⚠️ 次回メモ：署名検証には request.raw_post を使うこと（request.body.read は不可）
-  #   sig_header = request.headers['Stripe-Signature']
-  #   payload    = request.raw_post
-  #   event      = Stripe::Webhook.construct_event(payload, sig_header, ENV['STRIPE_WEBHOOK_SECRET'])
   def stripe
-    Rails.logger.info("[Webhook] stripe event received")
+    payload    = request.raw_post
+    sig_header = request.headers['Stripe-Signature']
+
+    begin
+      event = Stripe::Webhook.construct_event(
+        payload, sig_header, ENV['STRIPE_WEBHOOK_SECRET']
+      )
+    rescue JSON::ParserError => e
+      # リクエストボディが不正なJSON
+      Rails.logger.warn("[Webhook] JSON parse error: #{e.message}")
+      return head :bad_request
+    rescue Stripe::SignatureVerificationError => e
+      # 署名が一致しない（偽物のリクエストや改ざん）
+      Rails.logger.warn("[Webhook] Signature verification failed: #{e.message}")
+      return head :bad_request
+    end
+
+    # イベント種別ごとの処理
+    case event.type
+    when 'checkout.session.completed'
+      session = event.data.object
+      Rails.logger.info("[Webhook] 支払い完了 session_id=#{session.id} amount=#{session.amount_total}")
+      # TODO: 次回実装 → DB保存（Paymentモデル）or 寄付フラグの更新
+    else
+      Rails.logger.info("[Webhook] 未処理イベント: #{event.type}")
+    end
+
     head :ok
   end
 end
+


### PR DESCRIPTION
## 概要

前PR（#77）で作成したWebhook受け口に、**Stripe署名検証**を実装しました。
これにより、本物のStripeからのリクエストのみを受け付け、
偽リクエストや改ざんされたリクエストを確実に弾けるようになりました。

## 背景・動機

`POST /webhooks/stripe` の入口はすでにありましたが、
誰でも叩けば `200 OK` を返す状態でした。
署名検証なしでは「支払い完了」を偽装した攻撃が成立してしまうため、
今日セキュリティを担保する実装を追加しました。

## 変更内容

### [backend/app/controllers/webhooks_controller.rb](cci:7://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/backend/app/controllers/webhooks_controller.rb:0:0-0:0)

```ruby
payload    = request.raw_post           # ← body.readではなくraw_postを使う（重要）
sig_header = request.headers['Stripe-Signature']

event = Stripe::Webhook.construct_event(
  payload, sig_header, ENV['STRIPE_WEBHOOK_SECRET']
)

