### PR TITLE
chore(env): align JWT expiration env var name with AuthService (minutes)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,8 +34,8 @@ OPENAI_API_KEY=your_openai_api_key_here
 # JWT秘密鍵（`openssl rand -hex 64`で生成）
 JWT_SECRET_KEY=your_jwt_secret_key_here
 
-# JWTトークンの有効期限（秒単位: 3600 = 1時間）
-JWT_EXPIRATION_TIME=3600
+# JWTトークンの有効期限（分単位: 15 = 15分）
+JWT_EXPIRATION_MINUTES=15
 
 # ========================================
 # 📝 環境変数設定手順


### PR DESCRIPTION
## 概要
JWT有効期限の環境変数名が `AuthService` と `.env.example` で不一致だったため、`.env.example` を最小修正して統一しました。

## 変更内容
- `JWT_EXPIRATION_TIME`（秒）→ `JWT_EXPIRATION_MINUTES`（分）へ変更
- コメントも分単位に合わせて更新

## 判断理由（挙動維持）
既存コードは `JWT_EXPIRATION_MINUTES` を分として扱う実装のため、コード側を秒へ寄せるとトークン寿命が変わる可能性があります。
本PRは挙動を変えずに「名前の不一致」だけ解消するための最小変更です。