### PR TITLE
ux: Phase 3 — light theme default and reduced-motion support

### DIFF
--- a/frontend/__tests__/components/ThemeToggle.test.tsx
+++ b/frontend/__tests__/components/ThemeToggle.test.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import ThemeToggle from "@/app/components/ThemeToggle";
+import { ThemeProvider } from "@/context/ThemeContext";
+
+function renderWithThemeProvider() {
+  return render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>
+  );
+}
+
+describe("ThemeToggle", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    document.documentElement.classList.remove("dark");
+  });
+
+  it("defaults to light mode when no saved theme exists", async () => {
+    renderWithThemeProvider();
+
+    await waitFor(() => {
+      expect(document.documentElement).not.toHaveClass("dark");
+    });
+
+    expect(
+      screen.getByRole("button", { name: "ダークモードにする" })
+    ).toBeInTheDocument();
+  });
+
+  it("restores saved dark mode on mount", async () => {
+    window.localStorage.setItem("theme", "dark");
+
+    renderWithThemeProvider();
+
+    await waitFor(() => {
+      expect(document.documentElement).toHaveClass("dark");
+    });
+
+    expect(
+      screen.getByRole("button", { name: "ライトモードにする" })
+    ).toBeInTheDocument();
+  });
+
+  it("toggles theme and persists the next choice", async () => {
+    renderWithThemeProvider();
+
+    const button = await screen.findByRole("button", {
+      name: "ダークモードにする",
+    });
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(document.documentElement).toHaveClass("dark");
+      expect(window.localStorage.getItem("theme")).toBe("dark");
+    });
+  });
+});

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -323,3 +323,19 @@
     @apply flex flex-col grow;
   }
 }
+
+/* OSが「動きを減らしたい」と伝えてきたら、演出をほぼ止める。 */
+@media (prefers-reduced-motion: reduce) {
+  html:focus-within {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { Noto_Sans_JP } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import Header from "./Header";
 import Footer from "./components/Footer";
@@ -10,6 +11,15 @@ import { Providers } from "./providers";
 import PendingDreamsMonitor from "./components/PendingDreamsMonitor";
 
 const notoSansJP = Noto_Sans_JP({ subsets: ["latin"] });
+// Hydration前にテーマを合わせて、ライト→ダークのちらつきを防ぐ。
+const themeInitScript = `
+  try {
+    const storedTheme = window.localStorage.getItem("theme");
+    document.documentElement.classList.toggle("dark", storedTheme === "dark");
+  } catch {
+    document.documentElement.classList.remove("dark");
+  }
+`;
 
 const siteUrl = "https://dreamjournal-app.vercel.app";
 
@@ -45,10 +55,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>): React.ReactElement {
   return (
-    <html lang="ja" className="dark min-h-full">
+    <html lang="ja" className="min-h-full" suppressHydrationWarning>
       <body
         className={`${notoSansJP.className} px-4 sm:px-6 lg:px-8 flex flex-col min-h-screen`}
       >
+        <Script id="theme-init" strategy="beforeInteractive">
+          {themeInitScript}
+        </Script>
         <Providers>
           <Header />
           <div className="flex flex-col flex-grow">

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { MotionConfig } from "framer-motion";
 import { AuthProvider } from "../context/AuthContext";
 import { ThemeProvider } from "../context/ThemeContext";
 import dynamic from "next/dynamic";
@@ -12,11 +13,13 @@ const Toaster = dynamic(
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider>
-      <AuthProvider>
-        <Toaster position="top-center" />
-        {children}
-      </AuthProvider>
-    </ThemeProvider>
+    <MotionConfig reducedMotion="user">
+      <ThemeProvider>
+        <AuthProvider>
+          <Toaster position="top-center" />
+          {children}
+        </AuthProvider>
+      </ThemeProvider>
+    </MotionConfig>
   );
 }

--- a/frontend/context/ThemeContext.tsx
+++ b/frontend/context/ThemeContext.tsx
@@ -3,6 +3,11 @@
 import { createContext, useContext, useEffect, useState } from "react";
 
 type Theme = "dark" | "light";
+const THEME_STORAGE_KEY = "theme";
+
+function applyTheme(theme: Theme) {
+  document.documentElement.classList.toggle("dark", theme === "dark");
+}
 
 interface ThemeContextValue {
   theme: Theme;
@@ -10,31 +15,25 @@ interface ThemeContextValue {
 }
 
 const ThemeContext = createContext<ThemeContextValue>({
-  theme: "dark",
+  theme: "light",
   toggleTheme: () => {},
 });
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>("dark");
+  const [theme, setTheme] = useState<Theme>("light");
 
   useEffect(() => {
-    const stored = localStorage.getItem("theme") as Theme | null;
-    if (stored === "light") {
-      setTheme("light");
-      document.documentElement.classList.remove("dark");
-    }
-    // dark がデフォルト（layout.tsx の className="dark" をそのまま活かす）
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    const nextTheme: Theme = stored === "dark" ? "dark" : "light";
+    setTheme(nextTheme);
+    applyTheme(nextTheme);
   }, []);
 
   const toggleTheme = () => {
-    const next: Theme = theme === "dark" ? "light" : "dark";
-    setTheme(next);
-    localStorage.setItem("theme", next);
-    if (next === "dark") {
-      document.documentElement.classList.add("dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-    }
+    const nextTheme: Theme = theme === "dark" ? "light" : "dark";
+    setTheme(nextTheme);
+    localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+    applyTheme(nextTheme);
   };
 
   return (

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -3,7 +3,11 @@ import "@testing-library/jest-dom";
 // Mock framer-motion to prevent JSDOM issues
 jest.mock("framer-motion", () => {
   const React = require("react");
+  const MotionConfig = ({ children }: any) =>
+    React.createElement(React.Fragment, null, children);
+
   return {
+    MotionConfig,
     motion: {
       div: React.forwardRef(({ children, ...props }: any, ref: any) => {
         return React.createElement("div", { ref, ...props }, children);
@@ -11,5 +15,6 @@ jest.mock("framer-motion", () => {
     },
     AnimatePresence: ({ children }: any) =>
       React.createElement(React.Fragment, null, children),
+    useReducedMotion: () => false,
   };
 });


### PR DESCRIPTION
## Summary

- **ライトテーマを既定に変更**: 初回訪問・ログアウト後は明るい画面で表示。ダーク設定を保存済みのユーザーには自動で復元
- **チラつき防止**: `beforeInteractive` スクリプトで hydration 前にテーマを適用し、一瞬だけ色が変わる問題を解消
- **reduced-motion 対応**: `<MotionConfig reducedMotion="user">` と CSS メディアクエリで、OS の「動きを減らす」設定を尊重
- **ThemeToggle テスト追加**: ライト既定・ダーク復元・トグル後の永続化の3ケース

## Why

朝の子ども向け体験では「最初の見た目」が重要。ダーク既定のままでは初回ユーザーに暗い画面が表示される。
reduced-motion は視覚的な負荷が高いユーザーへの配慮（アクセシビリティ）。

## Test plan

- [ ] 初回アクセスでライトテーマが表示される
- [ ] テーマトグルでダークに切り替え → リロードしてもダークが維持される
- [ ] macOS「視差効果を減らす」ON でアニメーションが止まる
- [ ] Jest CI 通過
