### PR TITLE
ux: モルペウスを各画面で大きく見せるヒーロー表示に改善

### DIFF
--- a/frontend/app/components/MorpheusGuide.tsx
+++ b/frontend/app/components/MorpheusGuide.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { X } from "lucide-react";
 import MorpheusSVG, { type MorpheusExpression } from "./MorpheusSVG";
+import MorpheusHero from "./MorpheusHero";
 
 export interface MorpheusGuideProps {
   /** 表情 */
@@ -28,7 +29,7 @@ export default function MorpheusGuide({
   expression,
   title,
   message,
-  size = 72,
+  size = 96,
   defaultOpen = true,
   placement = "fixed",
   positionClassName = "bottom-6 right-4 sm:bottom-10 sm:right-8",
@@ -51,10 +52,10 @@ export default function MorpheusGuide({
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 10, scale: 0.92, transition: { duration: 0.15 } }}
             transition={{ type: "spring", stiffness: 300, damping: 28 }}
-            className="relative max-w-[220px] sm:max-w-xs rounded-2xl bg-slate-900/88 px-4 py-3 text-sm text-slate-100 shadow-xl ring-1 ring-white/15 backdrop-blur-sm
+            className="relative max-w-[240px] sm:max-w-sm rounded-3xl bg-slate-900/90 px-4 py-3 text-sm text-slate-100 shadow-2xl ring-1 ring-white/15 backdrop-blur-sm
               before:absolute before:-right-2.5 before:bottom-5 before:h-0 before:w-0
               before:border-y-[8px] before:border-y-transparent
-              before:border-l-[10px] before:border-l-slate-900/88
+              before:border-l-[10px] before:border-l-slate-900/90
               before:content-['']"
           >
             <button
@@ -85,7 +86,7 @@ export default function MorpheusGuide({
         <MorpheusSVG
           expression={expression}
           size={size}
-          className="drop-shadow-[0_8px_24px_rgba(56,189,248,0.3)]"
+          className="drop-shadow-[0_12px_30px_rgba(56,189,248,0.38)]"
         />
       </motion.button>
     </div>
@@ -103,7 +104,7 @@ export function MorpheusGuideLanding() {
       expression="dreaming"
       title="ようこそ、夢の世界へ…"
       message="ぼくはモルペウス。きみの夢を一緒に記録していくよ。"
-      size={80}
+      size={116}
     />
   );
 }
@@ -115,7 +116,7 @@ export function MorpheusGuideLogin() {
       expression="cheerful"
       title="おかえり！"
       message="また来てくれたんだね。今日の夢、楽しみにしてたよ。"
-      size={72}
+      size={108}
     />
   );
 }
@@ -133,7 +134,9 @@ export function MorpheusGuideHome({
       expression="curious"
       title={title}
       message={message}
-      size={72}
+      size={120}
+      positionClassName="bottom-24 right-3 sm:bottom-10 sm:right-8"
+      className="hidden sm:flex"
     />
   );
 }
@@ -145,7 +148,7 @@ export function MorpheusGuideDetail() {
       expression="proud"
       title="すてきな夢だね。"
       message="ちゃんと記録できてえらいよ。分析結果も見てみてね。"
-      size={72}
+      size={110}
       positionClassName="bottom-6 left-4 sm:bottom-10 sm:left-8"
     />
   );
@@ -155,18 +158,17 @@ export function MorpheusGuideDetail() {
 export function MorpheusGuideEmpty({ ageGroup }: { ageGroup?: string }) {
   const isSmallChild = ageGroup === "child_small" || ageGroup === "child";
   return (
-    <MorpheusGuide
+    <MorpheusHero
       expression="sleeping"
-      placement="inline"
-      positionClassName=""
+      variant="compose"
       title={isSmallChild ? "ゆめ、まだかな…" : "夢はまだありません"}
       message={
         isSmallChild
-          ? "ねたら でてくるよ 🌙　おきたら おしえてね。"
-          : "今夜みた夢を、起きたらすぐ記録してみてください。"
+          ? "ねたら でてくるよ 🌙　おきたら モルペウスに おしえてね。"
+          : "今夜みた夢を、起きたらすぐ記録してみてください。モルペウスがそばで待っています。"
       }
-      size={64}
-      defaultOpen={true}
+      size={132}
+      className="w-full"
     />
   );
 }
@@ -174,14 +176,13 @@ export function MorpheusGuideEmpty({ ageGroup }: { ageGroup?: string }) {
 /** 新規作成ページ用 */
 export function MorpheusGuideCompose() {
   return (
-    <MorpheusGuide
+    <MorpheusHero
       expression="cheerful"
-      title="思い出せるぶんで大丈夫"
-      message="さいしょは ひとことでも いいよ。あとから ふくらませよう。"
-      size={68}
-      placement="inline"
-      positionClassName=""
-      className="items-start"
+      variant="compose"
+      title="モルペウスに ゆめを おしえてね"
+      message="さいしょは ひとことでも だいじょうぶ。おもいだせる ぶんだけ、ゆっくり かいてみよう。"
+      size={154}
+      className="w-full"
     />
   );
 }

--- a/frontend/app/components/MorpheusHero.tsx
+++ b/frontend/app/components/MorpheusHero.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Sparkles } from "lucide-react";
+
+import MorpheusSVG, { type MorpheusExpression } from "./MorpheusSVG";
+
+type MorpheusHeroProps = {
+  title: string;
+  message: string;
+  expression?: MorpheusExpression;
+  size?: number;
+  variant?: "home" | "compose" | "detail" | "voice";
+  className?: string;
+  action?: React.ReactNode;
+};
+
+const variantStyles = {
+  home: "from-indigo-950 via-slate-900 to-sky-950 text-white border-white/15",
+  compose: "from-violet-100 via-white to-sky-100 text-slate-900 border-violet-200/80 dark:from-slate-950 dark:via-indigo-950 dark:to-sky-950 dark:text-white dark:border-white/15",
+  detail: "from-sky-100 via-white to-violet-100 text-slate-900 border-sky-200/80 dark:from-slate-950 dark:via-sky-950 dark:to-indigo-950 dark:text-white dark:border-white/15",
+  voice: "from-slate-950 via-indigo-950 to-sky-950 text-white border-white/15",
+} as const;
+
+/**
+ * 画面の主役として使う大きめのモルペウスカード。
+ * 小さいフローティングアイコンではなく、モック画面のように
+ * 「モルペウスが案内している」ことが一目で伝わる配置にする。
+ */
+export default function MorpheusHero({
+  title,
+  message,
+  expression = "cheerful",
+  size = 150,
+  variant = "home",
+  className = "",
+  action,
+}: MorpheusHeroProps) {
+  return (
+    <section
+      className={`relative overflow-hidden rounded-[2rem] border bg-gradient-to-br p-5 shadow-xl ${variantStyles[variant]} ${className}`}
+    >
+      <div className="pointer-events-none absolute -right-10 -top-10 h-32 w-32 rounded-full bg-sky-300/25 blur-3xl" />
+      <div className="pointer-events-none absolute -bottom-14 left-8 h-36 w-36 rounded-full bg-violet-300/25 blur-3xl" />
+      <div className="pointer-events-none absolute right-8 top-8 text-2xl text-amber-200/80 motion-safe:animate-pulse">
+        ✦
+      </div>
+      <div className="pointer-events-none absolute left-6 bottom-6 text-lg text-sky-200/70 motion-safe:animate-pulse">
+        ⋆
+      </div>
+
+      <div className="relative grid gap-4 sm:grid-cols-[1fr_auto] sm:items-center">
+        <div className="min-w-0">
+          <p className="mb-2 inline-flex items-center gap-1.5 rounded-full bg-white/16 px-3 py-1 text-xs font-bold tracking-[0.16em] text-sky-100 ring-1 ring-white/20 backdrop-blur dark:text-sky-100">
+            <Sparkles className="h-3.5 w-3.5" />
+            MORPHEUS GUIDE
+          </p>
+          <h2 className="text-2xl font-black leading-tight sm:text-3xl">
+            {title}
+          </h2>
+          <div className="relative mt-4 max-w-xl rounded-[1.5rem] bg-white/88 px-4 py-3 text-sm font-semibold leading-relaxed text-slate-800 shadow-lg ring-1 ring-white/60 dark:bg-slate-900/82 dark:text-slate-100 dark:ring-white/15">
+            {message}
+            <div className="absolute -right-2 top-8 hidden h-0 w-0 border-y-[9px] border-y-transparent border-l-[10px] border-l-white/88 dark:border-l-slate-900/82 sm:block" />
+          </div>
+          {action ? <div className="mt-4">{action}</div> : null}
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, scale: 0.86, y: 12 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          transition={{ type: "spring", stiffness: 210, damping: 18 }}
+          className="mx-auto grid place-items-center sm:mx-0"
+        >
+          <div className="relative">
+            <div className="absolute inset-x-3 bottom-1 h-8 rounded-full bg-sky-300/35 blur-xl" />
+            <MorpheusSVG
+              expression={expression}
+              size={size}
+              className="relative drop-shadow-[0_18px_40px_rgba(56,189,248,0.38)]"
+            />
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -16,6 +16,7 @@ import SearchBar from "@/app/components/SearchBar";
 import DreamEntryLauncher from "@/app/components/DreamEntryLauncher";
 import DreamAdventurePanel from "@/app/components/DreamAdventurePanel";
 import { MorpheusGuideHome } from "@/app/components/MorpheusGuide";
+import MorpheusHero from "@/app/components/MorpheusHero";
 import Loading from "../loading";
 
 /**
@@ -255,26 +256,25 @@ export default function HomePage() {
     >
       {/* メインセクション: ユーザー名の下に夢リストを表示 */}
       <section className="w-full lg:w-2/3 flex flex-col items-center px-3 md:px-6">
-        <div className="w-full rounded-3xl border border-border/70 bg-card px-5 py-5 shadow-sm">
-          <p className="text-sm font-semibold text-primary">
-            {user ? `${user.username}さん、おはよう` : "おはよう"}
-          </p>
-          <h1 className="mt-1 text-2xl font-bold text-foreground">
-            {copy.heading}
-          </h1>
-          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-            {copy.sub}
-          </p>
-          <div className="mt-4 max-w-md">
-            <DreamEntryLauncher
-              buttonLabel={copy.button}
-              buttonSize="lg"
-              buttonClassName="min-h-14 w-full text-base font-bold shadow-lg shadow-primary/15"
-              helperText={copy.helper}
-              showSparkles
-            />
-          </div>
-        </div>
+        <MorpheusHero
+          expression="cheerful"
+          variant="home"
+          title={user ? `${user.username}さん、おはよう！` : "おはよう！"}
+          message={`${copy.heading} ${copy.sub}`}
+          size={164}
+          className="w-full mb-4"
+          action={
+            <div className="max-w-md">
+              <DreamEntryLauncher
+                buttonLabel={copy.button}
+                buttonSize="lg"
+                buttonClassName="min-h-14 w-full text-base font-bold shadow-lg shadow-primary/15"
+                helperText={copy.helper}
+                showSparkles
+              />
+            </div>
+          }
+        />
         {shouldDeferSearch ? (
           <div className="mt-4 w-full rounded-2xl border border-border/70 bg-card px-4 py-4 shadow-sm">
             <p className="text-sm font-medium text-card-foreground">


### PR DESCRIPTION
## 概要

前回の修正ではモルペウスが小さいSVGアイコンとして表示されるため、生成モックのような「可愛いマスコットがはっきり見える」印象が弱くなっていました。

今回のPRでは、重要画面でモルペウスを大きく見せる `MorpheusHero` を追加し、ホーム・夢作成・空状態でキャラクターが主役として見える配置に寄せています。

## 変更内容

- `MorpheusHero.tsx` を新規追加
  - モルペウスを150px前後で大きく表示する専用カード
  - 吹き出し・星・グラデーション背景を含めて、生成モックに近い「案内役」感を強化
  - `home / compose / detail / voice` の variant を用意

- `home/page.tsx`
  - 既存の小さなウェルカムカードを `MorpheusHero` に差し替え
  - ホーム上部でモルペウスが大きく表示され、`DreamEntryLauncher` も同じカード内に配置

- `MorpheusGuide.tsx`
  - fixedの小型ガイドはサイズを少し拡大
  - `MorpheusGuideCompose` を `MorpheusHero` ベースに変更
  - `MorpheusGuideEmpty` も `MorpheusHero` ベースに変更
  - 夢作成・空状態でキャラクターが一目で分かる表示に改善

## ねらい

- 上のモックのように「モルペウスがいるアプリ」と一目で伝わるようにする
- 単なる装飾アイコンではなく、子どもに話しかける案内役として見せる
- ホーム画面と夢を書く画面のワクワク感を上げる

## 確認ポイント

- `/home` の上部カードでモルペウスが大きく見えること
- `/dream/new` の冒頭でモルペウスが主役として見えること
- 夢が0件の空状態でもモルペウスが小さすぎないこと
- スマホ幅で録音ボタンや右下ガイドと重なりすぎないこと
- `npm run lint` / `npm test`