### PR TITLE
feat: image quota API and remaining count display

### DIFF
--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -39,6 +39,17 @@ class DreamsController < ApplicationController
     render json: status_map
   end
 
+  # GET /dreams/image_quota
+  def image_quota
+    used  = current_user.dreams.with_image.generated_in_month.count
+    limit = IMAGE_MONTHLY_LIMIT
+    render json: {
+      used:      used,
+      limit:     limit,
+      remaining: [limit - used, 0].max
+    }
+  end
+
   # GET /dreams/:id
   def show
     render json: @dream.as_json(

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
       post :preview_analysis
       get :my_dreams
       get :statuses # 一括ステータス取得用
+      get :image_quota # 画像生成残数
       # /dreams/month/2023-05 のような形式でアクセス
       get 'month/:year_month', to: 'dreams#by_month_index', as: :by_month
     end

--- a/frontend/app/dream/[id]/page.tsx
+++ b/frontend/app/dream/[id]/page.tsx
@@ -99,12 +99,19 @@ export default function DreamDetailPage({
   const [isGeneratingImage, setIsGeneratingImage] = useState(false);
   const [generatedImageUrl, setGeneratedImageUrl] = useState<string | null>(null);
   const [imageError, setImageError] = useState<string | null>(null);
+  const [imageQuota, setImageQuota] = useState<{ used: number; limit: number; remaining: number } | null>(null);
 
   useEffect(() => {
     if (error) {
       console.error("夢データの取得に失敗しました:", error);
     }
   }, [error]);
+
+  useEffect(() => {
+    apiClient.get<{ used: number; limit: number; remaining: number }>("/dreams/image_quota")
+      .then(setImageQuota)
+      .catch(() => {/* 非致命的 */});
+  }, []);
 
   useEffect(() => {
     if (dream?.generated_image_url) {
@@ -337,7 +344,11 @@ export default function DreamDetailPage({
             {imageError && (
               <p className="text-xs text-destructive">{imageError}</p>
             )}
-            <p className="text-xs text-muted-foreground">AIが夢のイメージを絵にします（月30枚まで）</p>
+            <p className="text-xs text-muted-foreground">
+              {imageQuota
+                ? `今月あと ${imageQuota.remaining} 枚 生成できます（${imageQuota.used} / ${imageQuota.limit}）`
+                : "AIが夢のイメージを絵にします（月30枚まで）"}
+            </p>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- `GET /dreams/image_quota` エンドポイントを追加（used / limit / remaining を返す）
- 夢詳細ページの画像生成ボタン下に「今月あと N 枚 生成できます（used / limit）」を表示
- quota 取得失敗時は従来の静的文言にフォールバック

## 変更ファイル

- `backend/config/routes.rb` — `get :image_quota` を collection に追加
- `backend/app/controllers/dreams_controller.rb` — `image_quota` アクション追加
- `frontend/app/dream/[id]/page.tsx` — quota 取得 useEffect + 残数表示

## Test plan

- [ ] `/dream/[id]` で「今月あと N 枚 生成できます」が表示される
- [ ] `bundle exec rspec spec/requests/dreams_spec.rb` が通る
- [ ] `yarn lint` が通る
