### PR TITLE
fix: address review issues from PR #183 (profile settings)

### DIFF
--- a/backend/app/controllers/auth_controller.rb
+++ b/backend/app/controllers/auth_controller.rb
@@ -17,7 +17,7 @@ class AuthController < ApplicationController
       end
 
       set_token_cookies(result[:access_token], result[:refresh_token])
-      render json: { user: result[:user].as_json(only: [:id, :email, :username, :premium]) }, status: :ok
+      render json: { user: user_json(result[:user]) }, status: :ok
     rescue AuthService::InvalidCredentialsError => e
       render json: { error: e.message }, status: :unauthorized
     rescue StandardError => e # その他の予期せぬエラー

--- a/backend/app/controllers/trial_users_controller.rb
+++ b/backend/app/controllers/trial_users_controller.rb
@@ -12,7 +12,7 @@ class TrialUsersController < ApplicationController
         return
       end
       set_token_cookies(result[:access_token], result[:refresh_token])
-      render json: { user: result[:user].as_json(only: [:id, :email, :username, :premium]) }, status: :created
+      render json: { user: result[:user].as_json(only: [:id, :email, :username, :premium, :age_group, :analysis_tone]) }, status: :created
     rescue AuthService::RegistrationError => e
       Rails.logger.error "Error in TrialUsersController#create: #{e.message}"
       render json: { error: e.message }, status: :internal_server_error

--- a/backend/app/controllers/users_controller.rb
+++ b/backend/app/controllers/users_controller.rb
@@ -19,7 +19,7 @@ class UsersController < ApplicationController
 
       # ログイン時と同様にCookieを設定
       set_token_cookies(result[:access_token], result[:refresh_token])
-      render json: { user: result[:user].as_json(only: [:id, :email, :username, :premium]) }, status: :created
+      render json: { user: result[:user].as_json(only: [:id, :email, :username, :premium, :age_group, :analysis_tone]) }, status: :created
     rescue AuthService::RegistrationError => e
       render json: { error: e.message }, status: :unprocessable_entity
     end

--- a/backend/app/jobs/analyze_dream_job.rb
+++ b/backend/app/jobs/analyze_dream_job.rb
@@ -21,9 +21,14 @@ class AnalyzeDreamJob < ApplicationJob
 
   def process_audio_dream(dream)
     # OpenAI 呼び出し（Whisper + GPT）— ここが課金対象
+    user = dream.user
     result = nil
     dream.audio.open do |file|
-      result = AudioAnalysisService.new(file).call
+      result = AudioAnalysisService.new(
+        file,
+        age_group:     user&.age_group     || "child",
+        analysis_tone: user&.analysis_tone || "auto"
+      ).call
     end
 
     # 文字起こしが Dream.content の上限（1000文字）を超える場合は切り詰め

--- a/backend/app/services/audio_analysis_service.rb
+++ b/backend/app/services/audio_analysis_service.rb
@@ -6,8 +6,10 @@ class AudioAnalysisService
   class TranscriptionError < StandardError; end
   class AnalysisError < StandardError; end
 
-  def initialize(file_source)
+  def initialize(file_source, age_group: "child", analysis_tone: "auto")
     @file_source = file_source
+    @age_group = age_group
+    @analysis_tone = analysis_tone
     @client = OpenAI::Client.new(access_token: ENV.fetch("OPENAI_API_KEY"))
   end
 
@@ -90,16 +92,7 @@ class AudioAnalysisService
   end
 
   def analyze_transcript(text)
-    system_prompt = <<~PROMPT
-      あなたは子供向けの「夢占い博士」モルペウスです。
-      6歳の子供でもわかるように、ひらがなを多めに使って、優しく短く夢の意味を教えてあげてください。
-      漢字は小学校1年生で習うもの程度（例：山、川、月、日）に留め、難しい漢字はひらがなにしてください。
-      出力は必ず以下のJSONフォーマットに従ってください。
-      {
-        "analysis": "（例：◯◯くん、すごいゆめをみたね！それは・・・）",
-        "emotion_tags": ["感情1", "感情2"]
-      }
-    PROMPT
+    system_prompt = TonePromptBuilder.build(age_group: @age_group, analysis_tone: @analysis_tone)
 
     response = @client.chat(
       parameters: {

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../../context/AuthContext";
 import Loading from "../loading";
@@ -46,6 +46,14 @@ const SettingsPage = () => {
   const [profileAgeGroup, setProfileAgeGroup] = useState<AgeGroup>((user?.age_group as AgeGroup) ?? "child");
   const [profileTone, setProfileTone] = useState<AnalysisTone>((user?.analysis_tone as AnalysisTone) ?? "auto");
   const [isSavingProfile, setIsSavingProfile] = useState(false);
+
+  // 初回レンダー時は user === null (checking中)なので、verify 完了後に再同期する
+  useEffect(() => {
+    if (!user) return;
+    setProfileUsername(user.username ?? "");
+    setProfileAgeGroup((user.age_group as AgeGroup) ?? "child");
+    setProfileTone((user.analysis_tone as AnalysisTone) ?? "auto");
+  }, [user?.id]);
 
   const handleSaveProfile = async () => {
     if (!profileUsername.trim()) {


### PR DESCRIPTION
## 背景

PR #183 のコードレビューで Codex が指摘した 3 件の問題を修正します。

## 修正内容

### 1. [High] settings フォームの初期値が空白になるバグ

**問題**: `settings/page.tsx` の `useState` 初期化は初回レンダー時に実行されます。しかしその時点では `AuthContext` がまだ verify 中で `user === null` のため、`profileUsername=""` `age_group="child"` `analysis_tone="auto"` という空/デフォルト値で確定していました。verify 完了後も state は再同期されないため、既存ユーザーが設定画面を開くとフォームが空白のまま表示され、誤ってデータを上書きしてしまうリスクがありました。

**修正**: `useEffect(() => { ... }, [user?.id])` を追加し、`user` が確定した後にフォーム state を再同期するようにしました。

### 2. [High] 音声夢がトーン設定を無視していた

**問題**: `AnalyzeDreamJob#process_audio_dream` は `AudioAnalysisService.new(file)` で呼んでいました。`AudioAnalysisService#analyze_transcript` は固定の「子ども向けひらがなプロンプト」を持っていたため、ユーザーが `adult` / `standard` トーンに設定していても音声夢だけは常に子ども向けになっていました。

**修正**: `AudioAnalysisService` に `age_group:` / `analysis_tone:` kwargs を追加し、`TonePromptBuilder.build` でプロンプトを生成するように変更。`AnalyzeDreamJob` からユーザー設定を渡すようにしました。

### 3. [Medium] login/register/trial レスポンスに新フィールドが欠落

**問題**: `GET /auth/me`・`PATCH /auth/me`・`GET /auth/verify` は `user_json` ヘルパー経由で `age_group` / `analysis_tone` を返していましたが、`POST /auth/login`・`POST /auth/register`・`POST /auth/trial` は旧形式のまま (`only: [:id, :email, :username, :premium]`) でした。ログイン直後は AuthContext が空のフィールドを持ち、verify が走るまで設定ページのフォームに正しい値が入りませんでした。

**修正**: 3 つのコントローラーで `age_group` / `analysis_tone` をレスポンスに含めるように修正しました。

## Test plan

- [ ] `/settings` に直アクセス（URL 直打ち）したとき、nickname/年齢帯/トーンが既存の設定値で初期化されていること
- [ ] ログイン直後に `/settings` を開いたとき、フォームが正しく埋まっていること（verify を待たずに）
- [ ] `adult`/`standard` 設定ユーザーが音声入力で夢を保存すると、分析結果が標準的な文体になること
- [ ] 新規登録直後に `/settings` で年齢帯が `child`（デフォルト）になっていること