### PR TITLE
feat: モルペウスを新デザインのガイドキャラに刷新

### DIFF
--- a/frontend/app/components/DreamRecorderFloating.tsx
+++ b/frontend/app/components/DreamRecorderFloating.tsx
@@ -8,6 +8,7 @@ import { uploadAndAnalyzeAudio } from "@/lib/audioAnalysis";
 import type { AnalysisResult } from "@/app/types";
 import { motion, AnimatePresence } from "framer-motion";
 import { Mic, Square, Loader2 } from "lucide-react";
+import MorpheusSVG from "./MorpheusSVG";
 
 const DreamRecorderFloating: React.FC = () => {
   const router = useRouter();
@@ -21,15 +22,11 @@ const DreamRecorderFloating: React.FC = () => {
   // Whisper 解析結果 → 一覧画面へ遷移（非同期処理のため）
   const handleAnalysisResult = useCallback(
     (result: AnalysisResult) => {
-      // 成功メッセージを表示
       toast.success(
         result.message || "こえを きいたよ！ ちょっと まっててね。"
       );
 
-      // 一覧画面へリダイレクト（新しい夢が作成されているはず）
-      // 即時にリストを更新して、pending状態のカードを表示する
-      // 即時にリストを更新して、pending状態のカードを表示する
-      window.dispatchEvent(new Event("dream-created")); // PendingDreamsMonitorに通知
+      window.dispatchEvent(new Event("dream-created"));
       router.refresh();
       router.push("/home");
     },
@@ -102,8 +99,16 @@ const DreamRecorderFloating: React.FC = () => {
     handleToggleRecording();
   };
 
+  const helperCopy = isProcessing
+    ? "モルペウスが ゆめを よみといてるよ"
+    : status === "recording"
+      ? "うんうん、きいてるよ"
+      : status === "preparing"
+        ? "マイクを じゅんびするね"
+        : "こえで ゆめを おしえてね";
+
   return (
-    <div className="fixed bottom-24 left-4 z-[9999] flex flex-col items-end gap-3">
+    <div className="fixed bottom-24 left-4 z-[9999] flex flex-col items-start gap-3">
       <AnimatePresence>
         {error && (
           <motion.div
@@ -116,6 +121,28 @@ const DreamRecorderFloating: React.FC = () => {
           </motion.div>
         )}
       </AnimatePresence>
+
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="hidden items-end gap-2 sm:flex"
+      >
+        <MorpheusSVG
+          expression={
+            isProcessing
+              ? "dreaming"
+              : status === "recording"
+                ? "curious"
+                : "cheerful"
+          }
+          size={58}
+          className="drop-shadow-[0_8px_18px_rgba(56,189,248,0.32)]"
+        />
+        <div className="relative max-w-[210px] rounded-2xl rounded-bl-sm border border-sky-200/70 bg-slate-900/88 px-3 py-2 text-xs font-semibold leading-relaxed text-slate-100 shadow-xl backdrop-blur-sm">
+          {helperCopy}
+          <div className="absolute -left-2 bottom-3 h-0 w-0 border-y-[7px] border-y-transparent border-r-[8px] border-r-slate-900/88" />
+        </div>
+      </motion.div>
 
       <motion.button
         type="button"

--- a/frontend/app/components/MorpheusSVG.tsx
+++ b/frontend/app/components/MorpheusSVG.tsx
@@ -15,161 +15,85 @@ interface MorpheusSVGProps {
   className?: string;
 }
 
-// 目のパーツ（表情ごと）
 function Eyes({ expression }: { expression: MorpheusExpression }) {
-  switch (expression) {
-    case "cheerful":
-      return (
-        <>
-          <circle cx="33" cy="43" r="4.5" fill="#1e293b" />
-          <circle cx="47" cy="43" r="4.5" fill="#1e293b" />
-          {/* キラキラ */}
-          <circle cx="35" cy="41" r="1.8" fill="white" />
-          <circle cx="49" cy="41" r="1.8" fill="white" />
-          <circle cx="34.5" cy="44.5" r="0.8" fill="white" />
-          <circle cx="48.5" cy="44.5" r="0.8" fill="white" />
-        </>
-      );
-    case "curious":
-      // 左目が少し大きく、首をかしげた印象
-      return (
-        <>
-          <circle cx="33" cy="43" r="5" fill="#1e293b" />
-          <circle cx="47" cy="44" r="3.5" fill="#1e293b" />
-          <circle cx="35" cy="41" r="1.8" fill="white" />
-          <circle cx="49" cy="42" r="1.4" fill="white" />
-        </>
-      );
-    case "dreaming":
-      // 目を閉じた曲線（夢を見ている）
-      return (
-        <>
-          <path
-            d="M 29 43 Q 33 40 37 43"
-            stroke="#1e293b"
-            strokeWidth="2.5"
-            fill="none"
-            strokeLinecap="round"
-          />
-          <path
-            d="M 43 43 Q 47 40 51 43"
-            stroke="#1e293b"
-            strokeWidth="2.5"
-            fill="none"
-            strokeLinecap="round"
-          />
-          {/* Zzz */}
-          <text x="54" y="36" fontSize="7" fill="#94a3b8" fontWeight="bold" fontFamily="sans-serif">
-            z
-          </text>
-          <text x="58" y="30" fontSize="9" fill="#94a3b8" fontWeight="bold" fontFamily="sans-serif">
-            Z
-          </text>
-        </>
-      );
-    case "proud":
-      // 半目（目を細めた誇らしげな表情）
-      return (
-        <>
-          <ellipse cx="33" cy="44" rx="4.5" ry="3" fill="#1e293b" />
-          <ellipse cx="47" cy="44" rx="4.5" ry="3" fill="#1e293b" />
-          {/* まぶた */}
-          <path
-            d="M 28.5 43 Q 33 40 37.5 43"
-            stroke="#fef3c7"
-            strokeWidth="2.5"
-            fill="none"
-          />
-          <path
-            d="M 42.5 43 Q 47 40 51.5 43"
-            stroke="#fef3c7"
-            strokeWidth="2.5"
-            fill="none"
-          />
-          <circle cx="35" cy="43" r="1.2" fill="white" />
-          <circle cx="49" cy="43" r="1.2" fill="white" />
-        </>
-      );
-    case "sleeping":
-    default:
-      // しっかり閉じた目
-      return (
-        <>
-          <path
-            d="M 29 43 Q 33 40 37 43"
-            stroke="#1e293b"
-            strokeWidth="2.5"
-            fill="none"
-            strokeLinecap="round"
-          />
-          <path
-            d="M 43 43 Q 47 40 51 43"
-            stroke="#1e293b"
-            strokeWidth="2.5"
-            fill="none"
-            strokeLinecap="round"
-          />
-          {/* まつ毛 */}
-          <line x1="30" y1="43" x2="29" y2="41" stroke="#1e293b" strokeWidth="1.2" />
-          <line x1="33" y1="40.5" x2="33" y2="38" stroke="#1e293b" strokeWidth="1.2" />
-          <line x1="36" y1="43" x2="37" y2="41" stroke="#1e293b" strokeWidth="1.2" />
-          <line x1="44" y1="43" x2="43" y2="41" stroke="#1e293b" strokeWidth="1.2" />
-          <line x1="47" y1="40.5" x2="47" y2="38" stroke="#1e293b" strokeWidth="1.2" />
-          <line x1="50" y1="43" x2="51" y2="41" stroke="#1e293b" strokeWidth="1.2" />
-        </>
-      );
+  if (expression === "sleeping" || expression === "dreaming") {
+    return (
+      <>
+        <path
+          d="M 31 43 Q 35 40 39 43"
+          stroke="#312e81"
+          strokeWidth="2.4"
+          fill="none"
+          strokeLinecap="round"
+        />
+        <path
+          d="M 45 43 Q 49 40 53 43"
+          stroke="#312e81"
+          strokeWidth="2.4"
+          fill="none"
+          strokeLinecap="round"
+        />
+        {expression === "dreaming" && (
+          <>
+            <text x="57" y="34" fontSize="7" fill="#93c5fd" fontWeight="bold">
+              z
+            </text>
+            <text x="61" y="28" fontSize="9" fill="#c4b5fd" fontWeight="bold">
+              Z
+            </text>
+          </>
+        )}
+      </>
+    );
   }
+
+  if (expression === "proud") {
+    return (
+      <>
+        <ellipse cx="35" cy="43" rx="4.8" ry="3.2" fill="#312e81" />
+        <ellipse cx="49" cy="43" rx="4.8" ry="3.2" fill="#312e81" />
+        <circle cx="36.8" cy="41.6" r="1.4" fill="#ffffff" />
+        <circle cx="50.8" cy="41.6" r="1.4" fill="#ffffff" />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <circle cx="35" cy="43" r={expression === "curious" ? 5.1 : 4.7} fill="#312e81" />
+      <circle cx="49" cy={expression === "curious" ? 44 : 43} r={expression === "curious" ? 3.9 : 4.7} fill="#312e81" />
+      <circle cx="36.8" cy="41" r="1.7" fill="#ffffff" />
+      <circle cx="50.8" cy="41" r="1.7" fill="#ffffff" />
+      <circle cx="34.2" cy="45" r="0.8" fill="#bfdbfe" />
+      <circle cx="48.2" cy="45" r="0.8" fill="#bfdbfe" />
+    </>
+  );
 }
 
-// 口のパーツ（表情ごと）
 function Mouth({ expression }: { expression: MorpheusExpression }) {
-  switch (expression) {
-    case "cheerful":
-      return (
-        <path
-          d="M 34 57 Q 40 63 46 57"
-          stroke="#92400e"
-          strokeWidth="2"
-          fill="none"
-          strokeLinecap="round"
-        />
-      );
-    case "curious":
-      return (
-        <path
-          d="M 35 57 Q 40 61 45 57"
-          stroke="#92400e"
-          strokeWidth="1.8"
-          fill="none"
-          strokeLinecap="round"
-        />
-      );
-    case "dreaming":
-    case "sleeping":
-      return (
-        <path
-          d="M 36 57 Q 40 59 44 57"
-          stroke="#92400e"
-          strokeWidth="1.5"
-          fill="none"
-          strokeLinecap="round"
-        />
-      );
-    case "proud":
-    default:
-      return (
-        <path
-          d="M 35 57 Q 40 61 45 57"
-          stroke="#92400e"
-          strokeWidth="1.8"
-          fill="none"
-          strokeLinecap="round"
-        />
-      );
+  if (expression === "sleeping" || expression === "dreaming") {
+    return (
+      <path
+        d="M 38 55 Q 42 57 46 55"
+        stroke="#92400e"
+        strokeWidth="1.7"
+        fill="none"
+        strokeLinecap="round"
+      />
+    );
   }
+
+  return (
+    <path
+      d="M 36 55 Q 42 61 48 55"
+      stroke="#92400e"
+      strokeWidth="2"
+      fill="none"
+      strokeLinecap="round"
+    />
+  );
 }
 
-// 表情ごとの浮遊アニメーション設定
 const floatVariants: Record<MorpheusExpression, TargetAndTransition> = {
   cheerful: {
     y: [0, -6, 0],
@@ -178,7 +102,7 @@ const floatVariants: Record<MorpheusExpression, TargetAndTransition> = {
   },
   curious: {
     y: [0, -4, 0],
-    rotate: [-3, 0, -3],
+    rotate: [-3, 1, -3],
     transition: { duration: 3, repeat: Infinity, ease: "easeInOut" },
   },
   dreaming: {
@@ -211,101 +135,113 @@ export default function MorpheusSVG({
       <svg
         width={size}
         height={size}
-        viewBox="0 0 80 80"
+        viewBox="0 0 88 88"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
         aria-hidden="true"
       >
-        {/* ====== 毛並み（外側のふわふわ） ====== */}
-        <circle cx="40" cy="46" r="27" fill="white" />
-        <circle cx="18" cy="40" r="11" fill="white" />
-        <circle cx="62" cy="40" r="11" fill="white" />
-        <circle cx="28" cy="24" r="11" fill="white" />
-        <circle cx="52" cy="24" r="11" fill="white" />
-        <circle cx="40" cy="20" r="10" fill="white" />
+        <defs>
+          <radialGradient id="morpheusFace" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(42 44) rotate(90) scale(27 25)">
+            <stop stopColor="#fff7ed" />
+            <stop offset="1" stopColor="#fdebd3" />
+          </radialGradient>
+          <linearGradient id="morpheusHat" x1="27" y1="4" x2="71" y2="39" gradientUnits="userSpaceOnUse">
+            <stop stopColor="#a5b4fc" />
+            <stop offset="0.55" stopColor="#93c5fd" />
+            <stop offset="1" stopColor="#7c3aed" />
+          </linearGradient>
+          <linearGradient id="morpheusHair" x1="17" y1="27" x2="67" y2="63" gradientUnits="userSpaceOnUse">
+            <stop stopColor="#c4b5fd" />
+            <stop offset="0.55" stopColor="#a5b4fc" />
+            <stop offset="1" stopColor="#7dd3fc" />
+          </linearGradient>
+          <linearGradient id="morpheusCoat" x1="24" y1="55" x2="60" y2="87" gradientUnits="userSpaceOnUse">
+            <stop stopColor="#ffffff" />
+            <stop offset="1" stopColor="#e0f2fe" />
+          </linearGradient>
+        </defs>
 
-        {/* ====== 角（金色のカールした雄羊の角） ====== */}
-        {/* 左角 */}
+        <ellipse cx="44" cy="81" rx="25" ry="6" fill="#bae6fd" opacity="0.32" />
+
         <path
-          d="M 24 34 C 12 26 8 14 18 12 C 28 10 28 22 22 28"
-          stroke="#d97706"
-          strokeWidth="4.5"
-          fill="none"
+          d="M30 58 C20 62 15 69 15 76 C22 76 29 73 35 67"
+          fill="#ffffff"
+          stroke="#dbeafe"
+          strokeWidth="2"
           strokeLinecap="round"
         />
-        {/* 右角 */}
         <path
-          d="M 56 34 C 68 26 72 14 62 12 C 52 10 52 22 58 28"
-          stroke="#d97706"
-          strokeWidth="4.5"
-          fill="none"
+          d="M58 58 C68 62 73 69 73 76 C66 76 59 73 53 67"
+          fill="#ffffff"
+          stroke="#dbeafe"
+          strokeWidth="2"
           strokeLinecap="round"
-        />
-        {/* 角のハイライト */}
-        <path
-          d="M 22 30 C 14 24 11 16 17 13"
-          stroke="#fbbf24"
-          strokeWidth="1.5"
-          fill="none"
-          strokeLinecap="round"
-          opacity="0.7"
-        />
-        <path
-          d="M 58 30 C 66 24 69 16 63 13"
-          stroke="#fbbf24"
-          strokeWidth="1.5"
-          fill="none"
-          strokeLinecap="round"
-          opacity="0.7"
         />
 
-        {/* ====== 顔（クリーム色） ====== */}
-        <ellipse cx="40" cy="48" rx="20" ry="18" fill="#fef3c7" />
+        <path
+          d="M25 61 C25 52 32 47 44 47 C56 47 63 52 63 61 L67 82 C60 86 51 87 44 87 C37 87 28 86 21 82 L25 61Z"
+          fill="url(#morpheusCoat)"
+          stroke="#c7d2fe"
+          strokeWidth="2"
+          strokeLinejoin="round"
+        />
+        <path d="M37 55 L44 83 L51 55" stroke="#a78bfa" strokeWidth="2" strokeLinecap="round" />
+        <path d="M39 59 H49 L47 78 H41 L39 59Z" fill="#6366f1" opacity="0.85" />
+        <path d="M44 57 L48 62 L44 67 L40 62 Z" fill="#fbbf24" />
+        <circle cx="57" cy="66" r="4.4" fill="#dbeafe" stroke="#93c5fd" strokeWidth="1.5" />
+        <path d="M55.6 66.2 L57 67.5 L59.4 64.5" stroke="#6366f1" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
 
-        {/* ====== 目 ====== */}
+        <path
+          d="M18 43 C18 29 28 18 43 18 C58 18 69 29 69 43 C69 59 57 70 43 70 C29 70 18 59 18 43Z"
+          fill="url(#morpheusHair)"
+          stroke="#c4b5fd"
+          strokeWidth="2"
+        />
+        <path d="M24 42 C28 34 33 31 39 29 C36 35 31 39 24 42Z" fill="#ddd6fe" opacity="0.88" />
+        <path d="M50 28 C58 30 64 35 66 43 C59 41 54 37 50 28Z" fill="#bfdbfe" opacity="0.82" />
+
+        <ellipse cx="42" cy="45" rx="22" ry="20" fill="url(#morpheusFace)" />
+        <circle cx="27" cy="49" r="3.5" fill="#fda4af" opacity="0.65" />
+        <circle cx="57" cy="49" r="3.5" fill="#fda4af" opacity="0.65" />
+
         <Eyes expression={expression} />
-
-        {/* ====== 鼻 ====== */}
-        <ellipse cx="40" cy="54" rx="5.5" ry="3.5" fill="#fca5a5" />
-        <circle cx="38" cy="53" r="1.2" fill="#f87171" />
-        <circle cx="42" cy="53" r="1.2" fill="#f87171" />
-
-        {/* ====== 口 ====== */}
+        <ellipse cx="42" cy="51" rx="2.2" ry="1.6" fill="#f9a8d4" />
         <Mouth expression={expression} />
 
-        {/* ====== 耳 ====== */}
-        <ellipse
-          cx="20"
-          cy="42"
-          rx="5"
-          ry="7"
+        <path
+          d="M26 24 C27 9 40 1 55 7 C71 13 75 30 69 45 C66 37 55 32 43 31 C34 30 28 28 26 24Z"
+          fill="url(#morpheusHat)"
+          stroke="#dbeafe"
+          strokeWidth="2"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M27 25 C35 31 53 32 67 42"
+          stroke="#eef2ff"
+          strokeWidth="4"
+          strokeLinecap="round"
+          opacity="0.8"
+        />
+        <circle cx="70" cy="47" r="6" fill="#f5d0fe" stroke="#e9d5ff" strokeWidth="2" />
+
+        <path
+          d="M64 20 C59 25 60 34 68 37 C62 39 55 36 53 30 C51 24 56 18 64 20Z"
           fill="#fde68a"
-          transform="rotate(-15 20 42)"
+          stroke="#f59e0b"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
         />
-        <ellipse
-          cx="60"
-          cy="42"
-          rx="5"
-          ry="7"
-          fill="#fde68a"
-          transform="rotate(15 60 42)"
+        {["M40 10 L41.4 13.4 L45 13.7 L42.2 16 L43 19.5 L40 17.7 L37 19.5 L37.8 16 L35 13.7 L38.6 13.4 Z", "M55 16 L56 18.2 L58.4 18.5 L56.6 20.1 L57.1 22.5 L55 21.3 L52.9 22.5 L53.4 20.1 L51.6 18.5 L54 18.2 Z", "M62 29 L63 31.2 L65.4 31.5 L63.6 33.1 L64.1 35.5 L62 34.3 L59.9 35.5 L60.4 33.1 L58.6 31.5 L61 31.2 Z"].map((d) => (
+          <path key={d} d={d} fill="#fde68a" opacity="0.9" />
+        ))}
+
+        <path
+          d="M39 25 C42 18 49 20 50 26 C48 24 45 24 43 28 C41 31 36 30 34 27 C36 28 38 27 39 25Z"
+          fill="#ddd6fe"
         />
-        <ellipse
-          cx="20"
-          cy="42"
-          rx="2.5"
-          ry="4"
-          fill="#fca5a5"
-          transform="rotate(-15 20 42)"
-        />
-        <ellipse
-          cx="60"
-          cy="42"
-          rx="2.5"
-          ry="4"
-          fill="#fca5a5"
-          transform="rotate(15 60 42)"
-        />
+
+        <path d="M9 73 C16 64 25 68 29 76 C23 79 15 79 9 73Z" fill="#e0f2fe" opacity="0.8" />
+        <path d="M60 78 C66 69 77 70 81 79 C75 83 66 83 60 78Z" fill="#e0f2fe" opacity="0.8" />
       </svg>
     </motion.div>
   );

--- a/frontend/app/components/MorpheusSmall.tsx
+++ b/frontend/app/components/MorpheusSmall.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import Image from "next/image";
 import { motion } from "framer-motion";
+
+import MorpheusSVG, { type MorpheusExpression } from "./MorpheusSVG";
 
 interface MorpheusSmallProps {
   /** 吹き出しのメインメッセージ */
@@ -12,6 +13,8 @@ interface MorpheusSmallProps {
   size?: "sm" | "md";
   /** レイアウト方向: "row"=左吹き出し+右画像 / "col"=上画像+下吹き出し（デフォルト row） */
   layout?: "row" | "col";
+  /** モルペウスの表情 */
+  expression?: MorpheusExpression;
   /** 追加のラッパー className */
   className?: string;
 }
@@ -25,21 +28,22 @@ export default function MorpheusSmall({
   title,
   size = "md",
   layout = "row",
+  expression = "cheerful",
   className = "",
 }: MorpheusSmallProps) {
   const imgPx = size === "sm" ? 48 : 64;
+  const mascot = (
+    <MorpheusSVG
+      expression={expression}
+      size={imgPx}
+      className="drop-shadow-[0_4px_12px_rgba(56,189,248,0.3)]"
+    />
+  );
 
   if (layout === "col") {
     return (
       <div className={`flex flex-col items-center gap-2 ${className}`}>
-        <Image
-          src="/images/morpheus.png"
-          alt="モルペウス"
-          width={imgPx}
-          height={imgPx}
-          sizes={`${imgPx}px`}
-          className="opacity-90 drop-shadow-[0_4px_12px_rgba(56,189,248,0.3)]"
-        />
+        {mascot}
         <motion.div
           initial={{ opacity: 0, y: 6 }}
           animate={{ opacity: 1, y: 0 }}
@@ -72,17 +76,8 @@ export default function MorpheusSmall({
         <div className="absolute -right-2 bottom-3 w-0 h-0 border-t-[8px] border-t-transparent border-b-[8px] border-b-transparent border-l-[8px] border-l-slate-800/90" />
       </motion.div>
 
-      {/* モルペウス画像（右） */}
-      <div className="flex-shrink-0">
-        <Image
-          src="/images/morpheus.png"
-          alt="モルペウス"
-          width={imgPx}
-          height={imgPx}
-          sizes={`${imgPx}px`}
-          className="opacity-90 drop-shadow-[0_4px_12px_rgba(56,189,248,0.3)]"
-        />
-      </div>
+      {/* モルペウス本体（右） */}
+      <div className="flex-shrink-0">{mascot}</div>
     </div>
   );
 }


### PR DESCRIPTION
## 概要

生成した新しいモルペウス案（月帽子・白衣・星アクセントの夢ドクター風）を、実際のユメログUIで使いやすいインラインSVGコンポーネントとして反映しました。

## 変更内容

- `MorpheusSVG.tsx`
  - 旧：羊モチーフのSVG
  - 新：月帽子＋白衣＋ラベンダー髪のチビキャラ風モルペウス
  - 既存の `cheerful / curious / dreaming / proud / sleeping` 表情APIは維持
  - 既存の利用箇所を壊さず、各画面のモルペウス表示を一括更新

- `MorpheusSmall.tsx`
  - `/images/morpheus.png` 依存から `MorpheusSVG` 利用に変更
  - 小型ガイドでも新デザインに統一
  - `expression` prop を追加し、画面ごとに表情を指定可能に

- `DreamRecorderFloating.tsx`
  - 音声録音ボタンの近くにモルペウスのミニガイドを追加
  - 状態ごとに表情とコピーを切り替え
    - 録音前: `こえで ゆめを おしえてね`
    - 録音中: `うんうん、きいてるよ`
    - 準備中: `マイクを じゅんびするね`
    - 解析中: `モルペウスが ゆめを よみといてるよ`

## 期待される効果

- ホーム、夢作成、夢詳細、空状態、夢クエスト、分析中ローダーなど、既存の `MorpheusSVG` 利用画面に新キャラが反映されます。
- 子ども向けに「今なにをすればいいか」をモルペウスが案内する体験に近づきます。
- PNG画像ではなくSVGコンポーネントなので、軽量・レスポンシブ・表情差分付きで運用できます。

## 確認ポイント

- `npm run lint`
- `npm test`
- スマホ幅で `/home` の録音ボタンと右下モルペウスが重ならないこと
- `/dream/new` と `/dream/[id]` でモルペウスの見た目が新デザインに変わっていること