### PR TITLE
fix(routes): return 200 for GET/HEAD / to satisfy Render health checks

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   # 軽量ヘルスチェック（Docker HEALTHCHECK用）
   get "/health", to: proc { [200, {}, ["OK"]] }
+  match "/", to: proc { [200, {}, ["OK"]] }, via: [:get, :head]
   
   # 詳細ヘルスチェック（監視ツール用）
   get "/health/detailed", to: "health#detailed_check"


### PR DESCRIPTION
## 概要
Render のデプロイログで `No route matches [HEAD] "/"` が出ていたため、
`GET /` と `HEAD /` が 200 を返すルートを追加しました。

## 背景
Render が `HEAD /` を叩くケースがあり、root が未定義だと RoutingError になります。
`/health` は存在するものの、プラットフォーム側のチェックをコードで吸収するのが最小対応です。

## 変更内容
- `backend/config/routes.rb`
  - `match "/", ... via: [:get, :head]` を追加（200 OK）

## 動作確認（ローカル）
- `curl -I http://localhost:3001/` -> 200
- `curl -I http://localhost:3001/health` -> 200

## 影響範囲
- ルート `/` のみ（既存APIや認証には影響なし）
