### PR TITLE
chore: gitignore personal docs and temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,8 @@ postgres_backup/
 # Playwrightレポート（ログ・画面情報を含む）
 playwright-report/
 frontend/playwright-report/
+
+# 転職活動・個人メモ（公開禁止）
+docs/self-introduction.md
+docs/logs/
+backend/temp_rspec_output.txt


### PR DESCRIPTION
## 変更内容
- docs/self-introduction.md（面談用の個人メモ）をGit管理対象外に設定
- docs/logs/（日報フォルダ）をGit管理対象外に設定
- backend/temp_rspec_output.txt（テスト一時ファイル）をGit管理対象外に設定

## 理由
上記ファイルは転職活動の個人情報や一時的なファイルのため、
公開リポジトリには上げるべきではないため.gitignoreに追加。
