### PR TITLE
ux: age-group microcopy on new-dream and dream-detail pages

### DIFF
--- a/frontend/__tests__/components/DreamDetailPage.test.tsx
+++ b/frontend/__tests__/components/DreamDetailPage.test.tsx
@@ -67,6 +67,13 @@ jest.mock("@/hooks/useDream", () => ({
   useDream: jest.fn(),
 }));
 
+jest.mock("@/context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { age_group: "child" },
+    authStatus: "authenticated",
+  }),
+}));
+
 const { useDream } = require("@/hooks/useDream");
 
 describe("DreamDetailPage", () => {

--- a/frontend/app/dream/[id]/page.tsx
+++ b/frontend/app/dream/[id]/page.tsx
@@ -11,6 +11,8 @@ import { useRouter } from "next/navigation";
 import { useState, useEffect, use } from "react";
 import Image from "next/image";
 import apiClient from "../../../lib/apiClient";
+import { useAuth } from "../../../context/AuthContext";
+import { AgeGroup } from "@/app/types";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -21,6 +23,41 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+
+function getDreamDetailCopy(ageGroup: AgeGroup | undefined) {
+  switch (ageGroup) {
+    case "child_small":
+    case "child":
+      return {
+        content: "ゆめの おはなし",
+        analysis: "🔮 モルペウスの ゆめうらない",
+        image: "🎨 ゆめのえ",
+        imageAlt: "ゆめのえ",
+        imageRedraw: "かきなおす",
+        imageGenerating: "かいています...",
+      };
+    case "preteen":
+      return {
+        content: "夢の内容",
+        analysis: "🔮 夢の分析",
+        image: "🎨 夢のイラスト",
+        imageAlt: "夢のイラスト",
+        imageRedraw: "描き直す",
+        imageGenerating: "生成中...",
+      };
+    case "teen":
+    case "adult":
+    default:
+      return {
+        content: "夢の内容",
+        analysis: "🔮 AI分析",
+        image: "🎨 生成画像",
+        imageAlt: "生成された夢のイメージ",
+        imageRedraw: "再生成",
+        imageGenerating: "生成中...",
+      };
+  }
+}
 
 function formatDate(dateInput: string | undefined): string {
   if (!dateInput) return "";
@@ -51,6 +88,9 @@ export default function DreamDetailPage({
     updateDream: hookUpdateDream,
     deleteDream: hookDeleteDream,
   } = useDream(dreamId);
+
+  const { user } = useAuth();
+  const copy = getDreamDetailCopy(user?.age_group as AgeGroup | undefined);
 
   const router = useRouter();
   const [isEditing, setIsEditing] = useState(false);
@@ -227,7 +267,7 @@ export default function DreamDetailPage({
       {dream.content && dream.content !== dream.title && (
         <div className="bg-card border border-border rounded-xl p-5 mb-6">
           <p className="text-sm font-semibold text-muted-foreground mb-2">
-            ゆめの おはなし
+            {copy.content}
           </p>
           <p className="text-foreground leading-relaxed whitespace-pre-wrap">
             {dream.content}
@@ -239,7 +279,7 @@ export default function DreamDetailPage({
       {analysisText && (
         <div className="bg-muted/50 border border-input rounded-xl p-5 mb-6">
           <p className="text-sm font-semibold text-muted-foreground mb-2">
-            🔮 モルペウスの ゆめうらない
+            {copy.analysis}
           </p>
           <p className="text-foreground leading-relaxed whitespace-pre-wrap text-sm">
             {analysisText}
@@ -254,7 +294,7 @@ export default function DreamDetailPage({
             <div className="rounded-xl overflow-hidden border border-border">
               <Image
                 src={generatedImageUrl}
-                alt="ゆめのえ"
+                alt={copy.imageAlt}
                 width={1024}
                 height={1024}
                 className="w-full h-auto"
@@ -262,14 +302,14 @@ export default function DreamDetailPage({
                 onError={handleImageLoadError}
               />
               <div className="p-3 bg-card flex items-center justify-between">
-                <p className="text-xs text-muted-foreground">🎨 ゆめのえ</p>
+                <p className="text-xs text-muted-foreground">{copy.image}</p>
                 <button
                   type="button"
                   onClick={handleGenerateImage}
                   disabled={isGeneratingImage}
                   className="text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
                 >
-                  {isGeneratingImage ? "かいています..." : "かきなおす"}
+                  {isGeneratingImage ? copy.imageGenerating : copy.imageRedraw}
                 </button>
               </div>
             </div>

--- a/frontend/app/dream/new/page.tsx
+++ b/frontend/app/dream/new/page.tsx
@@ -9,12 +9,43 @@ import { useAuth } from "../../../context/AuthContext";
 import Loading from "../../loading";
 import { createDream } from "@/lib/apiClient";
 import { toast } from "@/lib/toast";
-import { DreamInput } from "@/app/types";
+import { DreamInput, AgeGroup } from "@/app/types";
 import { triggerDreamConfetti } from "@/lib/confetti";
+
+function getNewDreamCopy(ageGroup: AgeGroup | undefined) {
+  switch (ageGroup) {
+    case "child_small":
+      return {
+        heading: "あたらしい ゆめを かこう",
+        morpheus: "どんな ゆめを みたの？おしえてね！",
+      };
+    case "child":
+      return {
+        heading: "あたらしい ゆめを かく",
+        morpheus: "どんな ゆめを みたの？おもいだせる だけ おしえてね！",
+      };
+    case "preteen":
+      return {
+        heading: "夢を書いてみよう",
+        morpheus: "どんな夢だった？思い出せる範囲で書いてね。",
+      };
+    case "teen":
+      return {
+        heading: "今日の夢を記録する",
+        morpheus: "どんな夢を見た？細かくなくていいよ。",
+      };
+    case "adult":
+    default:
+      return {
+        heading: "新しい夢を記録",
+        morpheus: "どのような夢を見ましたか？思い出せる範囲で記録しましょう。",
+      };
+  }
+}
 
 export default function NewDreamPage() {
   const router = useRouter();
-  const { authStatus } = useAuth();
+  const { authStatus, user } = useAuth();
   const [isSaving, setIsSaving] = useState(false);
   const [hasDraft, setHasDraft] = useState(false);
   const [isDraftChecked, setIsDraftChecked] = useState(false);
@@ -86,9 +117,11 @@ export default function NewDreamPage() {
     );
   }
 
+  const copy = getNewDreamCopy(user?.age_group as AgeGroup | undefined);
+
   return (
     <div className="min-h-screen py-8 px-4 md:px-12 max-w-3xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">あたらしい ゆめを かく</h1>
+      <h1 className="text-2xl font-bold mb-4">{copy.heading}</h1>
 
       {/* ドラフト復元バナー（録音データがある場合のみ表示） */}
       {!isDraftChecked ? (
@@ -104,7 +137,7 @@ export default function NewDreamPage() {
         /* 通常時の励ましメッセージ */
         <div className="mb-6">
           <MorpheusSmall
-            message="どんな ゆめを みたの？おもいだせる だけ おしえてね！"
+            message={copy.morpheus}
             size="sm"
           />
         </div>

--- a/frontend/e2e/dream-detail-flow.spec.ts
+++ b/frontend/e2e/dream-detail-flow.spec.ts
@@ -28,7 +28,7 @@ test.describe("夢詳細の閲覧・編集・再分析・保存フロー", () =>
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
-          user: { id: 1, email: "test@example.com", username: "E2Eユーザー" },
+          user: { id: 1, email: "test@example.com", username: "E2Eユーザー", age_group: "child" },
         }),
       });
     });


### PR DESCRIPTION
## Summary

PR #189 のホームに続き、残り2ページに年齢帯別マイクロコピーを適用。

- `dream/new/page.tsx`: 見出し・モルペウスメッセージを age_group で切り替え
- `dream/[id]/page.tsx`: 夢の内容ラベル・AI分析ラベル・画像ラベル・ボタン文言を age_group で切り替え

child_small/child: ひらがな主体 / preteen: 常用漢字混じり / teen・adult: 標準的な日本語

## Test plan

- [ ] `/settings` で年齢帯を変更して保存
- [ ] `/dream/new` で見出しとモルペウスメッセージが切り替わる
- [ ] `/dream/[id]` で各ラベルが切り替わる
- [ ] `yarn lint` が通る
