### PR TITLE
fix(frontend): resolve Turbopack workspace root misdetection

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,14 +1,26 @@
 import { withSentryConfig } from "@sentry/nextjs";
+import path from "path";
+import { fileURLToPath } from "url";
 /** @type {import('next').NextConfig} */
 const isProd = process.env.NODE_ENV === "production";
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const nextConfig = {
+  // Ensure Turbopack resolves workspace root to this app directory.
+  // This avoids picking unrelated lockfiles from parent directories.
+  turbopack: {
+    root: __dirname,
+  },
   // 本番環境で必要なファイルのみを .next/standalone に出力する
   output: "standalone",
   compiler: {
     removeConsole: isProd ? { exclude: ["error"] } : false,
   },
   experimental: {
+    turbo: {
+      root: __dirname,
+    },
     optimizePackageImports: ["lucide-react"],
   },
   async rewrites() {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
+    "dev:turbo": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## 概要
Sentry に記録された「予期しない Turbopack エラー」を修正します。

## 背景・原因
`next dev --turbopack` 起動時に、Next.js が
プロジェクトのルート（`frontend/`）ではなく
親ディレクトリ（[/Users/tyougorou/yarn.lock](cci:7://file:///Users/tyougorou/yarn.lock:0:0-0:0)）を
ワークスペースルートとして誤検出していました。

これにより Turbopack の初期化が不安定になり、
[/trial](cci:7://file:///Users/tyougorou/Desktop/portfolio/dream-journal-app/frontend/app/trial:0:0-0:0) ページへのアクセス時に以下のエラーが発生：
