### PR TITLE
docs(env): add Stripe and Sentry env vars to .env.example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,6 +38,31 @@ JWT_SECRET_KEY=your_jwt_secret_key_here
 JWT_EXPIRATION_MINUTES=15
 
 # ========================================
+# 💳 Stripe決済設定
+# ========================================
+# Stripe公開可能キー（フロントエンド用、pk_test_ or pk_live_）
+STRIPE_PUBLISHABLE_KEY=your_stripe_publishable_key_here
+
+# Stripeシークレットキー（バックエンド用、sk_test_ or sk_live_）
+STRIPE_SECRET_KEY=your_stripe_secret_key_here
+
+# Stripe Webhook署名シークレット
+# ローカル: stripe listen --print-secret で取得（ローカル検証用）
+# 本番: Stripeダッシュボード → Developers → Webhooks で別途登録・発行
+STRIPE_WEBHOOK_SECRET=your_stripe_webhook_secret_here
+
+# フロントエンドURL（Stripe決済後のリダイレクト先）
+# ローカル: http://localhost:3000
+# 本番: https://your-app.vercel.app
+FRONTEND_URL=http://localhost:3000
+
+# ========================================
+# 🔍 監視・エラートラッキング設定
+# ========================================
+# Sentry DSN（https://sentry.ioで取得）
+SENTRY_DSN=your_sentry_dsn_here
+
+# ========================================
 # 📝 環境変数設定手順
 # ========================================
 # 


### PR DESCRIPTION
## 概要
`backend/.env.example` に Stripe・Sentry・FRONTEND_URL の環境変数が記載されていなかったため追記しました。

## 背景
コード上で参照している環境変数が `.env.example` に載っておらず、新規開発者やRender本番設定時に必要なENVが判断しづらい状態でした。

## 追加した変数
| 変数名 | 用途 |
|---|---|
| `STRIPE_PUBLISHABLE_KEY` | フロントエンド用Stripeキー |
| `STRIPE_SECRET_KEY` | バックエンド用Stripeキー |
| `STRIPE_WEBHOOK_SECRET` | Webhook署名検証シークレット |
| `FRONTEND_URL` | Stripe決済後のリダイレクト先URL |
| `SENTRY_DSN` | エラートラッキング設定 |

## 変更ファイル
- `backend/.env.example` のみ（実値は含めない）

## 注意事項
- `.env`（実値）は変更なし・Git管理対象外
- `STRIPE_WEBHOOK_SECRET` はローカル用と本番用で別になるため、コメントで補足しています