### PR TITLE
fix: prevent 403 from expired OpenAI Blob URLs in generated images

### DIFF
--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -189,11 +189,15 @@ class DreamsController < ApplicationController
       }
     )
 
-    image_url = response.dig("data", 0, "url")
-    if image_url.nil?
-      b64 = response.dig("data", 0, "b64_json")
-      image_url = "data:image/png;base64,#{b64}" if b64.present?
-    end
+    # OpenAI Blob URLs are temporary. Prefer base64 when available so saved
+    # dream images stay viewable after the upstream URL expires.
+    b64 = response.dig("data", 0, "b64_json")
+    image_url =
+      if b64.present?
+        "data:image/png;base64,#{b64}"
+      else
+        response.dig("data", 0, "url")
+      end
 
     unless image_url
       return render json: { error: "画像URLの取得に失敗しました" }, status: :unprocessable_entity

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -571,6 +571,20 @@ RSpec.describe 'Dreams API', type: :request do
         expect(dream.reload.generated_image_url).to eq(expected_data_url)
       end
 
+      it 'gpt-image-1 が url と b64_json の両方を返す場合は b64_json を優先して保存する' do
+        b64_data = Base64.strict_encode64('persistent_png_binary_data')
+        allow(images_client).to receive(:generate).and_return({
+          'data' => [{ 'url' => generated_url, 'b64_json' => b64_data }]
+        })
+
+        authenticated_post "/dreams/#{dream.id}/generate_image", user
+
+        expected_data_url = "data:image/png;base64,#{b64_data}"
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['image_url']).to eq(expected_data_url)
+        expect(dream.reload.generated_image_url).to eq(expected_data_url)
+      end
+
       it 'OpenAI が url も b64_json も返さない場合は 422 を返す' do
         allow(images_client).to receive(:generate).and_return({ 'data' => [{}] })
 

--- a/frontend/__tests__/lib/apiClient.test.ts
+++ b/frontend/__tests__/lib/apiClient.test.ts
@@ -24,4 +24,17 @@ describe("apiFetch timeout policy", () => {
 
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 15_000);
   });
+
+  it("preserves plain-text error bodies when the upstream response is not JSON", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: jest.fn().mockRejectedValue(new Error("invalid json")),
+      text: jest.fn().mockResolvedValue("upstream connect error or disconnect/reset before headers"),
+    } as unknown as Response) as typeof fetch;
+
+    await expect(apiFetch("/dreams")).rejects.toThrow(
+      "upstream connect error or disconnect/reset before headers"
+    );
+  });
 });

--- a/frontend/app/dream/[id]/page.tsx
+++ b/frontend/app/dream/[id]/page.tsx
@@ -92,6 +92,19 @@ export default function DreamDetailPage({
     }
   };
 
+  const handleImageLoadError = () => {
+    const isRemoteBlobUrl =
+      typeof generatedImageUrl === "string" &&
+      generatedImageUrl.startsWith("https://oaidalleapiprodscus.blob.core.windows.net/");
+
+    setImageError(
+      isRemoteBlobUrl
+        ? "ほぞんずみ の ゆめのえ の きげん が きれました。もういちど かいてみてください。"
+        : "ゆめのえ を ひょうじ できませんでした。"
+    );
+    setGeneratedImageUrl(null);
+  };
+
   const handleUpdateSubmit = async (formData: DreamInput) => {
     if (!dreamId) return;
     const success = await hookUpdateDream(formData);
@@ -246,6 +259,7 @@ export default function DreamDetailPage({
                 height={1024}
                 className="w-full h-auto"
                 unoptimized
+                onError={handleImageLoadError}
               />
               <div className="p-3 bg-card flex items-center justify-between">
                 <p className="text-xs text-muted-foreground">🎨 ゆめのえ</p>

--- a/frontend/lib/apiClient.ts
+++ b/frontend/lib/apiClient.ts
@@ -191,7 +191,12 @@ export async function apiFetch<T>(
 
       error.data = errorData;
     } catch {
-      // JSONのパースに失敗した場合
+      // JSONのパースに失敗した場合も、テキスト本文があれば残して調査しやすくする
+      const fallbackBody = await response.text().catch(() => "");
+      if (fallbackBody) {
+        error.message = fallbackBody;
+      }
+      error.data = fallbackBody || undefined;
       console.error(`Could not parse error response for ${endpoint}:`);
     }
     throw error;


### PR DESCRIPTION
## 原因

`gpt-image-1` が返す画像 URL（`oaidalleapiprodscus.blob.core.windows.net/...`）は**一時的なもので約60分で失効**します。バックエンドがこの URL をそのまま DB に保存していたため、古い生成画像を表示しようとすると Azure から以下のエラーが返っていました。

```
403 Server failed to authenticate the request.
Make sure the value of Authorization header is formed correctly including the signature.
```

`/api/dreams` の 502 はサーバーの起動中（コールドスタート）によるもので別原因です。

## 修正内容

| ファイル | 修正 |
|---------|------|
| `dreams_controller.rb` | OpenAI が `b64_json` と `url` の両方を返す場合は `b64_json` を優先。`data:image/png;base64,...` として保存するため URL が失効しない |
| `dream/[id]/page.tsx` | 画像読み込みエラー時に Blob URL かどうかを判定。期限切れの場合は「もういちどかいてみて」と再生成を促すメッセージを表示 |
| `apiClient.ts` | 502 などで JSON パース失敗時に plain-text のレスポンスボディを保持。「Could not parse error response」だけでなく実際のエラー内容が見えるようになる |
| `dreams_spec.rb` | `b64_json` 優先の spec を追加 |
| `apiClient.test.ts` | non-JSON 502 ボディ保持のテストを追加 |

## 注意事項

**既存の DB レコードに Blob URL が保存されているものは引き続き 403 になります。** 該当の夢の画像を再生成することで解消されます。今回の修正以降に生成した画像は永続的に保存されます。

## Test plan

- [ ] CI（RSpec / Jest）がグリーン
- [ ] 新規で夢の画像を生成 → `data:image/png;base64,...` で保存されることを確認
- [ ] 古い Blob URL を持つ夢の詳細ページで「ほぞんずみのゆめのえのきげんがきれました」メッセージが表示される