### PR TITLE
fix: NULL out expired OpenAI Blob URLs so users can regenerate images

### DIFF
--- a/backend/db/migrate/20260413000001_nullify_expired_openai_blob_urls.rb
+++ b/backend/db/migrate/20260413000001_nullify_expired_openai_blob_urls.rb
@@ -1,0 +1,19 @@
+class NullifyExpiredOpenaiBlobUrls < ActiveRecord::Migration[7.1]
+  def up
+    # OpenAI Blob URLs (oaidalleapiprodscus.blob.core.windows.net) expire ~60 minutes
+    # after generation. Dreams saved with these URLs show 403 errors for users.
+    # Setting to NULL lets users regenerate the image using gpt-image-1 which now
+    # returns a persistent base64 data URL instead.
+    affected = execute(<<~SQL)
+      UPDATE dreams
+      SET generated_image_url = NULL
+      WHERE generated_image_url LIKE 'https://oaidalleapiprodscus.blob.core.windows.net/%'
+    SQL
+    Rails.logger.info "[NullifyExpiredOpenaiBlobUrls] Cleared #{affected.cmd_tuples} expired Blob URL(s)"
+  end
+
+  def down
+    # Intentionally irreversible: we cannot restore the expired URLs.
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a one-time data migration that sets `generated_image_url = NULL` for any row where the URL points to `oaidalleapiprodscus.blob.core.windows.net`
- These temporary OpenAI Blob URLs expire ~60 minutes after generation, causing Azure 403 errors in production
- After this migration, affected dreams show the "🎨 ゆめのえを かく" button again, letting users regenerate with gpt-image-1 (which now returns a persistent base64 data URL via PR #177)
- Migration is marked `IrreversibleMigration` since the expired URLs cannot be restored

## Root Cause

Before PR #177, `generate_image` saved the temporary `url` field from OpenAI's response. These URLs work for ~60 minutes then return `403 AuthenticationFailed` from Azure Blob Storage. Users saw broken images with no way to fix them.

## Test plan

- [ ] Run `bundle exec rails db:migrate` locally (or on Render with `RUN_MIGRATIONS=true`)
- [ ] Confirm no Blob URL rows remain: `Dream.where("generated_image_url LIKE 'https://oaidalleapiprodscus%'").count` → 0
- [ ] Visit a dream detail page that previously showed 403 → regenerate button should appear
- [ ] Regenerate image → should save as `data:image/png;base64,...` (persistent)