### PR TITLE
perf: exclude generated_image_url from dreams index to prevent 502 timeout

### DIFF
--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -15,7 +15,12 @@ class DreamsController < ApplicationController
     initial_scope = current_user.dreams.order(created_at: :desc)
     filter_params = params.permit(:query, :start_date, :end_date, emotion_ids: [])
     @dreams = DreamFilterQuery.new(initial_scope, filter_params).call.includes(:emotions)
-    render json: @dreams.as_json(include: :emotions)
+    # generated_image_url は base64 で最大 1MB になるため一覧では除外する。
+    # 詳細画面（show）でのみ返す。
+    render json: @dreams.as_json(
+      only: [:id, :title, :content, :created_at, :analysis_json, :analysis_status, :analyzed_at],
+      include: :emotions
+    )
   end
 
   # GET /dreams/statuses?ids=1,2,3

--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -12,13 +12,15 @@ class DreamsController < ApplicationController
     # N+1問題を解消し、軽量化。
     # 感情タグはanalysis_jsonに含まれているため、emotionsテーブルの結合(N+1)は行わない...
     # -> 修正: 手動記録のタグが表示されないため、emotionsを含めるように変更。
-    initial_scope = current_user.dreams.order(created_at: :desc)
+    # generated_image_url は base64 で最大 1MB になるため一覧では SELECT 時点で除外する。
+    # as_json(only:) だけでは ActiveRecord が SELECT * でロードするためメモリに乗る。
+    # 詳細画面（show）でのみ返す。
+    index_columns = %i[id title content created_at analysis_json analysis_status analyzed_at user_id]
+    initial_scope = current_user.dreams.select(index_columns).order(created_at: :desc)
     filter_params = params.permit(:query, :start_date, :end_date, emotion_ids: [])
     @dreams = DreamFilterQuery.new(initial_scope, filter_params).call.includes(:emotions)
-    # generated_image_url は base64 で最大 1MB になるため一覧では除外する。
-    # 詳細画面（show）でのみ返す。
     render json: @dreams.as_json(
-      only: [:id, :title, :content, :created_at, :analysis_json, :analysis_status, :analyzed_at],
+      only: index_columns - [:user_id],
       include: :emotions
     )
   end


### PR DESCRIPTION
## 原因

PR #177 で画像を `base64` 文字列（`data:image/png;base64,...`）で保存するよう変更した結果、
夢一覧の `SELECT *` が画像データ（1枚あたり最大1MB）を全件ロードするようになった。

Renderのログで確認した実測値：
```
Dream Load (1709.2ms)
SELECT "dreams".* FROM "dreams" WHERE "dreams"."user_id" = $1
```

この遅延がVercelのタイムアウトを超え、502/503を引き起こしていた。

## 修正内容

`dreams#index` のレスポンスから `generated_image_url` を除外。
`generated_image_url` は詳細画面（`show`）でのみ必要なため影響なし。

## 確認方法

- [ ] ホーム画面の夢一覧が正常に表示される
- [ ] 夢の詳細画面で画像が表示される（showは変更なし）
- [ ] Renderログで `Dream Load` が 200ms 以下になっている