### PR TITLE
feat: age-group-aware image generation prompt

### DIFF
--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -293,10 +293,25 @@ class DreamsController < ApplicationController
     end
 
     def build_image_prompt(content, analysis)
-      base = "A dreamy, whimsical illustration of a dream: #{content}"
+      base = "A dreamy illustration of a dream: #{content}"
       base += " The mood is: #{analysis}" if analysis.present?
-      base += ". Soft watercolor style, gentle colors, child-friendly, peaceful atmosphere, no text."
+      base += ". #{image_style_for_age_group(@current_user&.age_group)} No text, no letters."
       base.truncate(900)
+    end
+
+    def image_style_for_age_group(age_group)
+      case age_group
+      when "child_small", "child"
+        "Soft watercolor style, pastel colors, child-friendly, gentle and peaceful atmosphere."
+      when "preteen"
+        "Colorful storybook illustration style, slightly adventurous, vivid but friendly colors."
+      when "teen"
+        "Stylized digital art, cinematic lighting, vivid colors, cool and dramatic dreamlike mood."
+      when "adult"
+        "Surrealist oil painting style, rich detail, deep colors, sophisticated and dreamlike atmosphere."
+      else
+        "Soft watercolor style, gentle colors, peaceful dreamlike atmosphere."
+      end
     end
 
     def set_dream_and_authorize_user

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -612,6 +612,54 @@ RSpec.describe 'Dreams API', type: :request do
 
         expect(response).to have_http_status(:forbidden)
       end
+
+      describe '年齢帯ごとのプロンプトスタイル' do
+        let(:style_dream) { create(:dream, user: age_user, content: 'テスト用の夢') }
+
+        shared_examples 'プロンプトにスタイルが含まれる' do |expected_fragment|
+          it "プロンプトに '#{expected_fragment}' が含まれる" do
+            expect(images_client).to receive(:generate).with(
+              parameters: hash_including(
+                prompt: a_string_including(expected_fragment)
+              )
+            ).and_return({ 'data' => [{ 'url' => generated_url }] })
+
+            authenticated_post "/dreams/#{style_dream.id}/generate_image", age_user
+            expect(response).to have_http_status(:ok)
+          end
+        end
+
+        context 'child ユーザー' do
+          let(:age_user) { create(:user, age_group: 'child') }
+          include_examples 'プロンプトにスタイルが含まれる', 'watercolor'
+        end
+
+        context 'child_small ユーザー' do
+          let(:age_user) { create(:user, age_group: 'child_small') }
+          include_examples 'プロンプトにスタイルが含まれる', 'child-friendly'
+        end
+
+        context 'preteen ユーザー' do
+          let(:age_user) { create(:user, age_group: 'preteen') }
+          include_examples 'プロンプトにスタイルが含まれる', 'storybook'
+        end
+
+        context 'teen ユーザー' do
+          let(:age_user) { create(:user, age_group: 'teen') }
+          include_examples 'プロンプトにスタイルが含まれる', 'cinematic'
+        end
+
+        context 'adult ユーザー' do
+          let(:age_user) { create(:user, age_group: 'adult') }
+          include_examples 'プロンプトにスタイルが含まれる', 'Surrealist'
+        end
+
+        context 'age_group が nil のユーザー（旧データ互換）' do
+          let(:age_user) { create(:user) }
+          before { age_user.update_column(:age_group, nil) }
+          include_examples 'プロンプトにスタイルが含まれる', 'watercolor'
+        end
+      end
     end
 
     context '認証されていない場合' do

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -654,9 +654,8 @@ RSpec.describe 'Dreams API', type: :request do
           include_examples 'プロンプトにスタイルが含まれる', 'Surrealist'
         end
 
-        context 'age_group が nil のユーザー（旧データ互換）' do
+        context 'age_group がデフォルト（child）のユーザー' do
           let(:age_user) { create(:user) }
-          before { age_user.update_column(:age_group, nil) }
           include_examples 'プロンプトにスタイルが含まれる', 'watercolor'
         end
       end


### PR DESCRIPTION
## 概要

画像生成プロンプトを年齢帯に応じて切り替えるようにしました。

従来は全ユーザー共通で `child-friendly, soft watercolor` 固定でしたが、`adult` 設定のユーザーでも子ども向けの絵になっていました。

## 変更内容

`DreamsController#build_image_prompt` を分割し、`image_style_for_age_group` ヘルパーで年齢帯ごとのスタイルを返すようにしました。

| age_group | 画像スタイル |
|---|---|
| child_small / child | Soft watercolor, pastel colors, child-friendly（従来と同じ） |
| preteen | Colorful storybook illustration, slightly adventurous |
| teen | Stylized digital art, cinematic lighting, vivid |
| adult | Surrealist oil painting style, rich detail, sophisticated |
| nil / 不明 | Soft watercolor fallback（安全側） |

プロフィール設定でユーザーが年齢帯を変更すると、次回の画像生成からすぐに反映されます。

## Test plan

- [ ] `child` 設定ユーザーで画像生成 → やわらかい水彩タッチ
- [ ] `adult` 設定ユーザーで画像生成 → シュールな油絵風
- [ ] `age_group = nil`（旧ユーザー・migration前）でもエラーにならないこと
