### PR TITLE
perf: add DB indexes, Dream scopes, and bullet gem

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           bundle exec rails db:create
           bundle exec rails db:schema:load
+          bundle exec rails db:migrate
 
       - name: Run tests
         working-directory: ./backend

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -87,6 +87,9 @@ group :development do
 
   # インブラウザでメール内容を確認
   gem "letter_opener"
+
+  # N+1クエリとメモリ使用の自動検出
+  gem "bullet"
 end
 
 # Stripe payment processing

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -87,6 +87,9 @@ GEM
     bootsnap (1.18.6)
       msgpack (~> 1.2)
     builder (3.3.0)
+    bullet (8.1.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (12.0.0)
     capybara (3.40.0)
       addressable
@@ -343,6 +346,7 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uniform_notifier (1.18.0)
     uri (1.1.1)
     useragent (0.16.11)
     web-console (4.2.1)
@@ -371,6 +375,7 @@ DEPENDENCIES
   annotate
   bcrypt (~> 3.1.22)
   bootsnap
+  bullet
   capybara
   database_cleaner-active_record
   debug

--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -261,10 +261,7 @@ class DreamsController < ApplicationController
 
     # 画像生成の月次上限チェック（全ユーザー共通）
     def check_monthly_image_limit
-      count = current_user.dreams
-        .where.not(generated_image_url: nil)
-        .where("updated_at >= ?", Time.current.beginning_of_month)
-        .count
+      count = current_user.dreams.with_image.generated_in_month.count
 
       if count >= IMAGE_MONTHLY_LIMIT
         render json: {

--- a/backend/app/models/dream.rb
+++ b/backend/app/models/dream.rb
@@ -10,6 +10,16 @@ class Dream < ApplicationRecord
   # analysis_status カラムを enum として定義し、メソッド名の衝突を避けるためにプレフィックスを付けます
   enum analysis_status: { pending: 'pending', done: 'done', failed: 'failed' }, _prefix: :analysis
 
+  # よく使うクエリパターンをスコープとして定義する
+  # current_user.dreams.with_image のように使う
+  scope :with_image, -> { where.not(generated_image_url: nil) }
+  # current_user.dreams.generated_in_month のように使う（引数省略時は当月）
+  scope :generated_in_month, ->(date = Time.current) {
+    where(updated_at: date.beginning_of_month..date.end_of_month)
+  }
+  # dream.analysis_done? の代わりに、コレクションの絞り込みにも使える
+  scope :analyzed, -> { where(analysis_status: 'done') }
+
   # 分析プロセスを開始するメソッド
   def start_analysis!
     update!(analysis_status: 'pending', analysis_json: nil, analyzed_at: nil)

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -60,4 +60,11 @@ Rails.application.configure do
   # 必要ならホスト許可（Docker 経由アクセス用）
   # フロントエンドコンテナ(backend)からのリクエストを許可
   config.hosts << "backend"
+
+  # Bullet: N+1クエリと不要なeager loadingをログに出力する
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.rails_logger  = true   # development.log にN+1を記録
+    Bullet.add_footer    = false  # API modeなのでHTML footerは不要
+  end
 end

--- a/backend/db/migrate/20260411000001_add_performance_indexes_to_dreams.rb
+++ b/backend/db/migrate/20260411000001_add_performance_indexes_to_dreams.rb
@@ -1,0 +1,22 @@
+class AddPerformanceIndexesToDreams < ActiveRecord::Migration[7.1]
+  def change
+    # (user_id, created_at) 複合インデックス
+    # current_user.dreams.order(created_at: :desc) の主要クエリを高速化する。
+    # user_id 単体インデックスより、ソートまで含めてカバーできる。
+    add_index :dreams, [:user_id, :created_at],
+              name: "index_dreams_on_user_id_and_created_at"
+
+    # 画像生成済みの夢に対する部分インデックス
+    # check_monthly_image_limit での
+    # WHERE generated_image_url IS NOT NULL AND updated_at >= ? を高速化する。
+    # generated_image_url が NULL の多数の行をインデックス対象から除外できる。
+    add_index :dreams, [:user_id, :updated_at],
+              where: "generated_image_url IS NOT NULL",
+              name: "index_dreams_on_user_id_and_updated_at_with_image"
+
+    # analysis_status インデックス
+    # ステータスポーリング（GET /dreams/:id/analysis）の高速化。
+    add_index :dreams, :analysis_status,
+              name: "index_dreams_on_analysis_status"
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_31_000002) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_11_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,6 +62,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_31_000002) do
     t.jsonb "analysis_json"
     t.datetime "analyzed_at"
     t.text "generated_image_url"
+    t.index ["analysis_status"], name: "index_dreams_on_analysis_status"
+    t.index ["user_id", "created_at"], name: "index_dreams_on_user_id_and_created_at"
+    t.index ["user_id", "updated_at"], name: "index_dreams_on_user_id_and_updated_at_with_image", where: "(generated_image_url IS NOT NULL)"
     t.index ["user_id"], name: "index_dreams_on_user_id"
   end
 

--- a/backend/spec/models/dream_spec.rb
+++ b/backend/spec/models/dream_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe Dream, type: :model do
+  let(:user) { create(:user) }
+
+  describe 'バリデーション' do
+    it { should validate_presence_of(:title) }
+    it { should validate_length_of(:title).is_at_most(100) }
+    it { should validate_presence_of(:content) }
+    it { should validate_length_of(:content).is_at_most(1000) }
+  end
+
+  describe 'アソシエーション' do
+    it { should belong_to(:user) }
+    it { should have_many(:dream_emotions).dependent(:destroy) }
+    it { should have_many(:emotions).through(:dream_emotions) }
+  end
+
+  describe 'スコープ' do
+    let!(:dream_with_image) do
+      create(:dream, user: user, generated_image_url: 'https://example.com/image.png', updated_at: Time.current)
+    end
+    let!(:dream_without_image) do
+      create(:dream, user: user, generated_image_url: nil)
+    end
+
+    describe '.with_image' do
+      it '画像URLが存在する夢だけを返す' do
+        expect(Dream.with_image).to include(dream_with_image)
+        expect(Dream.with_image).not_to include(dream_without_image)
+      end
+    end
+
+    describe '.generated_in_month' do
+      let!(:old_dream) do
+        create(:dream, user: user, generated_image_url: 'https://example.com/old.png',
+               updated_at: 2.months.ago)
+      end
+
+      it '当月に更新された夢だけを返す（引数省略時）' do
+        expect(Dream.generated_in_month).to include(dream_with_image)
+        expect(Dream.generated_in_month).not_to include(old_dream)
+      end
+
+      it '指定した月に更新された夢だけを返す' do
+        expect(Dream.generated_in_month(2.months.ago)).to include(old_dream)
+        expect(Dream.generated_in_month(2.months.ago)).not_to include(dream_with_image)
+      end
+    end
+
+    describe '.analyzed' do
+      let!(:done_dream)    { create(:dream, user: user, analysis_status: 'done') }
+      let!(:pending_dream) { create(:dream, user: user, analysis_status: 'pending') }
+
+      it '分析済みの夢だけを返す' do
+        expect(Dream.analyzed).to include(done_dream)
+        expect(Dream.analyzed).not_to include(pending_dream)
+      end
+    end
+  end
+
+  describe 'インスタンスメソッド' do
+    let(:dream) { create(:dream, user: user) }
+
+    describe '#start_analysis!' do
+      it 'analysis_status を pending にしてanalysis_jsonをnilにする' do
+        dream.update!(analysis_status: 'done', analysis_json: { analysis: 'test' })
+        dream.start_analysis!
+        expect(dream.analysis_status).to eq('pending')
+        expect(dream.analysis_json).to be_nil
+      end
+    end
+
+    describe '#mark_done!' do
+      it 'analysis_status を done にしてpayloadを保存する' do
+        payload = { analysis: '空を飛ぶ夢は自由の象徴です', emotion_tags: ['happy'] }
+        dream.mark_done!(payload)
+        expect(dream.analysis_status).to eq('done')
+        expect(dream.analysis_json['analysis']).to eq('空を飛ぶ夢は自由の象徴です')
+        expect(dream.analyzed_at).to be_present
+      end
+    end
+
+    describe '#mark_failed!' do
+      it 'analysis_status を failed にしてエラーメッセージを保存する' do
+        dream.mark_failed!('OpenAI APIエラー')
+        expect(dream.analysis_status).to eq('failed')
+        expect(dream.analysis_json['error']).to eq('OpenAI APIエラー')
+        expect(dream.analyzed_at).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

パフォーマンス改善とコード品質向上のための3点セット。

## 変更内容

### 1. DBインデックス追加（migration 20260411000001）

| インデックス | 対象クエリ | 効果 |
|---|---|---|
| `(user_id, created_at)` 複合 | `current_user.dreams.order(created_at: :desc)` | 一覧・月次ページの主要クエリを高速化 |
| `(user_id, updated_at)` 部分（画像あり行のみ） | `check_monthly_image_limit` | NULL行をインデックス対象から除外し効率化 |
| `analysis_status` 単体 | `GET /dreams/:id/analysis` ポーリング | ステータス確認クエリを高速化 |

### 2. Dreamモデルにスコープ追加

```ruby
Dream.with_image                    # 画像URLが存在する夢
Dream.generated_in_month            # 当月に画像生成された夢
Dream.generated_in_month(2.months.ago)  # 指定月
Dream.analyzed                      # 分析済みの夢
```

### 3. DreamsController リファクタ

`check_monthly_image_limit` をスコープを使った1行に整理。

### 4. Bullet gem（development only）

N+1クエリを `development.log` に自動記録するよう設定。

### 5. Dream model spec 新規追加

バリデーション / アソシエーション / スコープ / インスタンスメソッドを網羅。

## 面接で話せるポイント

- 複合インデックスと部分インデックスの使い分け
- NULL値をインデックスから除外するPostgreSQL部分インデックスの設計
- Bulletでの継続的なN+1監視の仕組み