### PR TITLE
ux: lighten save celebration and simplify home rewards

### DIFF
--- a/frontend/app/components/DreamStreakBadge.tsx
+++ b/frontend/app/components/DreamStreakBadge.tsx
@@ -14,7 +14,9 @@ function calcStreak(dreams: Dream[]): { current: number; longest: number } {
   // ユニークな日付を降順に並べる
   const uniqueDays = Array.from(
     new Set(dreams.map((d) => getJSTDateStr(d.created_at)))
-  ).sort().reverse();
+  )
+    .sort()
+    .reverse();
 
   const todayStr = new Date().toLocaleDateString("en-CA", {
     timeZone: "Asia/Tokyo",
@@ -31,9 +33,7 @@ function calcStreak(dreams: Dream[]): { current: number; longest: number } {
     for (let i = 1; i < uniqueDays.length; i++) {
       const prev = new Date(uniqueDays[i - 1]);
       const curr = new Date(uniqueDays[i]);
-      const diffDays = Math.round(
-        (prev.getTime() - curr.getTime()) / 86400000
-      );
+      const diffDays = Math.round((prev.getTime() - curr.getTime()) / 86400000);
       if (diffDays === 1) {
         current++;
       } else {
@@ -75,38 +75,32 @@ export default function DreamStreakBadge({ dreams }: DreamStreakBadgeProps) {
     return getJSTYearMonthKey(d.created_at) === currentJSTMonth;
   }).length;
 
-  // 獲得バッジの計算
-  const badges: { icon: string; label: string; color: string }[] = [];
-  if (current >= 3)
-    badges.push({
-      icon: "🔥",
-      label: `${current}日れんぞく！`,
-      color: "text-orange-400 border-orange-400/40 bg-orange-400/10",
-    });
-  if (current >= 7)
-    badges.push({
-      icon: "⭐",
-      label: "1しゅうかん！",
-      color: "text-yellow-400 border-yellow-400/40 bg-yellow-400/10",
-    });
-  if (current >= 30)
-    badges.push({
-      icon: "🏆",
-      label: "1ヶ月かいたよ！",
-      color: "text-sky-400 border-sky-400/40 bg-sky-400/10",
-    });
-  if (thisMonthCount >= 10)
-    badges.push({
-      icon: "🌟",
-      label: `今月${thisMonthCount}かい！`,
-      color: "text-purple-400 border-purple-400/40 bg-purple-400/10",
-    });
-  if (longest >= 7 && current < longest)
-    badges.push({
-      icon: "🎯",
-      label: `さいこう${longest}にち`,
-      color: "text-emerald-400 border-emerald-400/40 bg-emerald-400/10",
-    });
+  const milestone =
+    current === 30
+      ? {
+          icon: "🏆",
+          title: "1ヶ月つづいた！",
+          body: "きょうは とくべつ。たくさん つづけて かけたね。",
+          tone: "border-sky-400/40 bg-sky-400/10 text-sky-500",
+        }
+      : current === 7
+        ? {
+            icon: "⭐",
+            title: "1しゅうかん たっせい！",
+            body: "れんぞくで かけたよ。すごいペース！",
+            tone: "border-yellow-400/40 bg-yellow-400/10 text-yellow-500",
+          }
+        : current === 3
+          ? {
+              icon: "🔥",
+              title: "3日れんぞく！",
+              body: "このリズム、いいかんじ。そのまま つづけよう。",
+              tone: "border-orange-400/40 bg-orange-400/10 text-orange-500",
+            }
+          : null;
+
+  const nextMilestone =
+    current < 3 ? 3 : current < 7 ? 7 : current < 30 ? 30 : null;
 
   return (
     <div className="bg-card border border-border rounded-xl p-4 w-full mb-4">
@@ -137,25 +131,31 @@ export default function DreamStreakBadge({ dreams }: DreamStreakBadgeProps) {
         </div>
       </div>
 
-      {/* バッジ表示 */}
-      {badges.length > 0 ? (
-        <div className="flex flex-wrap gap-2">
-          {badges.map((badge, i) => (
-            <div
-              key={i}
-              className={`flex items-center gap-1 border rounded-full px-3 py-1 text-xs font-bold ${badge.color}`}
-            >
-              <span>{badge.icon}</span>
-              <span>{badge.label}</span>
-            </div>
-          ))}
+      {milestone ? (
+        <div
+          className={`rounded-2xl border px-4 py-3 shadow-sm transition-colors ${milestone.tone}`}
+        >
+          <div className="flex items-center gap-2 text-sm font-bold">
+            <span>{milestone.icon}</span>
+            <span>{milestone.title}</span>
+          </div>
+          <p className="mt-1 text-xs text-foreground/80">{milestone.body}</p>
         </div>
       ) : (
-        <p className="text-xs text-muted-foreground">
-          {current === 0
-            ? "きょうも ゆめを かいてみよう！🌙"
-            : `あと ${3 - current} にち れんぞくで バッジ がもらえるよ！`}
-        </p>
+        <div className="rounded-2xl border border-border/70 bg-muted/30 px-4 py-3">
+          <p className="text-xs text-muted-foreground">
+            {current === 0
+              ? "きょうも ゆめを かいてみよう！🌙"
+              : nextMilestone
+                ? `つぎの おいわいは ${nextMilestone}日れんぞく。あと ${nextMilestone - current} にち！`
+                : `さいこう きろくは ${longest}日。いいペースで つづいているよ。`}
+          </p>
+          {thisMonthCount >= 10 ? (
+            <p className="mt-2 text-xs font-medium text-primary">
+              今月は もう {thisMonthCount}かい かけているよ。
+            </p>
+          ) : null}
+        </div>
       )}
     </div>
   );

--- a/frontend/app/dream/new/page.tsx
+++ b/frontend/app/dream/new/page.tsx
@@ -39,7 +39,7 @@ export default function NewDreamPage() {
     try {
       await createDream(formData);
       triggerDreamConfetti();
-      toast.success("夢を保存しました！");
+      toast.success("夢を保存したよ！");
       router.push("/home");
     } catch (error) {
       console.error("Failed to save dream:", error);

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -136,6 +136,21 @@ export default function HomePage() {
     };
   }, [fetchDreams]);
 
+  // 検索フィルターが有効かどうかを判定（フックより前に計算）
+  const isSearchActive = !!(
+    searchParams.get("query") ||
+    searchParams.get("startDate") ||
+    searchParams.get("endDate") ||
+    searchParams.getAll("emotion_ids[]").length > 0
+  );
+
+  // 検索がアクティブになったらパネルを開く（条件分岐より前に置く必要あり）
+  useEffect(() => {
+    if (isSearchActive) {
+      setIsSearchPanelOpen(true);
+    }
+  }, [isSearchActive]);
+
   // 認証確認中
   if (authStatus === "checking") {
     return <Loading />;
@@ -153,25 +168,12 @@ export default function HomePage() {
   // 夢データを月ごとにグループ化
   const groupedDreams = groupDreamsByMonth(dreams);
 
-  // 検索フィルターが有効かどうかを判定
-  const isSearchActive = !!(
-    searchParams.get("query") ||
-    searchParams.get("startDate") ||
-    searchParams.get("endDate") ||
-    searchParams.getAll("emotion_ids[]").length > 0
-  );
   const shouldDeferSearch =
     !loading &&
     !isSearchActive &&
     !isSearchPanelOpen &&
     dreams.length > 0 &&
     dreams.length < 5;
-
-  useEffect(() => {
-    if (isSearchActive) {
-      setIsSearchPanelOpen(true);
-    }
-  }, [isSearchActive]);
 
   return (
     <div className="lg:flex text-foreground">

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -23,7 +23,6 @@ import Loading from "../loading";
 function groupDreamsByMonth(dreams: Dream[]) {
   return dreams.reduce(
     (groupedDreams, dream) => {
-
       const yearMonth = getJSTYearMonthKey(dream.created_at);
 
       if (!groupedDreams[yearMonth]) {
@@ -50,6 +49,7 @@ export default function HomePage() {
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [emotions, setEmotions] = useState<Emotion[]>([]);
+  const [isSearchPanelOpen, setIsSearchPanelOpen] = useState(false);
 
   const fetchDreams = useCallback(async () => {
     if (authStatus !== "authenticated") {
@@ -160,6 +160,18 @@ export default function HomePage() {
     searchParams.get("endDate") ||
     searchParams.getAll("emotion_ids[]").length > 0
   );
+  const shouldDeferSearch =
+    !loading &&
+    !isSearchActive &&
+    !isSearchPanelOpen &&
+    dreams.length > 0 &&
+    dreams.length < 5;
+
+  useEffect(() => {
+    if (isSearchActive) {
+      setIsSearchPanelOpen(true);
+    }
+  }, [isSearchActive]);
 
   return (
     <div className="lg:flex text-foreground">
@@ -185,13 +197,31 @@ export default function HomePage() {
             />
           </div>
         </div>
-        <SearchBar
-          query={searchParams.get("query") || undefined}
-          startDate={searchParams.get("startDate") || undefined}
-          endDate={searchParams.get("endDate") || undefined}
-          emotions={emotions}
-          selectedEmotionIds={searchParams.getAll("emotion_ids[]")}
-        />
+        {shouldDeferSearch ? (
+          <div className="mt-4 w-full rounded-2xl border border-border/70 bg-card px-4 py-4 shadow-sm">
+            <p className="text-sm font-medium text-card-foreground">
+              けんさくは まだ しまってあるよ
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              ゆめが ふえてからでも だいじょうぶ。ひつような ときだけ ひらこう。
+            </p>
+            <button
+              type="button"
+              onClick={() => setIsSearchPanelOpen(true)}
+              className="mt-3 inline-flex min-h-11 items-center justify-center rounded-xl border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+            >
+              まえの ゆめを さがす
+            </button>
+          </div>
+        ) : (
+          <SearchBar
+            query={searchParams.get("query") || undefined}
+            startDate={searchParams.get("startDate") || undefined}
+            endDate={searchParams.get("endDate") || undefined}
+            emotions={emotions}
+            selectedEmotionIds={searchParams.getAll("emotion_ids[]")}
+          />
+        )}
 
         {/* ローディング中: スケルトンカードを表示 */}
         {loading && <DreamListSkeleton count={6} />}

--- a/frontend/lib/confetti.ts
+++ b/frontend/lib/confetti.ts
@@ -1,9 +1,15 @@
 import confetti from "canvas-confetti";
 
 export const triggerDreamConfetti = () => {
-  const duration = 3000;
+  const duration = 800;
   const animationEnd = Date.now() + duration;
-  const defaults = { startVelocity: 30, spread: 360, ticks: 60, zIndex: 0 };
+  const defaults = {
+    startVelocity: 22,
+    spread: 70,
+    ticks: 45,
+    scalar: 0.9,
+    zIndex: 0,
+  };
 
   const randomInRange = (min: number, max: number) => {
     return Math.random() * (max - min) + min;
@@ -16,25 +22,27 @@ export const triggerDreamConfetti = () => {
       return clearInterval(interval);
     }
 
-    const particleCount = 50 * (timeLeft / duration);
+    const particleCount = Math.max(6, Math.round(18 * (timeLeft / duration)));
 
-    // 星と丸を混ぜる
-    // 夢っぽい色: 黄色(FFD700), 紫(9370DB), 青(4169E1), ピンク(FF69B4)
-    const colors = ["#FFD700", "#9370DB", "#4169E1", "#FF69B4", "#00CED1"];
+    const colors = ["#FFD700", "#FFB347", "#7DD3FC"];
 
     confetti({
       ...defaults,
       particleCount,
-      origin: { x: randomInRange(0.1, 0.3), y: Math.random() - 0.2 },
-      colors: colors,
-      shapes: ["star", "circle"],
+      origin: { x: randomInRange(0.2, 0.35), y: 0.2 },
+      drift: randomInRange(-0.2, 0.2),
+      gravity: 0.8,
+      colors,
+      shapes: ["star"],
     });
     confetti({
       ...defaults,
       particleCount,
-      origin: { x: randomInRange(0.7, 0.9), y: Math.random() - 0.2 },
-      colors: colors,
-      shapes: ["star", "circle"],
+      origin: { x: randomInRange(0.65, 0.8), y: 0.2 },
+      drift: randomInRange(-0.2, 0.2),
+      gravity: 0.8,
+      colors,
+      shapes: ["star"],
     });
   }, 250);
 };


### PR DESCRIPTION
## Summary

- **保存演出の軽量化**: 3秒の全画面コンフェッティ → 0.8秒の星スパーク（`confetti.ts`）
- **ストリーク節目演出**: 3日・7日・30日のときだけ強く祝い、それ以外は次の目標を静かに案内（`DreamStreakBadge.tsx`）
- **検索バーの後退配置**: 夢が1〜4件のときは初期非表示、ボタンで開ける形に（`home/page.tsx`）
- 成功トースト文言を微調整（`dream/new/page.tsx`）

## Test plan

- [ ] 夢を保存 → 星スパークが短く出てホームへ遷移する
- [ ] ストリーク3日・7日・30日 → 節目パネルが表示される（それ以外は次の目標が表示）
- [ ] 夢が4件以下のホーム → 検索バーが非表示・「まえのゆめをさがす」ボタンで開ける
- [ ] 夢が5件以上のホーム → 検索バーが通常表示される
- [ ] `yarn lint` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)