### PR TITLE
fix: remove /api rewrite fallback that caused login 404

### DIFF
--- a/frontend/__tests__/lib/api-config.test.ts
+++ b/frontend/__tests__/lib/api-config.test.ts
@@ -1,0 +1,33 @@
+import { createApiUrl, getApiUrl } from "../../lib/api-config";
+
+describe("api-config", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.NEXT_PUBLIC_API_URL;
+    delete process.env.NEXT_PUBLIC_VERCEL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("uses configured public API URL on the client", () => {
+    process.env.NEXT_PUBLIC_API_URL = "https://api.example.com/api/v1/";
+
+    expect(getApiUrl()).toBe("https://api.example.com");
+    expect(createApiUrl("/auth/login")).toBe(
+      "https://api.example.com/auth/login"
+    );
+  });
+
+  it("uses the Render production URL as fallback when NEXT_PUBLIC_API_URL is unset", () => {
+    process.env.NODE_ENV = "production";
+
+    expect(createApiUrl("/auth/login")).toBe(
+      "https://dreamjournal-app.onrender.com/auth/login"
+    );
+  });
+});

--- a/frontend/__tests__/lib/api-config.test.ts
+++ b/frontend/__tests__/lib/api-config.test.ts
@@ -30,4 +30,11 @@ describe("api-config", () => {
       "https://dreamjournal-app.onrender.com/auth/login"
     );
   });
+
+  it("returns empty string for Vercel preview to avoid silently hitting production backend", () => {
+    process.env.NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_VERCEL_ENV = "preview";
+
+    expect(getApiUrl()).toBe("");
+  });
 });

--- a/frontend/lib/api-config.ts
+++ b/frontend/lib/api-config.ts
@@ -12,7 +12,7 @@ export function getApiUrl(): string {
   const API_PREFIX_PATTERN = /\/api\/v1\/?$/;
 
   function normalizeBaseUrl(url: string): string {
-    return url.replace(API_PREFIX_PATTERN, "");
+    return url.replace(API_PREFIX_PATTERN, "").replace(/\/+$/, "");
   }
 
   // Check if we're running on the server side
@@ -29,16 +29,10 @@ export function getApiUrl(): string {
       return normalizeBaseUrl(process.env.NEXT_PUBLIC_API_URL);
     }
 
-    // Fallback logic for when NEXT_PUBLIC_API_URL is not set
-    const isVercel =
-      process.env.NEXT_PUBLIC_VERCEL === "1" ||
-      (typeof window !== "undefined" &&
-        window.location.hostname.includes("vercel.app"));
-
-    if (process.env.NODE_ENV === "production" && isVercel) {
-      // Vercel本番環境: Vercel Rewriteを使用（サードパーティCookie問題を回避）
-      // /api/* へのリクエストはnext.config.mjsのrewritesでRenderに転送される
-      return "/api";
+    // NEXT_PUBLIC_API_URL 未設定時のフォールバック
+    // rewriteに依存しないよう本番URLを直接使う（rewriteはai-summaryの動的ルートを壊す）
+    if (process.env.NODE_ENV === "production") {
+      return "https://dreamjournal-app.onrender.com";
     }
     return "http://localhost:3001";
   }

--- a/frontend/lib/api-config.ts
+++ b/frontend/lib/api-config.ts
@@ -31,7 +31,12 @@ export function getApiUrl(): string {
 
     // NEXT_PUBLIC_API_URL 未設定時のフォールバック
     // rewriteに依存しないよう本番URLを直接使う（rewriteはai-summaryの動的ルートを壊す）
+    // Vercel preview は NODE_ENV=production で動くため、production 判定だけでは不十分。
+    // preview デプロイが NEXT_PUBLIC_API_URL 未設定のまま本番 Render を叩かないよう空文字を返す。
     if (process.env.NODE_ENV === "production") {
+      if (process.env.NEXT_PUBLIC_VERCEL_ENV === "preview") {
+        return "";
+      }
       return "https://dreamjournal-app.onrender.com";
     }
     return "http://localhost:3001";


### PR DESCRIPTION
## 問題

PR #199 でキャッチオールrewriteを削除した後、本番環境でログインが404になっていた。

**原因:** `api-config.ts` が `NEXT_PUBLIC_API_URL` 未設定時に `/api` をベースURLとして返し、rewriteに依存していた。

## Codexの対応と問題点

Codexはキャッチオールrewriteを条件付きで復活させたが、これは **PR #199が直した問題を再発させる**:

```
/api/dreams/month/2026-04/ai-summary
→ afterFiles rewrite で Render に転送
→ ai-summary（ハイフン）で転送されるが Rails は ai_summary（アンダースコア）のみ受け付ける → 404
```

## この修正

- `next.config.mjs`: Codexが追加したrewriteを削除
- `api-config.ts`: フォールバックを `/api` → `https://dreamjournal-app.onrender.com` に変更
  - rewrite不要・ai-summaryルートも壊れない
  - CORS + credentials は既存設定済み

## Test plan

- [x] `yarn build` — ビルド通過
- [x] `yarn test __tests__/lib/api-config.test.ts` — 2 tests passed
- [ ] 本番VercelでログインできることをE2Eで確認