### PR TITLE
feat: subscription feature gating — free plan limits, webhook tests, session verification

### DIFF
--- a/backend/app/controllers/audio_dreams_controller.rb
+++ b/backend/app/controllers/audio_dreams_controller.rb
@@ -52,6 +52,7 @@ class AudioDreamsController < ApplicationController
   # 音声分析は Whisper + GPT で二重課金されるため厳しめに制限
   def check_trial_audio_limit
     user = current_user
+    return if user&.premium?
     return unless user&.trial_user?
 
     if user.trial_audio_count >= TRIAL_AUDIO_LIMIT

--- a/backend/app/controllers/checkout_controller.rb
+++ b/backend/app/controllers/checkout_controller.rb
@@ -61,6 +61,39 @@ class CheckoutController < ApplicationController
     end
   end
 
+  def show_session
+    session_id = params[:session_id].to_s
+    return render json: { error: 'session_id が必要です。' }, status: :bad_request if session_id.blank?
+
+    session = Stripe::Checkout::Session.retrieve(session_id)
+    return render json: { error: 'プレミアム決済のセッションではありません。' }, status: :unprocessable_content unless session.mode == 'subscription'
+
+    session_user_id = extract_session_user_id(session)
+    if session_user_id != current_user.id.to_s
+      return render json: { error: 'この決済セッションへのアクセス権限がありません。' }, status: :forbidden
+    end
+
+    unless session.status == 'complete'
+      return render json: { error: '決済がまだ完了していません。' }, status: :unprocessable_content
+    end
+
+    render json: {
+      verified: true,
+      session_id: session.id,
+      status: session.status,
+      payment_status: session.payment_status,
+      premium: current_user.premium?
+    }, status: :ok
+  rescue Stripe::InvalidRequestError => e
+    PaymentsObservability.increment('checkout.session_lookup.invalid', user_id: current_user.id)
+    PaymentsObservability.log(event: 'checkout.session_lookup.invalid', level: :warn, user_id: current_user.id, stripe_session_id: session_id, message: e.message)
+    render json: { error: '決済セッションが見つかりません。' }, status: :not_found
+  rescue Stripe::StripeError => e
+    PaymentsObservability.increment('checkout.session_lookup.error', user_id: current_user.id)
+    PaymentsObservability.log(event: 'checkout.session_lookup.error', level: :error, user_id: current_user.id, stripe_session_id: session_id, message: e.message)
+    render json: { error: '決済確認に失敗しました。' }, status: :bad_gateway
+  end
+
   private
 
   def requested_plan
@@ -158,5 +191,16 @@ class CheckoutController < ApplicationController
     PaymentsObservability.increment('checkout.customer.created', user_id: current_user.id)
     PaymentsObservability.log(event: 'checkout.customer.created', user_id: current_user.id, stripe_customer_id: customer.id)
     customer.id
+  end
+
+  def extract_session_user_id(session)
+    metadata_user_id =
+      if session.respond_to?(:metadata)
+        session.metadata.respond_to?(:[]) ? session.metadata['user_id'] : nil
+      end
+
+    client_reference_id = session.respond_to?(:client_reference_id) ? session.client_reference_id : nil
+
+    metadata_user_id.presence || client_reference_id
   end
 end

--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -1,10 +1,11 @@
 class DreamsController < ApplicationController
   before_action :set_dream_and_authorize_user, only: [:show, :update, :destroy, :analyze, :analysis, :generate_image]
-  before_action :check_trial_analysis_limit, only: [:analyze, :preview_analysis]
+  before_action :check_analysis_limit, only: [:analyze, :preview_analysis]
   before_action :check_monthly_image_limit, only: [:generate_image]
 
   TRIAL_ANALYSIS_LIMIT = 3   # トライアルユーザーの分析回数上限
   IMAGE_MONTHLY_LIMIT   = 30 # 全ユーザー共通の画像生成月次上限
+  FREE_ANALYSIS_MONTHLY_LIMIT = User::FREE_ANALYSIS_MONTHLY_LIMIT
   
 
   # GET /dreams
@@ -166,7 +167,7 @@ class DreamsController < ApplicationController
       analysis_json: nil
     )
 
-    current_user.increment!(:trial_analysis_count) if current_user.trial_user?
+    increment_analysis_usage!
 
     # 3. 非同期ジョブをエンキュー
     AnalyzeDreamJob.perform_later(@dream.id)
@@ -256,7 +257,7 @@ class DreamsController < ApplicationController
     if result[:error]
       render json: { error: result[:error] }, status: :unprocessable_content
     else
-      current_user.increment!(:trial_analysis_count) if current_user.trial_user?
+      increment_analysis_usage!
       render json: result
     end
   end
@@ -276,16 +277,38 @@ class DreamsController < ApplicationController
       )
     end
 
-    # トライアルユーザーの分析回数チェック
-    def check_trial_analysis_limit
-      return unless current_user.trial_user?
+    def check_analysis_limit
+      return if current_user.premium?
       return if action_name == "analyze" && cached_analysis_request?
 
-      if current_user.trial_analysis_count >= TRIAL_ANALYSIS_LIMIT
+      if current_user.trial_user?
+        return unless current_user.trial_analysis_count >= TRIAL_ANALYSIS_LIMIT
+
         render json: {
           error: "トライアルユーザーの分析上限（#{TRIAL_ANALYSIS_LIMIT}回）に達しました。アカウント登録すると無制限に分析できます。",
           limit_reached: true
         }, status: :forbidden
+        return
+      end
+
+      current_user.reset_monthly_analysis_count_if_needed!
+      return unless current_user.monthly_analysis_count >= FREE_ANALYSIS_MONTHLY_LIMIT
+
+      render json: {
+        error: "無料プランのAI分析上限（#{FREE_ANALYSIS_MONTHLY_LIMIT}回/月）に達しました。プレミアム会員になると無制限で利用できます。",
+        limit_reached: true,
+        monthly_analysis_count: current_user.monthly_analysis_count,
+        monthly_analysis_limit: FREE_ANALYSIS_MONTHLY_LIMIT
+      }, status: :forbidden
+    end
+
+    def increment_analysis_usage!
+      return if current_user.premium?
+
+      if current_user.trial_user?
+        current_user.increment!(:trial_analysis_count)
+      else
+        current_user.increment_monthly_analysis_count!
       end
     end
 

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  FREE_ANALYSIS_MONTHLY_LIMIT = 10
+
   # パスワード認証機能を提供
   has_secure_password
   has_many :dreams, dependent: :destroy
@@ -61,5 +63,20 @@ class User < ApplicationRecord
 
   def premium_active_subscription?
     subscriptions.where(status: Subscription::ACTIVE_STATUSES).exists?
+  end
+
+  def reset_monthly_analysis_count_if_needed!(now = Time.current)
+    current_month = now.beginning_of_month
+    return if monthly_analysis_count_reset_at.present? && monthly_analysis_count_reset_at >= current_month
+
+    update!(
+      monthly_analysis_count: 0,
+      monthly_analysis_count_reset_at: current_month
+    )
+  end
+
+  def increment_monthly_analysis_count!(now = Time.current)
+    reset_monthly_analysis_count_if_needed!(now)
+    increment!(:monthly_analysis_count)
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
 
   # Stripe決済関連
   post '/checkout', to: 'checkout#create'
+  get '/checkout/session', to: 'checkout#show_session'
   post '/billing_portal', to: 'billing_portal#create'
   post '/webhooks/stripe', to: 'webhooks#stripe'  # Webhook（署名検証は次回実装）
 

--- a/backend/db/migrate/20260419000000_add_monthly_analysis_usage_to_users.rb
+++ b/backend/db/migrate/20260419000000_add_monthly_analysis_usage_to_users.rb
@@ -1,0 +1,6 @@
+class AddMonthlyAnalysisUsageToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :monthly_analysis_count, :integer, null: false, default: 0
+    add_column :users, :monthly_analysis_count_reset_at, :datetime
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_18_140000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_19_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -138,6 +138,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_18_140000) do
     t.string "stripe_customer_id"
     t.integer "trial_analysis_count", default: 0, null: false
     t.integer "trial_audio_count", default: 0, null: false
+    t.integer "monthly_analysis_count", default: 0, null: false
+    t.datetime "monthly_analysis_count_reset_at"
     t.boolean "premium", default: false, null: false
     t.string "age_group", default: "child", null: false
     t.string "analysis_tone", default: "auto", null: false

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -1,6 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  describe '#reset_monthly_analysis_count_if_needed!' do
+    it 'resets the count when the tracked month is stale' do
+      user = create(
+        :user,
+        monthly_analysis_count: 7,
+        monthly_analysis_count_reset_at: 2.months.ago
+      )
+
+      user.reset_monthly_analysis_count_if_needed!(Time.zone.parse('2026-04-15 10:00:00'))
+
+      expect(user.reload.monthly_analysis_count).to eq(0)
+      expect(user.monthly_analysis_count_reset_at).to eq(Time.zone.parse('2026-04-01 00:00:00'))
+    end
+
+    it 'keeps the count when already in the current month' do
+      current_month = Time.zone.parse('2026-04-01 00:00:00')
+      user = create(
+        :user,
+        monthly_analysis_count: 4,
+        monthly_analysis_count_reset_at: current_month
+      )
+
+      user.reset_monthly_analysis_count_if_needed!(Time.zone.parse('2026-04-15 10:00:00'))
+
+      expect(user.reload.monthly_analysis_count).to eq(4)
+      expect(user.monthly_analysis_count_reset_at).to eq(current_month)
+    end
+  end
+
   describe '#premium_active_subscription?' do
     it 'returns true when the user has an active subscription' do
       user = create(:user)

--- a/backend/spec/requests/checkout_spec.rb
+++ b/backend/spec/requests/checkout_spec.rb
@@ -200,4 +200,62 @@ RSpec.describe 'Checkout API', type: :request do
       end
     end
   end
+
+  describe 'GET /checkout/session' do
+    it_behaves_like 'unauthorized request', :get, '/checkout/session'
+
+    it 'session_id が無い場合は 400 を返す' do
+      user = create(:user)
+
+      authenticated_get('/checkout/session', user)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(JSON.parse(response.body)['error']).to include('session_id')
+    end
+
+    it 'session_id を検証して成功レスポンスを返す' do
+      user = create(:user)
+      metadata = { 'user_id' => user.id.to_s }
+      stripe_session = double(
+        'StripeCheckoutSession',
+        id: 'cs_sub_verified_123',
+        mode: 'subscription',
+        status: 'complete',
+        payment_status: 'paid',
+        metadata: metadata,
+        client_reference_id: user.id.to_s
+      )
+
+      expect(Stripe::Checkout::Session).to receive(:retrieve).with('cs_sub_verified_123').and_return(stripe_session)
+
+      authenticated_get('/checkout/session', user, params: { session_id: 'cs_sub_verified_123' })
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to include(
+        'verified' => true,
+        'session_id' => 'cs_sub_verified_123',
+        'status' => 'complete',
+        'payment_status' => 'paid'
+      )
+    end
+
+    it '別ユーザーの session_id は 403 を返す' do
+      user = create(:user)
+      stripe_session = double(
+        'StripeCheckoutSession',
+        id: 'cs_sub_other_user',
+        mode: 'subscription',
+        status: 'complete',
+        payment_status: 'paid',
+        metadata: { 'user_id' => '999999' },
+        client_reference_id: '999999'
+      )
+
+      expect(Stripe::Checkout::Session).to receive(:retrieve).with('cs_sub_other_user').and_return(stripe_session)
+
+      authenticated_get('/checkout/session', user, params: { session_id: 'cs_sub_other_user' })
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
 end

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -446,6 +446,29 @@ RSpec.describe 'Dreams API', type: :request do
         expect(json_response['cached']).to be true
         expect(json_response['result']['analysis']).to eq('cached result')
       end
+
+      it '無料プランの月次上限に達している場合は403を返し、ジョブを積まない' do
+        user.update!(
+          monthly_analysis_count: User::FREE_ANALYSIS_MONTHLY_LIMIT,
+          monthly_analysis_count_reset_at: Time.current.beginning_of_month
+        )
+
+        assert_no_enqueued_jobs do
+          authenticated_post "/dreams/#{dream.id}/analyze", user
+        end
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json_response['limit_reached']).to eq(true)
+        expect(json_response['monthly_analysis_limit']).to eq(User::FREE_ANALYSIS_MONTHLY_LIMIT)
+      end
+
+      it '無料プランでは分析受付時に月次カウントを増やす' do
+        expect do
+          authenticated_post "/dreams/#{dream.id}/analyze", user
+        end.to change { user.reload.monthly_analysis_count }.by(1)
+
+        expect(response).to have_http_status(:accepted)
+      end
     end
 
     context '認証されていない場合' do
@@ -462,6 +485,29 @@ RSpec.describe 'Dreams API', type: :request do
         authenticated_post '/dreams/preview_analysis', user, params: { content: '空を飛ぶ夢' }
 
         expect(response).to have_http_status(:forbidden)
+      end
+
+      it '無料プランの月次上限に達している場合は403を返す' do
+        user.update!(
+          monthly_analysis_count: User::FREE_ANALYSIS_MONTHLY_LIMIT,
+          monthly_analysis_count_reset_at: Time.current.beginning_of_month
+        )
+
+        expect(DreamAnalysisService).not_to receive(:analyze)
+        authenticated_post '/dreams/preview_analysis', user, params: { content: '空を飛ぶ夢' }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json_response['limit_reached']).to eq(true)
+      end
+
+      it '無料プランでは成功時に月次カウントを増やす' do
+        allow(DreamAnalysisService).to receive(:analyze).and_return({ analysis: 'result', emotion_tags: ['happy'] })
+
+        expect do
+          authenticated_post '/dreams/preview_analysis', user, params: { content: '空を飛ぶ夢' }
+        end.to change { user.reload.monthly_analysis_count }.by(1)
+
+        expect(response).to have_http_status(:ok)
       end
     end
 

--- a/backend/spec/requests/webhooks_spec.rb
+++ b/backend/spec/requests/webhooks_spec.rb
@@ -325,6 +325,28 @@ RSpec.describe 'Webhooks API', type: :request do
           expect(subscription.current_period_end.to_i).to eq(period_end)
           expect(user.reload.premium).to be true
         end
+
+        it 'subscription が未作成でも customer から user を解決して作成する' do
+          user = create(:user, stripe_customer_id: 'cus_test_123', premium: false)
+          allow(Stripe::Webhook).to receive(:construct_event).and_return(invoice_event)
+
+          expect do
+            post '/webhooks/stripe',
+              params: payload,
+              headers: {
+                'Content-Type' => 'application/json',
+                'Stripe-Signature' => sig_header,
+                'HOST' => 'backend'
+              }
+          end.to change(Subscription, :count).by(1)
+
+          subscription = Subscription.find_by!(stripe_subscription_id: 'sub_test_renewal')
+          expect(response).to have_http_status(:ok)
+          expect(subscription.user_id).to eq(user.id)
+          expect(subscription.status).to eq('active')
+          expect(subscription.current_period_end.to_i).to eq(period_end)
+          expect(user.reload.premium).to be true
+        end
       end
 
       context 'customer.subscription.deleted の場合' do
@@ -370,6 +392,37 @@ RSpec.describe 'Webhooks API', type: :request do
           expect(response).to have_http_status(:ok)
           expect(subscription.reload.status).to eq('canceled')
           expect(user.reload.premium).to be false
+        end
+
+        it '他に有効な subscription が残っている場合は premium を維持する' do
+          user = create(:user, premium: true)
+          canceled_subscription = create(
+            :subscription,
+            user: user,
+            stripe_subscription_id: 'sub_test_cancelled',
+            stripe_customer_id: 'cus_cancel_123',
+            status: 'active'
+          )
+          create(
+            :subscription,
+            user: user,
+            stripe_subscription_id: 'sub_test_still_active',
+            stripe_customer_id: 'cus_cancel_123',
+            status: 'active'
+          )
+          allow(Stripe::Webhook).to receive(:construct_event).and_return(subscription_deleted_event)
+
+          post '/webhooks/stripe',
+            params: payload,
+            headers: {
+              'Content-Type' => 'application/json',
+              'Stripe-Signature' => sig_header,
+              'HOST' => 'backend'
+            }
+
+          expect(response).to have_http_status(:ok)
+          expect(canceled_subscription.reload.status).to eq('canceled')
+          expect(user.reload.premium).to be true
         end
       end
 

--- a/frontend/app/subscription/success/page.tsx
+++ b/frontend/app/subscription/success/page.tsx
@@ -1,6 +1,63 @@
 import Link from "next/link";
+import { redirect } from "next/navigation";
+import { ApiError, apiFetch } from "@/lib/apiClient";
+import { getServerAuth } from "@/lib/server-auth";
 
-export default function SubscriptionSuccessPage() {
+type PageProps = {
+  searchParams: Promise<{ session_id?: string }>;
+};
+
+function renderErrorState(message: string) {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <main className="container mx-auto max-w-2xl px-4 py-16">
+        <section className="rounded-2xl border border-border/60 bg-card/70 p-8 text-center shadow-sm backdrop-blur-sm">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">
+            決済を確認できませんでした
+          </h1>
+          <p className="mt-4 text-base text-muted-foreground">
+            {message}
+          </p>
+          <Link
+            href="/subscription"
+            className="mt-8 inline-flex min-h-11 items-center justify-center rounded-lg border border-border px-6 py-3 text-sm font-semibold text-foreground transition-colors hover:bg-muted"
+          >
+            プランページへ戻る
+          </Link>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default async function SubscriptionSuccessPage({
+  searchParams,
+}: PageProps) {
+  const params = await searchParams;
+  const sessionId = params.session_id;
+  const { isAuthenticated, token } = await getServerAuth();
+
+  if (!isAuthenticated || !token) {
+    redirect("/login");
+  }
+
+  if (!sessionId) {
+    return renderErrorState("Stripe の session_id が見つかりませんでした。");
+  }
+
+  try {
+    await apiFetch<{ verified: boolean }>(
+      `/checkout/session?session_id=${encodeURIComponent(sessionId)}`,
+      { token }
+    );
+  } catch (error) {
+    const message =
+      error instanceof ApiError
+        ? error.message
+        : "決済確認中にエラーが発生しました。時間をおいて再度ご確認ください。";
+    return renderErrorState(message);
+  }
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <main className="container mx-auto max-w-2xl px-4 py-16">
@@ -9,7 +66,7 @@ export default function SubscriptionSuccessPage() {
             プレミアム会員になりました！✨
           </h1>
           <p className="mt-4 text-base text-muted-foreground">
-            月額課金が開始されました。すべての機能をお楽しみください
+            Stripe の決済を確認しました。プレミアム反映まで数秒かかる場合があります。
           </p>
           <Link
             href="/home"


### PR DESCRIPTION
## Summary

- **無料プランの AI 分析上限（月10回）を実装**: プレミアムユーザーは無制限、trial ユーザーは従来の3回制限を維持。月初に自動リセット
- **Stripe 成功ページの検証強化**: `GET /checkout/session` エンドポイントを追加し、`/subscription/success` を Server Component 化。`session_id` なし・別ユーザー・未完了決済はエラー画面へフォールバック
- **Webhook テスト補完**: `invoice.payment_succeeded` の新規 Subscription 作成経路、`customer.subscription.deleted` で他に有効 Subscription がある場合の premium 維持を追加

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `backend/db/migrate/20260419000000_add_monthly_analysis_usage_to_users.rb` | `monthly_analysis_count` / `monthly_analysis_count_reset_at` カラム追加 |
| `backend/app/models/user.rb` | `FREE_ANALYSIS_MONTHLY_LIMIT = 10`、月次カウンタのリセット・インクリメントメソッド |
| `backend/app/controllers/dreams_controller.rb` | `check_analysis_limit` に統合（trial/free/premium の3段階判定） |
| `backend/app/controllers/audio_dreams_controller.rb` | premium ユーザーの trial 音声制限バイパス |
| `backend/app/controllers/checkout_controller.rb` | `GET /checkout/session` — セッション所有者・モード・完了状態を検証 |
| `backend/config/routes.rb` | `GET /checkout/session` ルート追加 |
| `frontend/app/subscription/success/page.tsx` | Server Component 化、Stripe session 検証後に成功表示 |
| `backend/spec/` (4ファイル) | 103 examples, 0 failures |

## Test plan

- [ ] `bundle exec rails db:migrate` を本番 DB で実行
- [ ] 無料ユーザーで AI 分析を 10 回 → 11 回目が 403 になることを確認
- [ ] プレミアムユーザーで 11 回目以降も通ることを確認
- [ ] `/subscription/success` を `session_id` なしで直アクセス → エラー画面
- [ ] Stripe テスト決済を完了 → `/subscription/success?session_id=cs_xxx` で正常表示