### PR TITLE
feat(db): add processed_webhook_events for Stripe webhook idempotency

### DIFF
--- a/backend/app/models/processed_webhook_event.rb
+++ b/backend/app/models/processed_webhook_event.rb
@@ -1,0 +1,4 @@
+class ProcessedWebhookEvent < ApplicationRecord
+  validates :stripe_event_id, presence: true, uniqueness: true
+  validates :processed_at, presence: true
+end

--- a/backend/db/migrate/20260302195527_create_processed_webhook_events.rb
+++ b/backend/db/migrate/20260302195527_create_processed_webhook_events.rb
@@ -1,0 +1,12 @@
+class CreateProcessedWebhookEvents < ActiveRecord::Migration[7.1]
+  def change
+    create_table :processed_webhook_events do |t|
+      t.string :stripe_event_id, null: false
+      t.datetime :processed_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :processed_webhook_events, :stripe_event_id, unique: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_07_201519) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_02_195527) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -68,6 +68,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_07_201519) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "processed_webhook_events", force: :cascade do |t|
+    t.string "stripe_event_id", null: false
+    t.datetime "processed_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["stripe_event_id"], name: "index_processed_webhook_events_on_stripe_event_id", unique: true
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
## 概要
Stripe Webhook の二重処理を防ぐため、処理済みイベントを記録する
`processed_webhook_events` テーブルを追加します（DB + Model のみ）。

## 背景
Stripe は同一イベントを複数回送信することがあるため、冪等性（idempotency）の仕組みが必要です。
今回は「イベントIDを一意に保存できる基盤」まで実装し、Webhookハンドラ側の利用は次PRで対応します。

## 変更内容
### 追加
- `db/migrate/20260302195527_create_processed_webhook_events.rb`
- `app/models/processed_webhook_event.rb`

### 更新
- `db/schema.rb`

## テーブル設計
| column | type | constraint |
|---|---|---|
| stripe_event_id | string | NOT NULL, UNIQUE |
| processed_at | datetime | NOT NULL |
| created_at / updated_at | datetime | auto |

## 次PRでやること
- Webhook 受信時に `stripe_event_id` を参照して冪等性を担保（既存ならスキップ）

## 今回対象外
- Webhook controller / service の改修
- Payment/Checkout 周りの実装

## テスト/CI
DB変更のため、CIでの `db:schema:load`（または `db:migrate`）により反映される想定です。
（ローカルでRSpecを実行する場合は test DB 構築が必要なことがあります）