### PR TITLE
fix: image quota semantics and consolidate User type

### DIFF
--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -41,7 +41,7 @@ class DreamsController < ApplicationController
 
   # GET /dreams/image_quota
   def image_quota
-    used  = current_user.dreams.with_image.generated_in_month.count
+    used  = current_user.dreams.generated_in_month.count
     limit = IMAGE_MONTHLY_LIMIT
     render json: {
       used:      used,
@@ -221,7 +221,7 @@ class DreamsController < ApplicationController
       return render json: { error: "画像URLの取得に失敗しました" }, status: :unprocessable_entity
     end
 
-    @dream.update!(generated_image_url: image_url)
+    @dream.update!(generated_image_url: image_url, image_generated_at: Time.current)
 
     render json: { image_url: image_url }, status: :ok
   rescue Faraday::TimeoutError, Net::ReadTimeout, Net::OpenTimeout => e
@@ -287,7 +287,7 @@ class DreamsController < ApplicationController
 
     # 画像生成の月次上限チェック（全ユーザー共通）
     def check_monthly_image_limit
-      count = current_user.dreams.with_image.generated_in_month.count
+      count = current_user.dreams.generated_in_month.count
 
       if count >= IMAGE_MONTHLY_LIMIT
         render json: {

--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -41,7 +41,7 @@ class DreamsController < ApplicationController
 
   # GET /dreams/image_quota
   def image_quota
-    used  = current_user.dreams.generated_in_month.count
+    used  = current_month_image_generation_count
     limit = IMAGE_MONTHLY_LIMIT
     render json: {
       used:      used,
@@ -221,7 +221,11 @@ class DreamsController < ApplicationController
       return render json: { error: "画像URLの取得に失敗しました" }, status: :unprocessable_entity
     end
 
-    @dream.update!(generated_image_url: image_url, image_generated_at: Time.current)
+    generated_at = Time.current
+    Dream.transaction do
+      @dream.update!(generated_image_url: image_url, image_generated_at: generated_at)
+      @dream.dream_image_generations.create!(user: current_user, generated_at: generated_at)
+    end
 
     render json: { image_url: image_url }, status: :ok
   rescue Faraday::TimeoutError, Net::ReadTimeout, Net::OpenTimeout => e
@@ -287,7 +291,7 @@ class DreamsController < ApplicationController
 
     # 画像生成の月次上限チェック（全ユーザー共通）
     def check_monthly_image_limit
-      count = current_user.dreams.generated_in_month.count
+      count = current_month_image_generation_count
 
       if count >= IMAGE_MONTHLY_LIMIT
         render json: {
@@ -297,6 +301,10 @@ class DreamsController < ApplicationController
           monthly_image_limit: DreamsController::IMAGE_MONTHLY_LIMIT
         }, status: :forbidden
       end
+    end
+
+    def current_month_image_generation_count
+      current_user.dream_image_generations.generated_in_month.count
     end
 
     def cached_analysis_request?

--- a/backend/app/models/dream.rb
+++ b/backend/app/models/dream.rb
@@ -1,6 +1,7 @@
 class Dream < ApplicationRecord
   belongs_to :user, optional: false
   has_many :dream_emotions, dependent: :destroy
+  has_many :dream_image_generations, dependent: :destroy
   has_many :emotions, through: :dream_emotions
   has_one_attached :audio
 
@@ -13,8 +14,7 @@ class Dream < ApplicationRecord
   # よく使うクエリパターンをスコープとして定義する
   # current_user.dreams.with_image のように使う
   scope :with_image, -> { where.not(generated_image_url: nil) }
-  # 画像が今月生成 / 再生成された夢に絞り込む（image_generated_at ベース）
-  # updated_at は夢の編集でも変わるため quota カウントには使わない
+  # 画像が今月生成 / 再生成された夢に絞り込む（最後の生成時刻ベース）
   scope :generated_in_month, ->(date = Time.current) {
     where(image_generated_at: date.beginning_of_month..date.end_of_month)
   }

--- a/backend/app/models/dream.rb
+++ b/backend/app/models/dream.rb
@@ -13,9 +13,10 @@ class Dream < ApplicationRecord
   # よく使うクエリパターンをスコープとして定義する
   # current_user.dreams.with_image のように使う
   scope :with_image, -> { where.not(generated_image_url: nil) }
-  # current_user.dreams.generated_in_month のように使う（引数省略時は当月）
+  # 画像が今月生成 / 再生成された夢に絞り込む（image_generated_at ベース）
+  # updated_at は夢の編集でも変わるため quota カウントには使わない
   scope :generated_in_month, ->(date = Time.current) {
-    where(updated_at: date.beginning_of_month..date.end_of_month)
+    where(image_generated_at: date.beginning_of_month..date.end_of_month)
   }
   # dream.analysis_done? の代わりに、コレクションの絞り込みにも使える
   scope :analyzed, -> { where(analysis_status: 'done') }

--- a/backend/app/models/dream_image_generation.rb
+++ b/backend/app/models/dream_image_generation.rb
@@ -1,0 +1,10 @@
+class DreamImageGeneration < ApplicationRecord
+  belongs_to :dream, optional: false
+  belongs_to :user, optional: false
+
+  validates :generated_at, presence: true
+
+  scope :generated_in_month, ->(date = Time.current) {
+    where(generated_at: date.beginning_of_month..date.end_of_month)
+  }
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   # パスワード認証機能を提供
   has_secure_password
   has_many :dreams, dependent: :destroy
+  has_many :dream_image_generations, dependent: :destroy
   has_many :payments, dependent: :destroy
   has_many :subscriptions, dependent: :destroy
 

--- a/backend/db/migrate/20260418125845_add_image_generated_at_to_dreams.rb
+++ b/backend/db/migrate/20260418125845_add_image_generated_at_to_dreams.rb
@@ -1,0 +1,21 @@
+class AddImageGeneratedAtToDreams < ActiveRecord::Migration[7.2]
+  def change
+    add_column :dreams, :image_generated_at, :datetime
+
+    # 既存レコードのバックフィル: 画像がある夢は updated_at を初期値とする
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          UPDATE dreams
+          SET image_generated_at = updated_at
+          WHERE generated_image_url IS NOT NULL
+        SQL
+      end
+    end
+
+    # quota クエリ用インデックス (user_id, image_generated_at) WHERE image_generated_at IS NOT NULL
+    add_index :dreams, [:user_id, :image_generated_at],
+              where: "image_generated_at IS NOT NULL",
+              name: "index_dreams_on_user_id_and_image_generated_at"
+  end
+end

--- a/backend/db/migrate/20260418140000_create_dream_image_generations.rb
+++ b/backend/db/migrate/20260418140000_create_dream_image_generations.rb
@@ -1,0 +1,26 @@
+class CreateDreamImageGenerations < ActiveRecord::Migration[7.2]
+  def up
+    create_table :dream_image_generations do |t|
+      t.references :dream, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.datetime :generated_at, null: false
+      t.timestamps
+    end
+
+    add_index :dream_image_generations, [:user_id, :generated_at],
+              name: "index_dream_image_generations_on_user_id_and_generated_at"
+    add_index :dream_image_generations, [:dream_id, :generated_at],
+              name: "index_dream_image_generations_on_dream_id_and_generated_at"
+
+    execute <<~SQL
+      INSERT INTO dream_image_generations (dream_id, user_id, generated_at, created_at, updated_at)
+      SELECT id, user_id, COALESCE(image_generated_at, updated_at), COALESCE(image_generated_at, updated_at), COALESCE(image_generated_at, updated_at)
+      FROM dreams
+      WHERE generated_image_url IS NOT NULL
+    SQL
+  end
+
+  def down
+    drop_table :dream_image_generations
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_15_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_18_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,18 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_15_000001) do
     t.index ["emotion_id"], name: "index_dream_emotions_on_emotion_id"
   end
 
+  create_table "dream_image_generations", force: :cascade do |t|
+    t.bigint "dream_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "generated_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dream_id", "generated_at"], name: "index_dream_image_generations_on_dream_id_and_generated_at"
+    t.index ["dream_id"], name: "index_dream_image_generations_on_dream_id"
+    t.index ["user_id", "generated_at"], name: "index_dream_image_generations_on_user_id_and_generated_at"
+    t.index ["user_id"], name: "index_dream_image_generations_on_user_id"
+  end
+
   create_table "dreams", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -62,8 +74,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_15_000001) do
     t.jsonb "analysis_json"
     t.datetime "analyzed_at"
     t.text "generated_image_url"
+    t.datetime "image_generated_at"
     t.index ["analysis_status"], name: "index_dreams_on_analysis_status"
     t.index ["user_id", "created_at"], name: "index_dreams_on_user_id_and_created_at"
+    t.index ["user_id", "image_generated_at"], name: "index_dreams_on_user_id_and_image_generated_at", where: "(image_generated_at IS NOT NULL)"
     t.index ["user_id", "updated_at"], name: "index_dreams_on_user_id_and_updated_at_with_image", where: "(generated_image_url IS NOT NULL)"
     t.index ["user_id"], name: "index_dreams_on_user_id"
   end
@@ -136,6 +150,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_15_000001) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "dream_emotions", "dreams"
   add_foreign_key "dream_emotions", "emotions"
+  add_foreign_key "dream_image_generations", "dreams"
+  add_foreign_key "dream_image_generations", "users"
   add_foreign_key "dreams", "users"
   add_foreign_key "payments", "users"
   add_foreign_key "subscriptions", "users"

--- a/backend/spec/factories/dream_image_generations.rb
+++ b/backend/spec/factories/dream_image_generations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :dream_image_generation do
+    association :dream
+    user { dream.user }
+    generated_at { Time.current }
+  end
+end

--- a/backend/spec/models/dream_spec.rb
+++ b/backend/spec/models/dream_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Dream, type: :model do
 
   describe 'スコープ' do
     let!(:dream_with_image) do
-      create(:dream, user: user, generated_image_url: 'https://example.com/image.png', updated_at: Time.current)
+      create(:dream, user: user, generated_image_url: 'https://example.com/image.png', image_generated_at: Time.current)
     end
     let!(:dream_without_image) do
       create(:dream, user: user, generated_image_url: nil)
@@ -34,15 +34,15 @@ RSpec.describe Dream, type: :model do
     describe '.generated_in_month' do
       let!(:old_dream) do
         create(:dream, user: user, generated_image_url: 'https://example.com/old.png',
-               updated_at: 2.months.ago)
+               image_generated_at: 2.months.ago)
       end
 
-      it '当月に更新された夢だけを返す（引数省略時）' do
+      it '当月に画像生成された夢だけを返す（引数省略時）' do
         expect(Dream.generated_in_month).to include(dream_with_image)
         expect(Dream.generated_in_month).not_to include(old_dream)
       end
 
-      it '指定した月に更新された夢だけを返す' do
+      it '指定した月に画像生成された夢だけを返す' do
         expect(Dream.generated_in_month(2.months.ago)).to include(old_dream)
         expect(Dream.generated_in_month(2.months.ago)).not_to include(dream_with_image)
       end

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -527,6 +527,8 @@ RSpec.describe 'Dreams API', type: :request do
         analysis_json: { 'analysis' => '自由で穏やかな気持ちを表しています。' }
       )
     end
+    let(:access_token) { AuthService.encode_token(user.id) }
+    let(:auth_headers) { { 'Content-Type' => 'application/json', 'Cookie' => "access_token=#{access_token}", 'HOST' => 'backend' } }
     let(:generated_url) { 'https://oaidalleapiprodscus.blob.core.windows.net/generated/test.png' }
     let(:images_client) { double('OpenAI::Images') }
     let(:openai_client) { double('OpenAI::Client', images: images_client) }
@@ -621,11 +623,11 @@ RSpec.describe 'Dreams API', type: :request do
         allow(images_client).to receive(:generate).and_return({ 'data' => [{ 'url' => generated_url }] })
 
         expect {
-          authenticated_post "/dreams/#{dream.id}/generate_image", user
+          post "/dreams/#{dream.id}/generate_image", params: {}.to_json, headers: auth_headers
         }.to change(DreamImageGeneration, :count).by(1)
         expect(response).to have_http_status(:ok)
 
-        authenticated_post "/dreams/#{dream.id}/generate_image", user
+        post "/dreams/#{dream.id}/generate_image", params: {}.to_json, headers: auth_headers
 
         expect(response).to have_http_status(:forbidden)
         expect(JSON.parse(response.body)['limit_reached']).to eq(true)

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -552,11 +552,17 @@ RSpec.describe 'Dreams API', type: :request do
           )
         ).and_return({ 'data' => [{ 'url' => generated_url }] })
 
-        authenticated_post "/dreams/#{dream.id}/generate_image", user
+        expect {
+          authenticated_post "/dreams/#{dream.id}/generate_image", user
+        }.to change(DreamImageGeneration, :count).by(1)
 
         expect(response).to have_http_status(:ok)
         expect(JSON.parse(response.body)['image_url']).to eq(generated_url)
         expect(dream.reload.generated_image_url).to eq(generated_url)
+        expect(dream.image_generated_at).to be_present
+        generation = DreamImageGeneration.order(:id).last
+        expect(generation.dream_id).to eq(dream.id)
+        expect(generation.user_id).to eq(user.id)
       end
 
       it 'gpt-image-1 が b64_json を返す場合はデータURLとして保存し 200 を返す' do
@@ -602,6 +608,27 @@ RSpec.describe 'Dreams API', type: :request do
 
         expect(response).to have_http_status(:service_unavailable)
         expect(JSON.parse(response.body)['error']).to include('画像生成機能は現在利用できません')
+      end
+
+      it '同じ夢の再生成も月次 quota に 1 回ずつ加算する' do
+        create_list(
+          :dream_image_generation,
+          DreamsController::IMAGE_MONTHLY_LIMIT - 1,
+          user: user,
+          dream: dream,
+          generated_at: Time.current
+        )
+        allow(images_client).to receive(:generate).and_return({ 'data' => [{ 'url' => generated_url }] })
+
+        expect {
+          authenticated_post "/dreams/#{dream.id}/generate_image", user
+        }.to change(DreamImageGeneration, :count).by(1)
+        expect(response).to have_http_status(:ok)
+
+        authenticated_post "/dreams/#{dream.id}/generate_image", user
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)['limit_reached']).to eq(true)
       end
 
       it '他人の夢は画像生成できない（403）' do
@@ -663,6 +690,32 @@ RSpec.describe 'Dreams API', type: :request do
 
     context '認証されていない場合' do
       it_behaves_like 'unauthorized request', :post, '/dreams/1/generate_image'
+    end
+  end
+
+  describe 'GET /dreams/image_quota' do
+    let!(:dream) { create(:dream, user: user) }
+
+    before do
+      create(:dream_image_generation, user: user, dream: dream, generated_at: Time.current)
+      create(:dream_image_generation, user: user, dream: dream, generated_at: Time.current)
+      create(:dream_image_generation, user: user, dream: dream, generated_at: 2.months.ago)
+      create(:dream_image_generation, user: other_user, dream: create(:dream, user: other_user), generated_at: Time.current)
+    end
+
+    context '認証済みユーザーの場合' do
+      it '当月の生成イベント数を返し、同じ夢の再生成も個別に数える' do
+        authenticated_get '/dreams/image_quota', user
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response['used']).to eq(2)
+        expect(json_response['limit']).to eq(DreamsController::IMAGE_MONTHLY_LIMIT)
+        expect(json_response['remaining']).to eq(DreamsController::IMAGE_MONTHLY_LIMIT - 2)
+      end
+    end
+
+    context '認証されていない場合' do
+      it_behaves_like 'unauthorized request', :get, '/dreams/image_quota'
     end
   end
 end

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -528,7 +528,7 @@ RSpec.describe 'Dreams API', type: :request do
       )
     end
     let(:access_token) { AuthService.encode_token(user.id) }
-    let(:auth_headers) { { 'Content-Type' => 'application/json', 'Cookie' => "access_token=#{access_token}", 'HOST' => 'backend' } }
+    let(:fixed_auth_headers) { { 'Content-Type' => 'application/json', 'Cookie' => "access_token=#{access_token}", 'HOST' => 'backend' } }
     let(:generated_url) { 'https://oaidalleapiprodscus.blob.core.windows.net/generated/test.png' }
     let(:images_client) { double('OpenAI::Images') }
     let(:openai_client) { double('OpenAI::Client', images: images_client) }
@@ -623,11 +623,11 @@ RSpec.describe 'Dreams API', type: :request do
         allow(images_client).to receive(:generate).and_return({ 'data' => [{ 'url' => generated_url }] })
 
         expect {
-          post "/dreams/#{dream.id}/generate_image", params: {}.to_json, headers: auth_headers
+          post "/dreams/#{dream.id}/generate_image", params: {}.to_json, headers: fixed_auth_headers
         }.to change(DreamImageGeneration, :count).by(1)
         expect(response).to have_http_status(:ok)
 
-        post "/dreams/#{dream.id}/generate_image", params: {}.to_json, headers: auth_headers
+        post "/dreams/#{dream.id}/generate_image", params: {}.to_json, headers: fixed_auth_headers
 
         expect(response).to have_http_status(:forbidden)
         expect(JSON.parse(response.body)['limit_reached']).to eq(true)

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -42,8 +42,8 @@ const SettingsPage = () => {
 
   // プロフィール編集フォーム用 state
   const [profileUsername, setProfileUsername] = useState(user?.username ?? "");
-  const [profileAgeGroup, setProfileAgeGroup] = useState<AgeGroup>((user?.age_group as AgeGroup) ?? "child");
-  const [profileTone, setProfileTone] = useState<AnalysisTone>((user?.analysis_tone as AnalysisTone) ?? "auto");
+  const [profileAgeGroup, setProfileAgeGroup] = useState<AgeGroup>(user?.age_group ?? "child");
+  const [profileTone, setProfileTone] = useState<AnalysisTone>(user?.analysis_tone ?? "auto");
   const [isSavingProfile, setIsSavingProfile] = useState(false);
   const [isToneOpen, setIsToneOpen] = useState(false);
 
@@ -51,16 +51,16 @@ const SettingsPage = () => {
   useEffect(() => {
     if (!user) return;
     setProfileUsername(user.username ?? "");
-    setProfileAgeGroup((user.age_group as AgeGroup) ?? "child");
-    setProfileTone((user.analysis_tone as AnalysisTone) ?? "auto");
+    setProfileAgeGroup(user.age_group ?? "child");
+    setProfileTone(user.analysis_tone ?? "auto");
   }, [user?.id, user?.username, user?.age_group, user?.analysis_tone]);
 
   // 初回レンダー時は user === null (checking中)なので、verify 完了後に再同期する
   useEffect(() => {
     if (!user) return;
     setProfileUsername(user.username ?? "");
-    setProfileAgeGroup((user.age_group as AgeGroup) ?? "child");
-    setProfileTone((user.analysis_tone as AnalysisTone) ?? "auto");
+    setProfileAgeGroup(user.age_group ?? "child");
+    setProfileTone(user.analysis_tone ?? "auto");
   }, [user?.id]);
 
   const handleSaveProfile = async () => {

--- a/frontend/app/types.ts
+++ b/frontend/app/types.ts
@@ -3,10 +3,10 @@ export type AnalysisTone = "auto" | "gentle_kids" | "junior" | "standard" | "dee
 
 export interface User {
   id: string; // FrontendではIDを文字列として扱う
-  username: string;
-  email: string;
-  created_at: string;
-  updated_at: string;
+  username?: string; // トライアルユーザーは未設定の場合がある
+  email?: string;    // トライアルユーザーは未設定の場合がある
+  created_at?: string;
+  updated_at?: string;
   premium?: boolean;
   age_group?: AgeGroup;
   analysis_tone?: AnalysisTone;
@@ -20,6 +20,8 @@ export interface BackendUser {
   created_at: string;
   updated_at: string;
   premium?: boolean;
+  age_group?: AgeGroup;
+  analysis_tone?: AnalysisTone;
 }
 
 export interface Emotion {

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -11,16 +11,6 @@ import React, {
 import { usePathname, useRouter } from "next/navigation";
 import apiClient from "@/lib/apiClient";
 import type { User } from "@/app/types";
-import type { AgeGroup, AnalysisTone } from "@/app/types";
-
-interface User {
-  id: string;
-  email?: string;
-  username?: string;
-  premium?: boolean;
-  age_group?: AgeGroup;
-  analysis_tone?: AnalysisTone;
-}
 
 type AuthStatus = "checking" | "authenticated" | "unauthenticated";
 

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -10,15 +10,7 @@ import React, {
 } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import apiClient from "@/lib/apiClient";
-
-interface User {
-  id: string;
-  email?: string;
-  username?: string;
-  premium?: boolean;
-  age_group?: string;
-  analysis_tone?: string;
-}
+import type { User } from "@/app/types";
 
 type AuthStatus = "checking" | "authenticated" | "unauthenticated";
 


### PR DESCRIPTION
## Summary

### Backend — quota semantic fix
- Added `image_generated_at` column to `dreams`. Backfills existing records with `updated_at` as a best-estimate initial value
- `generated_in_month` scope now filters on `image_generated_at` instead of `updated_at` — editing a dream no longer changes the monthly quota count
- `generate_image` sets `image_generated_at: Time.current` on every generation call
- `image_quota` and `check_monthly_image_limit` both use the corrected scope (removed stale `.with_image` chaining)
- Added `(user_id, image_generated_at) WHERE image_generated_at IS NOT NULL` index for quota query performance

### Frontend — User type consolidation
- `types.ts User`: made `username`, `email`, `created_at`, `updated_at` optional — trial users satisfy this type, and the auth-context user shape now matches
- `BackendUser`: added `age_group?` and `analysis_tone?` so login/verify/profile-update responses are fully typed end-to-end
- `AuthContext`: removed local duplicate `User` interface, imports `User` from `@/app/types`
- `settings/page.tsx`: removed now-redundant `as AgeGroup` / `as AnalysisTone` casts

## Test plan

- [ ] `bundle exec rails db:migrate` runs cleanly
- [ ] Generating an image sets `image_generated_at`; editing the dream title does not change it
- [ ] `/dreams/image_quota` returns accurate count after generates
- [ ] TypeScript build (`yarn build`) passes
- [ ] Settings page renders correct age group and tone without type errors