### PR TITLE
fix: wire production DB to DATABASE_URL and unify backend URL resolver

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,6 +13,9 @@
 # PostgreSQLのパスワード（16文字以上の複雑なパスワードを設定）
 POSTGRES_PASSWORD=your_secure_database_password_here
 
+# Render/Supabaseなどの外部PostgreSQLを使う場合はこちらを優先
+# DATABASE_URL=postgres://USER:PASSWORD@HOST:5432/DB_NAME
+
 # ========================================
 # 🔑 Rails セキュリティキー
 # ========================================

--- a/backend/config/database.yml
+++ b/backend/config/database.yml
@@ -1,23 +1,30 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  host: <%= ENV.fetch("POSTGRES_HOST") { "db" } %>
   port: 5432
-  username: <%= ENV.fetch("POSTGRES_USER") { "postgres" } %>
-  password: <%= ENV["POSTGRES_PASSWORD"] %>
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
   <<: *default
+  host: <%= ENV.fetch("POSTGRES_HOST") { "db" } %>
+  username: <%= ENV.fetch("POSTGRES_USER") { "postgres" } %>
+  password: <%= ENV["POSTGRES_PASSWORD"] %>
   database: <%= ENV.fetch("POSTGRES_DB") { "dream_journal_development" } %>
 
   
 test:
   <<: *default
+  host: <%= ENV.fetch("POSTGRES_HOST") { "db" } %>
+  username: <%= ENV.fetch("POSTGRES_USER") { "postgres" } %>
+  password: <%= ENV["POSTGRES_PASSWORD"] %>
   database: app_test
 
 
 
 production:
   <<: *default
-  database: <%= ENV["POSTGRES_DB"] %>
+  url: <%= ENV["DATABASE_URL"] if ENV["DATABASE_URL"].present? %>
+  host: <%= ENV.fetch("POSTGRES_HOST") { "db" } unless ENV["DATABASE_URL"].present? %>
+  username: <%= ENV.fetch("POSTGRES_USER") { "postgres" } unless ENV["DATABASE_URL"].present? %>
+  password: <%= ENV["POSTGRES_PASSWORD"] unless ENV["DATABASE_URL"].present? %>
+  database: <%= ENV["POSTGRES_DB"] unless ENV["DATABASE_URL"].present? %>

--- a/frontend/app/api/analyze_audio_dream/route.ts
+++ b/frontend/app/api/analyze_audio_dream/route.ts
@@ -1,17 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { resolveBackendUrl } from "../checkout/backend-url";
 
-// サーバーサイド（コンテナ間通信）ではINTERNAL_BACKEND_URLを優先し、
-// 未設定の場合はNEXT_PUBLIC_BACKEND_URL（ホストマシンからのアクセス用）を使用する
-// Vercel本番環境（NODE_ENV=production）でのみRenderのURLをフォールバックとして使用する
-const PRODUCTION_FALLBACK =
-  process.env.NODE_ENV === "production"
-    ? "https://dreamjournal-app.onrender.com"
-    : undefined;
-
-const BACKEND_URL =
-  process.env.INTERNAL_BACKEND_URL ||
-  process.env.NEXT_PUBLIC_BACKEND_URL ||
-  PRODUCTION_FALLBACK;
+const BACKEND_URL = resolveBackendUrl();
 
 export async function POST(req: NextRequest) {
   try {

--- a/frontend/app/api/dreams/statuses/route.ts
+++ b/frontend/app/api/dreams/statuses/route.ts
@@ -1,15 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { resolveBackendUrl } from "../../checkout/backend-url";
 
-// Vercel本番環境（NODE_ENV=production）でのみRenderのURLをフォールバックとして使用する
-const PRODUCTION_FALLBACK =
-  process.env.NODE_ENV === "production"
-    ? "https://dreamjournal-app.onrender.com"
-    : undefined;
-
-const BACKEND_URL =
-  process.env.INTERNAL_BACKEND_URL ||
-  process.env.NEXT_PUBLIC_BACKEND_URL ||
-  PRODUCTION_FALLBACK;
+const BACKEND_URL = resolveBackendUrl();
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);

--- a/frontend/lib/apiClient.ts
+++ b/frontend/lib/apiClient.ts
@@ -167,38 +167,44 @@ export async function apiFetch<T>(
       `API request to ${endpoint} failed with status ${response.status}.`
     );
     error.status = response.status;
-    try {
-      const errorData = await response.json();
-      // Railsのエラー形式に合わせて調整 (より堅牢な形式)
-      if (errorData.error) {
-        error.message = errorData.error;
-      } else if (Array.isArray(errorData.errors)) {
-        error.message = errorData.errors.join(", ");
-      } else if (
-        typeof errorData.errors === "object" &&
-        errorData.errors !== null
-      ) {
-        // { "email": ["has already been taken"], "password": ["is too short"] } のような形式に対応
-        error.message = Object.entries(errorData.errors)
-          .map(
-            ([key, messages]) =>
-              `${key} ${Array.isArray(messages) ? messages.join(", ") : messages}`
-          )
-          .join("; ");
-      } else if (errorData.message) {
-        error.message = errorData.message;
-      }
+    const responseBody = await response.text().catch(() => "");
 
-      error.data = errorData;
-    } catch {
-      // JSONのパースに失敗した場合も、テキスト本文があれば残して調査しやすくする
-      const fallbackBody = await response.text().catch(() => "");
-      if (fallbackBody) {
-        error.message = fallbackBody;
+    if (responseBody) {
+      try {
+        const errorData = JSON.parse(responseBody);
+        // Railsのエラー形式に合わせて調整 (より堅牢な形式)
+        if (errorData.error) {
+          error.message = errorData.error;
+        } else if (Array.isArray(errorData.errors)) {
+          error.message = errorData.errors.join(", ");
+        } else if (
+          typeof errorData.errors === "object" &&
+          errorData.errors !== null
+        ) {
+          // { "email": ["has already been taken"], "password": ["is too short"] } のような形式に対応
+          error.message = Object.entries(errorData.errors)
+            .map(
+              ([key, messages]) =>
+                `${key} ${Array.isArray(messages) ? messages.join(", ") : messages}`
+            )
+            .join("; ");
+        } else if (errorData.message) {
+          error.message = errorData.message;
+        }
+
+        error.data = errorData;
+      } catch {
+        const plainTextBody = responseBody
+          .replace(/<[^>]+>/g, " ")
+          .replace(/\s+/g, " ")
+          .trim();
+        if (plainTextBody) {
+          error.message = plainTextBody;
+        }
+        error.data = responseBody;
       }
-      error.data = fallbackBody || undefined;
-      console.error(`Could not parse error response for ${endpoint}:`);
     }
+
     throw error;
   }
 


### PR DESCRIPTION
## 原因

Render での 503/502 エラーの根本原因が判明しました。

`entrypoint.sh` は Render 環境で `DATABASE_URL` を使う前提で書かれていますが、`database.yml` の production セクションが `DATABASE_URL` を一切見ていませんでした。その結果、Render 上では DB 接続先が Docker Compose 専用の `host: db` にフォールバックし、DB が必要なルート（`/auth/login`・`/emotions`・`/dreams`）がすべて 503/502 を返す状態になっていました。

## 修正内容

| ファイル | 修正 |
|---------|------|
| `database.yml` | production に `DATABASE_URL` サポートを追加。存在する場合は優先使用、なければ `POSTGRES_*` 変数を使用（Docker Compose / ローカル開発に影響なし） |
| `analyze_audio_dream/route.ts` | インライン BACKEND_URL ロジックを `resolveBackendUrl()` に統一 |
| `dreams/statuses/route.ts` | 同上 |
| `apiClient.ts` | レスポンスボディをテキストで先読みしてから JSON パース。502/503 の HTML ゲートウェイページもタグを除去して読めるエラーメッセージとして表示 |
| `.env.example` | Render 用 `DATABASE_URL` のコメントを追加 |

## 検証

- `bundle exec ruby` で database.yml の production セクションを評価 → `url` キーが存在することを確認
- `jest __tests__/app/api/checkout/backend-url.test.ts` → PASS

## Test plan

- [ ] CI グリーン
- [ ] Render デプロイ後にログインが成功する（503 が消える）
- [ ] `/emotions`・`/dreams` が正常レスポンスを返す

🤖 Generated with [Claude Code](https://claude.com/claude-code)