### PR TITLE
feat: profile settings, age-based analysis tones, and password toggle fix

### DIFF
--- a/backend/app/controllers/auth_controller.rb
+++ b/backend/app/controllers/auth_controller.rb
@@ -28,7 +28,16 @@ class AuthController < ApplicationController
 
   # 現在のユーザーを返す
   def me
-    render json: { user: @current_user.as_json(only: [:id, :email, :username, :premium]) }, status: :ok
+    render json: { user: user_json(@current_user) }, status: :ok
+  end
+
+  # プロフィール更新 PATCH /auth/me
+  def update_me
+    if @current_user.update(profile_params)
+      render json: { user: user_json(@current_user) }, status: :ok
+    else
+      render json: { error: @current_user.errors.full_messages.join(", ") }, status: :unprocessable_entity
+    end
   end
 
   # トークンをリフレッシュする
@@ -89,6 +98,16 @@ class AuthController < ApplicationController
 
   # トークンの検証
   def verify
-    render json: { authenticated: true, user: @current_user.as_json(only: [:id, :email, :username, :premium]) }, status: :ok
+    render json: { authenticated: true, user: user_json(@current_user) }, status: :ok
+  end
+
+  private
+
+  def user_json(user)
+    user.as_json(only: [:id, :email, :username, :premium, :age_group, :analysis_tone])
+  end
+
+  def profile_params
+    params.require(:user).permit(:username, :age_group, :analysis_tone)
   end
 end

--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -232,7 +232,11 @@ class DreamsController < ApplicationController
       return render json: { error: "ゆめの ないよう が ないよ" }, status: :unprocessable_content
     end
 
-    result = DreamAnalysisService.analyze(content)
+    result = DreamAnalysisService.analyze(
+      content,
+      age_group:     current_user.age_group,
+      analysis_tone: current_user.analysis_tone
+    )
 
     if result[:error]
       render json: { error: result[:error] }, status: :unprocessable_content

--- a/backend/app/jobs/analyze_dream_job.rb
+++ b/backend/app/jobs/analyze_dream_job.rb
@@ -50,8 +50,13 @@ class AnalyzeDreamJob < ApplicationJob
   end
 
   def process_text_dream(dream)
-    result = DreamAnalysisService.analyze(dream.content)
-    
+    user = dream.user
+    result = DreamAnalysisService.analyze(
+      dream.content,
+      age_group:     user&.age_group     || "child",
+      analysis_tone: user&.analysis_tone || "auto"
+    )
+
     if result[:error]
       dream.update!(analysis_status: "failed", analysis_json: { error: result[:error] })
     else

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -5,6 +5,12 @@ class User < ApplicationRecord
   has_many :payments, dependent: :destroy
   has_many :subscriptions, dependent: :destroy
 
+  AGE_GROUPS = %w[child_small child preteen teen adult].freeze
+  ANALYSIS_TONES = %w[auto gentle_kids junior standard deep].freeze
+
+  validates :age_group, inclusion: { in: AGE_GROUPS }
+  validates :analysis_tone, inclusion: { in: ANALYSIS_TONES }
+
   # バリデーション
   validates :email, presence: true, uniqueness: true
   validates :username, presence: true, uniqueness: true

--- a/backend/app/services/dream_analysis_service.rb
+++ b/backend/app/services/dream_analysis_service.rb
@@ -3,21 +3,13 @@ require 'openai'
 
 class DreamAnalysisService
   # 夢の内容を分析するクラスメソッド
-  def self.analyze(dream_content)
+  # age_group / analysis_tone はユーザー設定から渡す。省略時は子ども向けデフォルト。
+  def self.analyze(dream_content, age_group: "child", analysis_tone: "auto")
     client = OpenAI::Client.new(access_token: ENV.fetch("OPENAI_API_KEY"))
 
-    Rails.logger.info("DreamAnalysisService: Analyzing with child-friendly prompt")
-    system_prompt = <<~'PROMPT'
-      あなたは子供向けの「夢占い博士」モルペウスです。
-      6歳の子供でもわかるように、ひらがなを多めに使って、優しく短く夢の意味を教えてあげてください。
-      漢字は小学校1年生で習うもの程度（例：山、川、月、日）に留め、難しい漢字はひらがなにしてください。
-      出力は必ず以下のJSONフォーマットに従ってください。
-      {
-        "analysis": "（例：◯◯くん、すごいゆめをみたね！それは・・・）",
-        "emotion_tags": ["感情1", "感情2"]
-      }
-      emotion_tags には夢から読み取れる主要な感情を日本語で1〜3個だけ含めてください。
-    PROMPT
+    resolved_tone = TonePromptBuilder.resolve_tone(age_group: age_group, analysis_tone: analysis_tone)
+    Rails.logger.info("DreamAnalysisService: tone=#{resolved_tone} (age_group=#{age_group}, analysis_tone=#{analysis_tone})")
+    system_prompt = TonePromptBuilder.build(age_group: age_group, analysis_tone: analysis_tone)
 
     begin
       response = client.chat(parameters: {

--- a/backend/app/services/tone_prompt_builder.rb
+++ b/backend/app/services/tone_prompt_builder.rb
@@ -1,0 +1,83 @@
+# 年齢帯・分析トーン設定に応じたシステムプロンプトを生成する
+class TonePromptBuilder
+  # 有効なトーン値にない場合のデフォルト
+  DEFAULT_TONE = "gentle_kids"
+
+  # age_group と analysis_tone から実際に使うトーンを解決する。
+  # tone が "auto" の場合は age_group を見て自動選択する。
+  def self.resolve_tone(age_group:, analysis_tone:)
+    return analysis_tone unless analysis_tone == "auto"
+
+    case age_group
+    when "child_small" then "gentle_kids"
+    when "child"       then "gentle_kids"
+    when "preteen"     then "junior"
+    when "teen"        then "standard"
+    when "adult"       then "standard"
+    else                    DEFAULT_TONE
+    end
+  end
+
+  def self.build(age_group:, analysis_tone:)
+    tone = resolve_tone(age_group: age_group, analysis_tone: analysis_tone)
+
+    case tone
+    when "gentle_kids"
+      <<~PROMPT
+        あなたは子供向けの「夢占い博士」モルペウスです。
+        6歳の子供でもわかるように、ひらがなを多めに使って、優しく短く夢の意味を教えてあげてください。
+        漢字は小学校1年生で習うもの程度（例：山、川、月、日）に留め、難しい漢字はひらがなにしてください。
+        こわい表現や不安になる言葉は使わず、かならず明るく締めくくってください。
+        出力は必ず以下のJSONフォーマットに従ってください。
+        {
+          "analysis": "（例：◯◯くん、すごいゆめをみたね！それは・・・）",
+          "emotion_tags": ["感情1", "感情2"]
+        }
+        emotion_tags には夢から読み取れる主要な感情を日本語で1〜3個だけ含めてください。
+      PROMPT
+
+    when "junior"
+      <<~PROMPT
+        あなたは「夢占い博士」モルペウスです。小中学生にわかりやすい言葉で、夢の意味を教えてください。
+        むずかしすぎる漢字は避け、気持ちの整理に役立つやさしい説明をしてください。
+        少し詳しく、でも読みやすい長さにまとめてください。
+        出力は必ず以下のJSONフォーマットに従ってください。
+        {
+          "analysis": "夢の分析テキスト",
+          "emotion_tags": ["感情1", "感情2"]
+        }
+        emotion_tags には夢から読み取れる主要な感情を日本語で1〜3個だけ含めてください。
+      PROMPT
+
+    when "standard"
+      <<~PROMPT
+        あなたは「夢占い博士」モルペウスです。
+        自然な日本語で、夢の意味をわかりやすく分析してください。
+        気持ちの整理に役立つ視点を加えながら、読みやすくまとめてください。
+        出力は必ず以下のJSONフォーマットに従ってください。
+        {
+          "analysis": "夢の分析テキスト",
+          "emotion_tags": ["感情1", "感情2"]
+        }
+        emotion_tags には夢から読み取れる主要な感情を日本語で1〜3個だけ含めてください。
+      PROMPT
+
+    when "deep"
+      <<~PROMPT
+        あなたは「夢占い博士」モルペウスです。
+        夢の象徴・感情・潜在的なテーマを、少し詳しく丁寧に分析してください。
+        心理学的な視点も交えながら、読者が自己理解を深められるような分析を提供してください。
+        出力は必ず以下のJSONフォーマットに従ってください。
+        {
+          "analysis": "夢の分析テキスト",
+          "emotion_tags": ["感情1", "感情2"]
+        }
+        emotion_tags には夢から読み取れる主要な感情を日本語で1〜3個だけ含めてください。
+      PROMPT
+
+    else
+      # フォールバック：gentle_kids と同じ
+      build(age_group: "child", analysis_tone: "gentle_kids")
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
     post 'logout', to: 'auth#logout'
     post 'refresh', to: 'auth#refresh'
     get 'me', to: 'auth#me'
+    patch 'me', to: 'auth#update_me'
     get 'verify', to: 'auth#verify'
     post 'register', to: 'users#create'
     post 'trial_login', to: 'trial_users#create'

--- a/backend/db/migrate/20260415000001_add_profile_fields_to_users.rb
+++ b/backend/db/migrate/20260415000001_add_profile_fields_to_users.rb
@@ -1,0 +1,6 @@
+class AddProfileFieldsToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :age_group, :string, default: "child", null: false
+    add_column :users, :analysis_tone, :string, default: "auto", null: false
+  end
+end

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -129,31 +129,33 @@ export default function Login() {
             >
               パスワード
             </label>
-            <input
-              id="login-password"
-              type={showPassword ? "text" : "password"}
-              name="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="8もじ いじょう"
-              autoComplete="current-password"
-              autoCapitalize="none"
-              autoCorrect="off"
-              spellCheck={false}
-              required
-              aria-label="パスワード"
-              aria-required="true"
-              aria-invalid={pageError ? "true" : "false"}
-              className="w-full px-4 py-2 pr-12 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-ring"
-            />
-            <button
-              type="button"
-              onClick={() => setShowPassword((v) => !v)}
-              aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示"}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
-            >
-              {showPassword ? "🙈" : "👁"}
-            </button>
+            <div className="relative">
+              <input
+                id="login-password"
+                type={showPassword ? "text" : "password"}
+                name="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="8もじ いじょう"
+                autoComplete="current-password"
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+                required
+                aria-label="パスワード"
+                aria-required="true"
+                aria-invalid={pageError ? "true" : "false"}
+                className="w-full px-4 py-2 pr-12 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示"}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+              >
+                {showPassword ? "🙈" : "👁"}
+              </button>
+            </div>
           </div>
           <button
             type="submit"

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -7,6 +7,25 @@ import Loading from "../loading";
 import Link from "next/link";
 import { ChevronLeft } from "lucide-react";
 import DonationButton from "../components/DonationButton";
+import { updateProfile } from "@/lib/apiClient";
+import { toast } from "@/lib/toast";
+import type { AgeGroup, AnalysisTone } from "@/app/types";
+
+const AGE_GROUP_OPTIONS: { value: AgeGroup; label: string }[] = [
+  { value: "child_small", label: "6さい いか" },
+  { value: "child",       label: "7〜9さい" },
+  { value: "preteen",     label: "10〜12さい" },
+  { value: "teen",        label: "13〜15さい" },
+  { value: "adult",       label: "16さい いじょう" },
+];
+
+const ANALYSIS_TONE_OPTIONS: { value: AnalysisTone; label: string; desc: string }[] = [
+  { value: "auto",        label: "じどうで あわせる",    desc: "年れいたいに合わせて自動でえらぶ" },
+  { value: "gentle_kids", label: "やさしく・ひらがなで", desc: "ひらがな多め・こわくない説明" },
+  { value: "junior",      label: "小中学生むけ",         desc: "わかりやすい語句・少し詳しく" },
+  { value: "standard",    label: "ふつう",               desc: "一般的な日本語で" },
+  { value: "deep",        label: "くわしく",             desc: "少し詳しい分析" },
+];
 
 // ジュニアロックのための簡単な計算問題を生成する関数
 const generateMathProblem = () => {
@@ -21,6 +40,32 @@ const generateMathProblem = () => {
 const SettingsPage = () => {
   const { authStatus, userId, user, logout, deleteUser } = useAuth();
   const router = useRouter();
+
+  // プロフィール編集フォーム用 state
+  const [profileUsername, setProfileUsername] = useState(user?.username ?? "");
+  const [profileAgeGroup, setProfileAgeGroup] = useState<AgeGroup>((user?.age_group as AgeGroup) ?? "child");
+  const [profileTone, setProfileTone] = useState<AnalysisTone>((user?.analysis_tone as AnalysisTone) ?? "auto");
+  const [isSavingProfile, setIsSavingProfile] = useState(false);
+
+  const handleSaveProfile = async () => {
+    if (!profileUsername.trim()) {
+      toast.error("ニックネームを いれてね。");
+      return;
+    }
+    setIsSavingProfile(true);
+    try {
+      await updateProfile({
+        username: profileUsername.trim(),
+        age_group: profileAgeGroup,
+        analysis_tone: profileTone,
+      });
+      toast.success("プロフィールを ほぞんしたよ！");
+    } catch {
+      toast.error("ほぞんできなかったよ。もういちど ためしてね。");
+    } finally {
+      setIsSavingProfile(false);
+    }
+  };
 
   const [isPortalLoading, setIsPortalLoading] = useState(false);
   const [portalError, setPortalError] = useState<string | null>(null);
@@ -120,6 +165,90 @@ const SettingsPage = () => {
       </header>
 
       <main className="container max-w-2xl mx-auto px-4 py-8 space-y-8">
+        {/* プロフィール設定 */}
+        <section className="space-y-4">
+          <div className="bg-card/50 backdrop-blur-sm border border-border/50 rounded-2xl p-6 shadow-sm">
+            <h2 className="text-lg font-bold mb-4 text-primary flex items-center">
+              <span className="text-2xl mr-2">👤</span>
+              プロフィール せってい
+            </h2>
+            <div className="space-y-5">
+              {/* ニックネーム */}
+              <div>
+                <label htmlFor="profile-username" className="mb-1 block text-sm font-medium text-card-foreground">
+                  ニックネーム
+                </label>
+                <input
+                  id="profile-username"
+                  type="text"
+                  value={profileUsername}
+                  onChange={(e) => setProfileUsername(e.target.value)}
+                  placeholder="みんなに よばれたい なまえ"
+                  className="w-full rounded-xl border border-input bg-background px-4 py-3 text-base text-foreground focus:ring-2 focus:ring-ring"
+                />
+              </div>
+
+              {/* 年齢帯 */}
+              <div>
+                <label htmlFor="profile-age-group" className="mb-1 block text-sm font-medium text-card-foreground">
+                  とし（ねんれいたい）
+                </label>
+                <select
+                  id="profile-age-group"
+                  value={profileAgeGroup}
+                  onChange={(e) => setProfileAgeGroup(e.target.value as AgeGroup)}
+                  className="w-full rounded-xl border border-input bg-background px-4 py-3 text-base text-foreground focus:ring-2 focus:ring-ring"
+                >
+                  {AGE_GROUP_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </select>
+              </div>
+
+              {/* 分析トーン */}
+              <div>
+                <p className="mb-2 block text-sm font-medium text-card-foreground">
+                  ゆめ分析の スタイル
+                </p>
+                <div className="space-y-2">
+                  {ANALYSIS_TONE_OPTIONS.map((opt) => (
+                    <label
+                      key={opt.value}
+                      className={`flex items-start gap-3 rounded-xl border p-3 cursor-pointer transition-colors ${
+                        profileTone === opt.value
+                          ? "border-primary bg-primary/5"
+                          : "border-border bg-background hover:bg-muted"
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="analysis-tone"
+                        value={opt.value}
+                        checked={profileTone === opt.value}
+                        onChange={() => setProfileTone(opt.value)}
+                        className="mt-0.5 accent-primary"
+                      />
+                      <div>
+                        <p className="text-sm font-medium text-foreground">{opt.label}</p>
+                        <p className="text-xs text-muted-foreground">{opt.desc}</p>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <button
+                type="button"
+                onClick={handleSaveProfile}
+                disabled={isSavingProfile}
+                className="w-full min-h-12 rounded-xl bg-primary px-5 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+              >
+                {isSavingProfile ? "ほぞんしているよ..." : "ほぞんする"}
+              </button>
+            </div>
+          </div>
+        </section>
+
         {/* 安心感を与えるメッセージセクション */}
         <section className="space-y-4">
           <div className="bg-card/50 backdrop-blur-sm border border-border/50 rounded-2xl p-6 shadow-sm">

--- a/frontend/app/types.ts
+++ b/frontend/app/types.ts
@@ -1,3 +1,6 @@
+export type AgeGroup = "child_small" | "child" | "preteen" | "teen" | "adult";
+export type AnalysisTone = "auto" | "gentle_kids" | "junior" | "standard" | "deep";
+
 export interface User {
   id: string; // FrontendではIDを文字列として扱う
   username: string;
@@ -5,6 +8,8 @@ export interface User {
   created_at: string;
   updated_at: string;
   premium?: boolean;
+  age_group?: AgeGroup;
+  analysis_tone?: AnalysisTone;
 }
 
 // Backendから直接受け取るユーザー情報の型。IDは数値。

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -16,6 +16,8 @@ interface User {
   email?: string;
   username?: string;
   premium?: boolean;
+  age_group?: string;
+  analysis_tone?: string;
 }
 
 type AuthStatus = "checking" | "authenticated" | "unauthenticated";

--- a/frontend/lib/apiClient.ts
+++ b/frontend/lib/apiClient.ts
@@ -244,6 +244,21 @@ export async function getMe(token: string): Promise<User> {
   return { ...data.user, id: String(data.user.id) };
 }
 
+/**
+ * プロフィール情報を更新します（username, age_group, analysis_tone）
+ */
+export async function updateProfile(data: {
+  username?: string;
+  age_group?: string;
+  analysis_tone?: string;
+}): Promise<{ user: User }> {
+  const response = await apiFetch<{ user: BackendUser }>("/auth/me", {
+    method: "PATCH",
+    body: JSON.stringify({ user: data }),
+  });
+  return { user: { ...response.user, id: String(response.user.id) } };
+}
+
 // --- Client Component Functions ---
 
 export async function clientLogin(


### PR DESCRIPTION
## Summary

- **プロフィール設定ページ** (`/settings`) に nickname・年齢帯・分析スタイルの編集機能を追加
- **年齢別AI分析トーン** — `TonePromptBuilder` サービスで age_group + analysis_tone からプロンプトを生成（gentle_kids / junior / standard / deep の4段階）
- **バグ修正** — ログイン画面のパスワード表示切り替えボタンの `absolute` 配置が壊れていた問題を修正（`div.relative` ラッパーが欠けていた）

## Backend changes

- `db/migrate/20260415000001_add_profile_fields_to_users.rb` — age_group, analysis_tone カラム追加
- `User` model — AGE_GROUPS / ANALYSIS_TONES 定数とバリデーション
- `AuthController#update_me` — `PATCH /auth/me` エンドポイント
- `TonePromptBuilder` — 新規サービス: 年齢帯と分析トーンからシステムプロンプトを生成
- `DreamAnalysisService` — age_group / analysis_tone kwargs を受け付けるように変更
- `AnalyzeDreamJob` / `DreamsController#preview_analysis` — ユーザー設定を DreamAnalysisService に渡す

## Frontend changes

- `types.ts` — AgeGroup, AnalysisTone 型を追加; User に age_group / analysis_tone を追加
- `AuthContext` — ローカル User interface に age_group / analysis_tone を追加
- `apiClient.ts` — `updateProfile()` 関数を追加
- `settings/page.tsx` — プロフィール設定セクション（nickname input, 年齢帯 select, 分析スタイル radio）
- `login/page.tsx` — パスワード toggle バグ修正

## Test plan

- [ ] `/settings` でニックネーム・年齢帯・分析スタイルを変更して「ほぞんする」が動作することを確認
- [ ] ログイン画面でパスワードの目アイコンが正しく表示・非表示を切り替えられること
- [ ] 年齢帯 `child_small` で夢を分析するとひらがな多めのやさしい文体になること
- [ ] 年齢帯 `adult` で夢を分析すると標準的な文体になること
- [ ] Rails migration: `bundle exec rails db:migrate` を本番(Render)で実行する必要あり
