### PR TITLE
fix: 7 UI/UX improvements — light mode, footer, layout, auth UX, search presets

### DIFF
--- a/frontend/__tests__/components/SearchBar.test.js
+++ b/frontend/__tests__/components/SearchBar.test.js
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SearchBar from "@/app/components/SearchBar";
+
+const mockEmotions = [
+  { id: 1, name: "嬉しい" },
+  { id: 2, name: "楽しい" },
+  { id: 3, name: "悲しい" },
+  { id: 4, name: "怖い" },
+  { id: 5, name: "不思議" },
+  { id: 6, name: "感動的" },
+];
+
+describe("SearchBar", () => {
+  describe("感情ラベルの子ども向け変換", () => {
+    it("嬉しい → 😊 うれしい と表示される", () => {
+      render(<SearchBar emotions={[{ id: 1, name: "嬉しい" }]} />);
+      expect(screen.getByText("😊 うれしい")).toBeInTheDocument();
+    });
+
+    it("楽しい → 😆 たのしい と表示される", () => {
+      render(<SearchBar emotions={[{ id: 2, name: "楽しい" }]} />);
+      expect(screen.getByText("😆 たのしい")).toBeInTheDocument();
+    });
+
+    it("怖い → 😰 こわい と表示される", () => {
+      render(<SearchBar emotions={[{ id: 4, name: "怖い" }]} />);
+      expect(screen.getByText("😰 こわい")).toBeInTheDocument();
+    });
+
+    it("感動的 → 🥺 じーんとした と表示される", () => {
+      render(<SearchBar emotions={[{ id: 6, name: "感動的" }]} />);
+      expect(screen.getByText("🥺 じーんとした")).toBeInTheDocument();
+    });
+
+    it("全感情の生ラベルが表示されない", () => {
+      render(<SearchBar emotions={mockEmotions} />);
+      mockEmotions.forEach(({ name }) => {
+        expect(screen.queryByText(name)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("日付プリセット", () => {
+    it("きょう・今週・今月 のプリセットボタンが表示される", () => {
+      render(<SearchBar />);
+      expect(screen.getByText("きょう")).toBeInTheDocument();
+      expect(screen.getByText("今週")).toBeInTheDocument();
+      expect(screen.getByText("今月")).toBeInTheDocument();
+    });
+
+    it("「きょう」ボタンを押すと開始日と終了日が同じ日付になる", async () => {
+      const user = userEvent.setup();
+      render(<SearchBar />);
+      await user.click(screen.getByText("きょう"));
+      const startInput = screen.getByLabelText("いつから");
+      const endInput = screen.getByLabelText("いつまで");
+      expect(startInput.value).not.toBe("");
+      expect(startInput.value).toBe(endInput.value);
+    });
+  });
+});

--- a/frontend/app/Header.tsx
+++ b/frontend/app/Header.tsx
@@ -1,5 +1,4 @@
-import Link from "next/link";
-import { Moon, Sparkles } from "lucide-react";
+import HeaderLogo from "./components/HeaderLogo";
 import AuthNav from "./components/AuthNav";
 import ThemeToggle from "./components/ThemeToggle";
 
@@ -12,16 +11,7 @@ export default function Header() {
   return (
     <header className="py-3 px-4 sm:px-6 border-b border-border bg-background text-foreground flex flex-col md:flex-row items-center gap-4 md:gap-8">
       <div className="flex-shrink-0">
-        <Link
-          href="/"
-          className="flex items-center gap-2 text-primary hover:text-primary/90 transition-opacity"
-        >
-          <Moon className="text-blue-300" size={32} />
-          <span className="text-2xl font-extrabold tracking-tight">
-            ユメログ
-          </span>
-          <Sparkles className="text-yellow-300" size={24} />
-        </Link>
+        <HeaderLogo />
       </div>
       <div className="w-full flex-grow">
         <AuthNav />

--- a/frontend/app/components/Footer.tsx
+++ b/frontend/app/components/Footer.tsx
@@ -4,79 +4,24 @@ export default function Footer() {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="bg-gradient-to-r from-indigo-900 via-purple-900 to-pink-900 text-white py-8 mt-auto">
-      <div className="max-w-7xl mx-auto px-4">
-        <div className="grid md:grid-cols-3 gap-8">
-          {/* About Section */}
-          <div>
-            <h3 className="text-lg font-bold mb-3 flex items-center gap-2">
-              <span>🌙</span>
-              <span>ユメログについて</span>
-            </h3>
-            <p className="text-sm text-gray-300 leading-relaxed">
-              家族みんなで使える、夢の記録アプリ。
-              モルペウスと一緒に、夢の世界を探検しよう！
-            </p>
-          </div>
-
-          {/* Links Section */}
-          <div>
-            <h3 className="text-lg font-bold mb-3 flex items-center gap-2">
-              <span>📚</span>
-              <span>リンク</span>
-            </h3>
-            <ul className="space-y-2 text-sm">
-              <li>
-                <Link
-                  href="/privacy"
-                  className="text-gray-300 hover:text-white transition-colors duration-200 flex items-center gap-1"
-                >
-                  <span>🛡️</span>
-                  <span>プライバシーポリシー</span>
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/terms"
-                  className="text-gray-300 hover:text-white transition-colors duration-200 flex items-center gap-1"
-                >
-                  <span>📜</span>
-                  <span>利用規約</span>
-                </Link>
-              </li>
-            </ul>
-          </div>
-
-          {/* Contact Section */}
-          <div>
-            <h3 className="text-lg font-bold mb-3 flex items-center gap-2">
-              <span>✉️</span>
-              <span>お問い合わせ</span>
-            </h3>
-            <p className="text-sm text-gray-300">
-              ご質問・ご要望は
-              <br />
-              GitHub Issues からどうぞ。
-            </p>
-            <a
-              href="https://github.com/isekaisaru/dreamjournal-app/issues"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-sm text-indigo-300 hover:text-indigo-200 transition-colors duration-200 mt-2 inline-block"
-            >
-              GitHub Issues →
-            </a>
-          </div>
-        </div>
-
-        {/* Divider */}
-        <div className="border-t border-gray-700 mt-8 pt-6">
-          <div className="flex flex-col md:flex-row justify-between items-center gap-4">
-            <p className="text-sm text-gray-400">
-              © {currentYear} ユメログ (DreamJournal). All rights reserved.
-            </p>
-            <p className="text-xs text-gray-500">Made with ❤️ for families</p>
-          </div>
+    <footer className="border-t border-border bg-muted/40 py-4 mt-auto">
+      <div className="max-w-7xl mx-auto px-4 flex flex-wrap items-center justify-between gap-4 text-xs text-muted-foreground">
+        <span>© {currentYear} ユメログ</span>
+        <div className="flex items-center gap-4">
+          <Link href="/privacy" className="hover:text-foreground transition-colors">
+            プライバシーポリシー
+          </Link>
+          <Link href="/terms" className="hover:text-foreground transition-colors">
+            利用規約
+          </Link>
+          <a
+            href="https://github.com/isekaisaru/dreamjournal-app/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-foreground transition-colors"
+          >
+            お問い合わせ
+          </a>
         </div>
       </div>
     </footer>

--- a/frontend/app/components/HeaderLogo.tsx
+++ b/frontend/app/components/HeaderLogo.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import Link from "next/link";
+import { Moon, Sparkles } from "lucide-react";
+import { useAuth } from "@/context/AuthContext";
+
+export default function HeaderLogo() {
+  const { isLoggedIn } = useAuth();
+
+  return (
+    <Link
+      href={isLoggedIn ? "/home" : "/"}
+      className="flex items-center gap-2 text-primary hover:text-primary/90 transition-opacity"
+    >
+      <Moon className="text-blue-300" size={32} />
+      <span className="text-2xl font-extrabold tracking-tight">ユメログ</span>
+      <Sparkles className="text-yellow-300" size={24} />
+    </Link>
+  );
+}

--- a/frontend/app/components/HeaderLogo.tsx
+++ b/frontend/app/components/HeaderLogo.tsx
@@ -5,11 +5,15 @@ import { Moon, Sparkles } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
 
 export default function HeaderLogo() {
-  const { isLoggedIn } = useAuth();
+  const { authStatus } = useAuth();
+  // "unauthenticated" のみ / に向ける。
+  // "checking" 中はプロテクトページにいる可能性が高いので /home に向けることで
+  // 認証完了前のクリックでも二段ジャンプを起こさない。
+  const href = authStatus === "unauthenticated" ? "/" : "/home";
 
   return (
     <Link
-      href={isLoggedIn ? "/home" : "/"}
+      href={href}
       className="flex items-center gap-2 text-primary hover:text-primary/90 transition-opacity"
     >
       <Moon className="text-blue-300" size={32} />

--- a/frontend/app/components/SearchBar.tsx
+++ b/frontend/app/components/SearchBar.tsx
@@ -1,4 +1,6 @@
-import React from "react";
+"use client";
+
+import React, { useState } from "react";
 import { Emotion } from "@/app/types";
 import { getChildFriendlyEmotionLabel } from "@/app/components/EmotionTag";
 
@@ -17,6 +19,13 @@ function normalizeParam(value: string | string[] | undefined): string {
   return value ?? "";
 }
 
+function toLocalDateStr(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
 export default function SearchBar({
   query,
   startDate,
@@ -25,8 +34,40 @@ export default function SearchBar({
   selectedEmotionIds = [],
 }: SearchBarProps) {
   const normalizedQuery = normalizeParam(query);
-  const normalizedStartDate = normalizeParam(startDate);
-  const normalizedEndDate = normalizeParam(endDate);
+  const [dateFrom, setDateFrom] = useState(normalizeParam(startDate));
+  const [dateTo, setDateTo] = useState(normalizeParam(endDate));
+
+  const applyPreset = (from: Date, to: Date) => {
+    setDateFrom(toLocalDateStr(from));
+    setDateTo(toLocalDateStr(to));
+  };
+
+  const presets = [
+    {
+      label: "きょう",
+      onClick: () => {
+        const t = new Date();
+        applyPreset(t, t);
+      },
+    },
+    {
+      label: "今週",
+      onClick: () => {
+        const to = new Date();
+        const from = new Date();
+        from.setDate(to.getDate() - 6);
+        applyPreset(from, to);
+      },
+    },
+    {
+      label: "今月",
+      onClick: () => {
+        const to = new Date();
+        const from = new Date(to.getFullYear(), to.getMonth(), 1);
+        applyPreset(from, to);
+      },
+    },
+  ];
 
   return (
     <form
@@ -62,7 +103,8 @@ export default function SearchBar({
             id="start-date"
             name="startDate"
             type="date"
-            defaultValue={normalizedStartDate}
+            value={dateFrom}
+            onChange={(e) => setDateFrom(e.target.value)}
             className="w-full border border-input bg-background text-foreground p-2 rounded focus:ring-2 focus:ring-ring"
           />
         </div>
@@ -77,10 +119,25 @@ export default function SearchBar({
             id="end-date"
             name="endDate"
             type="date"
-            defaultValue={normalizedEndDate}
+            value={dateTo}
+            onChange={(e) => setDateTo(e.target.value)}
             className="w-full border border-input bg-background text-foreground p-2 rounded focus:ring-2 focus:ring-ring"
           />
         </div>
+      </div>
+
+      {/* 日付プリセット */}
+      <div className="flex gap-2 mt-3">
+        {presets.map(({ label, onClick }) => (
+          <button
+            key={label}
+            type="button"
+            onClick={onClick}
+            className="px-3 py-1 text-xs rounded-full border border-border bg-muted text-muted-foreground hover:bg-muted/70 transition-colors"
+          >
+            {label}
+          </button>
+        ))}
       </div>
 
       {emotions.length > 0 && (

--- a/frontend/app/components/SearchBar.tsx
+++ b/frontend/app/components/SearchBar.tsx
@@ -27,12 +27,16 @@ export default function SearchBar({
   emotions = [],
   selectedEmotionIds = [],
 }: SearchBarProps) {
-  const normalizedQuery = normalizeParam(query);
+  const [queryValue, setQueryValue] = useState(normalizeParam(query));
   const [dateFrom, setDateFrom] = useState(normalizeParam(startDate));
   const [dateTo, setDateTo] = useState(normalizeParam(endDate));
 
   // URL パラメータ（props）が変わったとき（例：ブラウザ戻る・検索リセット）に
-  // 表示中の日付入力を同期する。プリセットで直接書き込んだ値は上書きしない。
+  // フォームの表示値を同期する。
+  useEffect(() => {
+    setQueryValue(normalizeParam(query));
+  }, [query]);
+
   useEffect(() => {
     setDateFrom(normalizeParam(startDate));
   }, [startDate]);
@@ -91,7 +95,8 @@ export default function SearchBar({
             id="search-query"
             name="query"
             type="text"
-            defaultValue={normalizedQuery}
+            value={queryValue}
+            onChange={(e) => setQueryValue(e.target.value)}
             placeholder="「ねこ」「こわい」など..."
             className="w-full border border-input bg-background text-foreground p-2 rounded focus:ring-2 focus:ring-ring"
           />

--- a/frontend/app/components/SearchBar.tsx
+++ b/frontend/app/components/SearchBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Emotion } from "@/app/types";
 import { getChildFriendlyEmotionLabel } from "@/app/components/EmotionTag";
 import { getJSTDateStr } from "@/lib/date";
@@ -30,6 +30,16 @@ export default function SearchBar({
   const normalizedQuery = normalizeParam(query);
   const [dateFrom, setDateFrom] = useState(normalizeParam(startDate));
   const [dateTo, setDateTo] = useState(normalizeParam(endDate));
+
+  // URL パラメータ（props）が変わったとき（例：ブラウザ戻る・検索リセット）に
+  // 表示中の日付入力を同期する。プリセットで直接書き込んだ値は上書きしない。
+  useEffect(() => {
+    setDateFrom(normalizeParam(startDate));
+  }, [startDate]);
+
+  useEffect(() => {
+    setDateTo(normalizeParam(endDate));
+  }, [endDate]);
 
   const applyPreset = (from: Date, to: Date) => {
     setDateFrom(getJSTDateStr(from));

--- a/frontend/app/components/SearchBar.tsx
+++ b/frontend/app/components/SearchBar.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import { Emotion } from "@/app/types";
 import { getChildFriendlyEmotionLabel } from "@/app/components/EmotionTag";
+import { getJSTDateStr } from "@/lib/date";
 
 type SearchBarProps = {
   query?: string | string[] | undefined;
@@ -19,13 +20,6 @@ function normalizeParam(value: string | string[] | undefined): string {
   return value ?? "";
 }
 
-function toLocalDateStr(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
-}
-
 export default function SearchBar({
   query,
   startDate,
@@ -38,8 +32,8 @@ export default function SearchBar({
   const [dateTo, setDateTo] = useState(normalizeParam(endDate));
 
   const applyPreset = (from: Date, to: Date) => {
-    setDateFrom(toLocalDateStr(from));
-    setDateTo(toLocalDateStr(to));
+    setDateFrom(getJSTDateStr(from));
+    setDateTo(getJSTDateStr(to));
   };
 
   const presets = [

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -113,14 +113,15 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    /* 朝空ライトモード: 淡い空色ベース + 白カード */
+    --background: 214 60% 97%;    /* #f0f6fd — 朝のうすい空 */
+    --foreground: 222 47% 15%;    /* #182238 — 濃いネイビー文字 */
 
-    --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
+    --card: 0 0% 100%;            /* 白カードが空背景に浮かぶ */
+    --card-foreground: 222 47% 15%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
+    --popover-foreground: 222 47% 15%;
 
     --primary: 262.1 83.3% 57.8%;
     --primary-foreground: 210 20% 98%;
@@ -128,8 +129,8 @@
     --secondary: 217.2 91.2% 59.8%;
     --secondary-foreground: 210 20% 98%;
 
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
+    --muted: 214 35% 93%;         /* 空色ミュート */
+    --muted-foreground: 222 20% 45%;
 
     --accent: 142.1 70.6% 45.3%;
     --accent-foreground: 142.1 70.6% 95.3%;
@@ -140,9 +141,9 @@
     --success: 140 60% 45%;
     --success-foreground: 140 60% 95%;
 
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
+    --border: 214 30% 87%;        /* 空色ボーダー */
+    --input: 214 30% 87%;
+    --ring: 222 47% 15%;
 
     --radius: 0.5rem;
 

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -162,9 +162,9 @@ export default function HomePage() {
   );
 
   return (
-    <div className="md:flex text-foreground">
+    <div className="lg:flex text-foreground">
       {/* メインセクション: ユーザー名の下に夢リストを表示 */}
-      <section className="w-full md:w-2/3 flex flex-col items-center px-3 md:px-6">
+      <section className="w-full lg:w-2/3 flex flex-col items-center px-3 md:px-6">
         <h1 className="text-2xl font-bold text-foreground">
           {user ? `${user.username}ちゃんの ゆめ日記` : "ゆめ日記"}
         </h1>
@@ -193,7 +193,7 @@ export default function HomePage() {
       </section>
 
       {/* サイドバー: 統計・ストリーク・月ごとリンク */}
-      <aside className="w-full md:w-1/3 flex flex-col items-center px-3 md:px-6 mt-4 md:mt-0">
+      <aside className="w-full lg:w-1/3 flex flex-col items-center px-3 md:px-6 mt-4 lg:mt-0">
         {/* 連続記録バッジ */}
         <DreamStreakBadge dreams={dreams} />
 

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { clientLogin } from "@/lib/apiClient";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
+import MorpheusSmall from "@/app/components/MorpheusSmall";
 
 const hiddenEmailStyle = {
   WebkitTextSecurity: "disc",
@@ -72,6 +73,11 @@ export default function Login() {
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-background text-foreground px-4 sm:px-6 lg:px-8">
+      <div className="w-full max-w-md">
+        <MorpheusSmall
+          message="おかえり！ゆめの世界へ ようこそ"
+          className="mb-4"
+        />
       <form
         onSubmit={handleSubmit}
         className="bg-card p-6 sm:p-8 md:p-10 rounded-lg shadow-lg w-full max-w-md border border-border"
@@ -152,6 +158,7 @@ export default function Login() {
           <p className="text-destructive mt-4 text-center">{pageError}</p>
         )}
       </form>
+      </div>
     </div>
   );
 }

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { clientRegister } from "@/lib/apiClient";
 import { useAuth } from "@/context/AuthContext";
+import MorpheusSmall from "@/app/components/MorpheusSmall";
 
 const hiddenEmailStyle = {
   WebkitTextSecurity: "disc",
@@ -94,6 +95,11 @@ export default function Register() {
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-background text-foreground px-4 sm:px-6 lg:px-8">
+      <div className="w-full max-w-md">
+        <MorpheusSmall
+          message="はじめまして！いっしょにゆめを記録しよう"
+          className="mb-4"
+        />
       <form
         onSubmit={handleSubmit}
         className="bg-card p-6 sm:p-8 md:p-10 rounded-lg shadow-lg w-full max-w-md border border-border"
@@ -261,6 +267,7 @@ export default function Register() {
           </Link>
         </div>
       </form>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### 変更一覧

| # | ファイル | 内容 |
|---|---------|------|
| 1 | `globals.css` | ライトモード背景を朝空青 (`#f0f6fd`) に変更。白カードが浮かぶ陰影感を確立 |
| 2 | `Footer.tsx` | 3カラム+グラデーション → 1行コンパクトフッター。主役を食わない |
| 3 | `home/page.tsx` | 2カラム分岐を `md:` → `lg:` に変更。夢が少ない時の左空白を解消 |
| 4 | `login/page.tsx` | フォーム上部に MorpheusSmall を追加。ランディングと世界観を統一 |
| 5 | `register/page.tsx` | 同上 |
| 6 | `SearchBar.tsx` | クライアントコンポーネント化 + `きょう/今週/今月` プリセットボタン追加 |
| 7 | `Header.tsx` + `HeaderLogo.tsx` | ロゴをクライアントコンポーネントに分離。認証済み → `/home`、未認証 → `/` に直接遷移 |
| 8 | `SearchBar.test.js` | 感情ラベル変換と日付プリセットの Jest テスト追加 |

## Test plan

- [ ] ライトモードで背景が淡い青みがかった色になり、カードが白く浮いて見える
- [ ] ダークモードが変わっていない
- [ ] フッターが1行に圧縮されリンクが機能する
- [ ] ホーム画面で夢が少ない時（タブレット幅）にサイドバーが下に来る
- [ ] ログイン・登録画面でモルペウスの吹き出しが表示される
- [ ] 検索バーに「きょう/今週/今月」ボタンがあり、日付入力欄が更新される
- [ ] 認証済みユーザーがロゴをクリックすると `/home` に直接遷移する（`/` を経由しない）
- [ ] `yarn test` の SearchBar テストが通る
