### PR TITLE
fix: apply 5 UI/UX fixes from Codex design review

### DIFF
--- a/frontend/app/components/AuthNav.tsx
+++ b/frontend/app/components/AuthNav.tsx
@@ -113,7 +113,7 @@ export default function AuthNav() {
     <nav className="flex flex-col md:flex-row items-center justify-between w-full h-full gap-4 md:gap-0">
       {/* 行動（左側）：毎日つかうもの */}
       <div className="flex items-center bg-secondary/30 p-1 rounded-full gap-1">
-        <NavItem href="/" icon={House} label="おうち" />
+        <NavItem href="/home" icon={House} label="おうち" />
         <NavItem href="/dream/new" icon={Pencil} label="ゆめをかく" />
       </div>
 

--- a/frontend/app/components/DreamForm.tsx
+++ b/frontend/app/components/DreamForm.tsx
@@ -259,7 +259,7 @@ export default function DreamForm({
                 ${
                   isAnalyzing
                     ? "bg-slate-200 text-slate-500 cursor-not-allowed"
-                    : "bg-gradient-to-r from-indigo-500 to-purple-600 text-white hover:shadow-lg hover:scale-105 active:scale-95"
+                    : "bg-muted text-muted-foreground hover:bg-muted/70 border border-border"
                 }
               `}
           >

--- a/frontend/app/components/DreamRecorderFloating.tsx
+++ b/frontend/app/components/DreamRecorderFloating.tsx
@@ -103,7 +103,7 @@ const DreamRecorderFloating: React.FC = () => {
   };
 
   return (
-    <div className="fixed bottom-4 left-4 z-[9999] flex flex-col items-start gap-3">
+    <div className="fixed bottom-24 left-4 z-[9999] flex flex-col items-end gap-3">
       <AnimatePresence>
         {error && (
           <motion.div

--- a/frontend/app/components/DreamRecorderFloating.tsx
+++ b/frontend/app/components/DreamRecorderFloating.tsx
@@ -103,7 +103,7 @@ const DreamRecorderFloating: React.FC = () => {
   };
 
   return (
-    <div className="fixed bottom-24 right-4 z-[9999] flex flex-col items-end gap-3">
+    <div className="fixed bottom-4 left-4 z-[9999] flex flex-col items-start gap-3">
       <AnimatePresence>
         {error && (
           <motion.div

--- a/frontend/app/components/SearchBar.tsx
+++ b/frontend/app/components/SearchBar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Emotion } from "@/app/types";
+import { getChildFriendlyEmotionLabel } from "@/app/components/EmotionTag";
 
 type SearchBarProps = {
   query?: string | string[] | undefined;
@@ -110,7 +111,7 @@ export default function SearchBar({
                         : "bg-muted text-muted-foreground border-border hover:bg-muted/70")
                     }
                   >
-                    {emotion.name}
+                    {getChildFriendlyEmotionLabel(emotion.name)}
                   </span>
                 </label>
               );

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -13,7 +13,7 @@ const hiddenEmailStyle = {
 
 export default function Login() {
   const [email, setEmail] = useState("");
-  const [showEmail, setShowEmail] = useState(false);
+  const [showEmail, setShowEmail] = useState(true);
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [pageError, setPageError] = useState("");

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -14,7 +14,7 @@ const hiddenEmailStyle = {
 
 export default function Register() {
   const [email, setEmail] = useState("");
-  const [showEmail, setShowEmail] = useState(false);
+  const [showEmail, setShowEmail] = useState(true);
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");


### PR DESCRIPTION
## Summary

UI/UX 問題をまとめて修正。

- **AuthNav**: ホームリンクを `href="/"` → `href="/home"` に変更。`/home` 以下でアクティブ状態が正しく表示されるようになった。
- **SearchBar**: 感情フィルターのラベルを `emotion.name`（英語）から `getChildFriendlyEmotionLabel()` で子ども向け日本語表示に統一。
- **login / register**: メールアドレスフィールドのデフォルトを `showEmail: false`（隠し状態）→ `true`（表示状態）に変更。初期表示で入力欄が見えないバグを修正。
- **DreamForm**: 「モルペウスに きく」ボタンのスタイルを派手なグラデーションから `muted` 系のセカンダリスタイルに変更。保存ボタンとの視覚的階層を明確化。
- **DreamRecorderFloating**: 録音ボタンを `bottom-24 right-4`（Morpheus と重なる）→ `bottom-4 left-4`（左下）に移動してオーバーラップを解消。

## Test plan

- [ ] `/home` でナビのアクティブ状態が正しく表示される
- [ ] 夢一覧ページの感情フィルターが日本語ラベルで表示される
- [ ] ログイン・登録ページでメールアドレスフィールドが最初から見える
- [ ] 夢記録フォームで「モルペウスに きく」ボタンが「ゆめを のこす」より目立たない
- [ ] 夢記録ページで録音ボタンと Morpheus が重ならない
