### PR TITLE
fix: remove AgeGroup type casts, type AuthContext properly

### DIFF
--- a/frontend/app/dream/[id]/page.tsx
+++ b/frontend/app/dream/[id]/page.tsx
@@ -33,6 +33,7 @@ function getDreamDetailCopy(ageGroup: AgeGroup | undefined) {
         analysis: "🔮 モルペウスの ゆめうらない",
         image: "🎨 ゆめのえ",
         imageAlt: "ゆめのえ",
+        button: "ゆめのえを かく",
         imageRedraw: "かきなおす",
         imageGenerating: "かいています...",
       };
@@ -42,6 +43,7 @@ function getDreamDetailCopy(ageGroup: AgeGroup | undefined) {
         analysis: "🔮 夢の分析",
         image: "🎨 夢のイラスト",
         imageAlt: "夢のイラスト",
+        button: "夢のイラストを生成",
         imageRedraw: "描き直す",
         imageGenerating: "生成中...",
       };
@@ -53,6 +55,7 @@ function getDreamDetailCopy(ageGroup: AgeGroup | undefined) {
         analysis: "🔮 AI分析",
         image: "🎨 生成画像",
         imageAlt: "生成された夢のイメージ",
+        button: "画像を生成する",
         imageRedraw: "再生成",
         imageGenerating: "生成中...",
       };
@@ -90,7 +93,7 @@ export default function DreamDetailPage({
   } = useDream(dreamId);
 
   const { user } = useAuth();
-  const copy = getDreamDetailCopy(user?.age_group as AgeGroup | undefined);
+  const copy = getDreamDetailCopy(user?.age_group);
 
   const router = useRouter();
   const [isEditing, setIsEditing] = useState(false);
@@ -335,10 +338,10 @@ export default function DreamDetailPage({
               {isGeneratingImage ? (
                 <>
                   <span className="w-3 h-3 rounded-full border-2 border-primary-foreground/30 border-t-primary-foreground animate-spin" />
-                  ゆめのえを かいています...
+                  {copy.imageGenerating}
                 </>
               ) : (
-                <>🎨 ゆめのえを かく</>
+                <>🎨 {copy.button}</>
               )}
             </button>
             {imageError && (

--- a/frontend/app/dream/new/page.tsx
+++ b/frontend/app/dream/new/page.tsx
@@ -117,7 +117,7 @@ export default function NewDreamPage() {
     );
   }
 
-  const copy = getNewDreamCopy(user?.age_group as AgeGroup | undefined);
+  const copy = getNewDreamCopy(user?.age_group);
 
   return (
     <div className="min-h-screen py-8 px-4 md:px-12 max-w-3xl mx-auto">

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -212,7 +212,7 @@ export default function HomePage() {
   // 夢データを月ごとにグループ化
   const groupedDreams = groupDreamsByMonth(dreams);
 
-  const copy = getHomeCopy(user?.age_group as AgeGroup | undefined);
+  const copy = getHomeCopy(user?.age_group);
 
   const shouldDeferSearch =
     !loading &&

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -10,14 +10,15 @@ import React, {
 } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import apiClient from "@/lib/apiClient";
+import type { AgeGroup, AnalysisTone } from "@/app/types";
 
 interface User {
   id: string;
   email?: string;
   username?: string;
   premium?: boolean;
-  age_group?: string;
-  analysis_tone?: string;
+  age_group?: AgeGroup;
+  analysis_tone?: AnalysisTone;
 }
 
 type AuthStatus = "checking" | "authenticated" | "unauthenticated";


### PR DESCRIPTION
## Summary

- `AuthContext.tsx`: `age_group` / `analysis_tone` now typed as `AgeGroup` / `AnalysisTone` union types instead of `string`, removing the source of all downstream casts
- `dream/[id]/page.tsx`: added missing `button` field to all `getDreamDetailCopy` branches; initial-generate CTA now uses `copy.button` / `copy.imageGenerating` (age-group aware); removed `as AgeGroup | undefined` cast
- `dream/new/page.tsx`, `home/page.tsx`: removed `as AgeGroup | undefined` casts — no longer needed

## Why

Codex review flagged the repeated `as AgeGroup | undefined` casts as a type-safety smell. Root cause was `AuthContext` using `string` for `age_group`. Fixing the type at the source eliminates all casts downstream.

## Test plan

- [ ] TypeScript build passes (`yarn build` in frontend)
- [ ] Age-group microcopy renders correctly for each age group on home, new dream, and dream detail pages
- [ ] Image generation CTA shows correct label per age group

🤖 Generated with [Claude Code](https://claude.com/claude-code)