### PR TITLE
ux: 添付モルペウス画像を画面別ガイドとして配置

### DIFF
--- a/docs/morpheus-image-assets.md
+++ b/docs/morpheus-image-assets.md
@@ -1,0 +1,41 @@
+# モルペウス画像アセット配置ガイド
+
+このPRでは、添付画像のモルペウスをアプリ画面に配置するためのコードを追加しています。
+
+## 画像配置先
+
+以下の6ファイルを `frontend/public/images/morpheus/` に配置してください。
+
+```text
+frontend/public/images/morpheus/
+  morpheus-home.jpg
+  morpheus-compose.jpg
+  morpheus-voice.jpg
+  morpheus-analysis.jpg
+  morpheus-empty.jpg
+  morpheus-praise.jpg
+```
+
+## 画面ごとの使い分け
+
+| ファイル | 用途 | 主な配置先 |
+|---|---|---|
+| `morpheus-home.jpg` | 手を振る案内役 | `/home` のヒーロー |
+| `morpheus-compose.jpg` | 夢を書く案内 | `/dream/new`、フォーム上部 |
+| `morpheus-voice.jpg` | 音声を聞く案内 | 音声入力ボタン |
+| `morpheus-analysis.jpg` | 夢を読み解く | 分析中、分析結果 |
+| `morpheus-empty.jpg` | 夢待ち・空状態 | 夢が0件の空状態 |
+| `morpheus-praise.jpg` | ほめる・達成 | 夢詳細、達成演出 |
+
+## 実装方針
+
+- `MorpheusImage` コンポーネントで画像パスと alt を集約します。
+- `MorpheusHero` は `MorpheusImage` を使って、大きいモルペウス画像を表示します。
+- 既存の `MorpheusSVG` はすぐ削除せず、フローティング補助やフォールバックとして残します。
+
+## 確認ポイント
+
+- `/home` のヒーローで `morpheus-home.jpg` が大きく表示されること。
+- `/dream/new` の上部で `morpheus-compose.jpg` が表示されること。
+- 音声入力ボタン付近で `morpheus-voice.jpg` が表示されること。
+- 画像未配置の場合はブラウザで 404 になるため、マージ前に画像ファイルを必ず配置してください。

--- a/frontend/app/components/DreamRecorderFloating.tsx
+++ b/frontend/app/components/DreamRecorderFloating.tsx
@@ -8,7 +8,7 @@ import { uploadAndAnalyzeAudio } from "@/lib/audioAnalysis";
 import type { AnalysisResult } from "@/app/types";
 import { motion, AnimatePresence } from "framer-motion";
 import { Mic, Square, Loader2 } from "lucide-react";
-import MorpheusSVG from "./MorpheusSVG";
+import MorpheusImage from "./MorpheusImage";
 
 const DreamRecorderFloating: React.FC = () => {
   const router = useRouter();
@@ -127,16 +127,10 @@ const DreamRecorderFloating: React.FC = () => {
         animate={{ opacity: 1, y: 0 }}
         className="hidden items-end gap-2 sm:flex"
       >
-        <MorpheusSVG
-          expression={
-            isProcessing
-              ? "dreaming"
-              : status === "recording"
-                ? "curious"
-                : "cheerful"
-          }
-          size={58}
-          className="drop-shadow-[0_8px_18px_rgba(56,189,248,0.32)]"
+        <MorpheusImage
+          variant={isProcessing ? "analysis" : "voice"}
+          size={86}
+          className={status === "recording" ? "motion-safe:animate-pulse" : ""}
         />
         <div className="relative max-w-[210px] rounded-2xl rounded-bl-sm border border-sky-200/70 bg-slate-900/88 px-3 py-2 text-xs font-semibold leading-relaxed text-slate-100 shadow-xl backdrop-blur-sm">
           {helperCopy}

--- a/frontend/app/components/MorpheusGuide.tsx
+++ b/frontend/app/components/MorpheusGuide.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { X } from "lucide-react";
 import MorpheusSVG, { type MorpheusExpression } from "./MorpheusSVG";
 import MorpheusHero from "./MorpheusHero";
+import MorpheusImage from "./MorpheusImage";
 
 export interface MorpheusGuideProps {
   /** 表情 */
@@ -160,6 +161,7 @@ export function MorpheusGuideEmpty({ ageGroup }: { ageGroup?: string }) {
   return (
     <MorpheusHero
       expression="sleeping"
+      imageVariant="empty"
       variant="compose"
       title={isSmallChild ? "ゆめ、まだかな…" : "夢はまだありません"}
       message={
@@ -167,7 +169,7 @@ export function MorpheusGuideEmpty({ ageGroup }: { ageGroup?: string }) {
           ? "ねたら でてくるよ 🌙　おきたら モルペウスに おしえてね。"
           : "今夜みた夢を、起きたらすぐ記録してみてください。モルペウスがそばで待っています。"
       }
-      size={132}
+      size={210}
       className="w-full"
     />
   );
@@ -178,11 +180,22 @@ export function MorpheusGuideCompose() {
   return (
     <MorpheusHero
       expression="cheerful"
+      imageVariant="compose"
       variant="compose"
       title="モルペウスに ゆめを おしえてね"
       message="さいしょは ひとことでも だいじょうぶ。おもいだせる ぶんだけ、ゆっくり かいてみよう。"
-      size={154}
+      size={220}
       className="w-full"
     />
   );
+}
+
+/** 夢分析中・読み解き中のインライン表示 */
+export function MorpheusGuideAnalysis() {
+  return <MorpheusImage variant="analysis" size={118} />;
+}
+
+/** ほめる・達成状態のインライン表示 */
+export function MorpheusGuidePraise() {
+  return <MorpheusImage variant="praise" size={132} />;
 }

--- a/frontend/app/components/MorpheusHero.tsx
+++ b/frontend/app/components/MorpheusHero.tsx
@@ -3,12 +3,14 @@
 import { motion } from "framer-motion";
 import { Sparkles } from "lucide-react";
 
-import MorpheusSVG, { type MorpheusExpression } from "./MorpheusSVG";
+import type { MorpheusExpression } from "./MorpheusSVG";
+import MorpheusImage, { type MorpheusImageVariant } from "./MorpheusImage";
 
 type MorpheusHeroProps = {
   title: string;
   message: string;
   expression?: MorpheusExpression;
+  imageVariant?: MorpheusImageVariant;
   size?: number;
   variant?: "home" | "compose" | "detail" | "voice";
   className?: string;
@@ -22,16 +24,24 @@ const variantStyles = {
   voice: "from-slate-950 via-indigo-950 to-sky-950 text-white border-white/15",
 } as const;
 
+const expressionToImageVariant: Record<MorpheusExpression, MorpheusImageVariant> = {
+  cheerful: "home",
+  curious: "analysis",
+  dreaming: "analysis",
+  proud: "praise",
+  sleeping: "empty",
+};
+
 /**
  * 画面の主役として使う大きめのモルペウスカード。
- * 小さいフローティングアイコンではなく、モック画面のように
- * 「モルペウスが案内している」ことが一目で伝わる配置にする。
+ * 添付画像版のモルペウスを使い、生成画像の可愛さをそのまま画面へ出す。
  */
 export default function MorpheusHero({
   title,
   message,
   expression = "cheerful",
-  size = 150,
+  imageVariant,
+  size = 190,
   variant = "home",
   className = "",
   action,
@@ -71,14 +81,12 @@ export default function MorpheusHero({
           transition={{ type: "spring", stiffness: 210, damping: 18 }}
           className="mx-auto grid place-items-center sm:mx-0"
         >
-          <div className="relative">
-            <div className="absolute inset-x-3 bottom-1 h-8 rounded-full bg-sky-300/35 blur-xl" />
-            <MorpheusSVG
-              expression={expression}
-              size={size}
-              className="relative drop-shadow-[0_18px_40px_rgba(56,189,248,0.38)]"
-            />
-          </div>
+          <MorpheusImage
+            variant={imageVariant ?? expressionToImageVariant[expression]}
+            size={size}
+            priority={variant === "home"}
+            className="relative"
+          />
         </motion.div>
       </div>
     </section>

--- a/frontend/app/components/MorpheusImage.tsx
+++ b/frontend/app/components/MorpheusImage.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import { motion } from "framer-motion";
+
+import MorpheusSVG, { type MorpheusExpression } from "./MorpheusSVG";
 
 export type MorpheusImageVariant =
   | "home"
@@ -28,6 +31,15 @@ const ALT_BY_VARIANT: Record<MorpheusImageVariant, string> = {
   praise: "星を掲げて夢の記録をほめるモルペウス",
 };
 
+const FALLBACK_EXPRESSION: Record<MorpheusImageVariant, MorpheusExpression> = {
+  home: "cheerful",
+  compose: "cheerful",
+  voice: "curious",
+  analysis: "dreaming",
+  empty: "sleeping",
+  praise: "proud",
+};
+
 type MorpheusImageProps = {
   variant?: MorpheusImageVariant;
   size?: number;
@@ -39,7 +51,7 @@ type MorpheusImageProps = {
  * 添付されたモルペウス画像を画面別に表示する共通コンポーネント。
  *
  * 画像ファイルは frontend/public/images/morpheus/ に配置する。
- * SVG版のモルペウスより大きく、生成画像の可愛さをそのまま画面へ出す用途。
+ * 画像未配置の環境でも UI が壊れないよう、読み込み失敗時は既存の SVG 版へフォールバックする。
  */
 export default function MorpheusImage({
   variant = "home",
@@ -47,6 +59,18 @@ export default function MorpheusImage({
   className = "",
   priority = false,
 }: MorpheusImageProps) {
+  const [hasImageError, setHasImageError] = useState(false);
+
+  if (hasImageError) {
+    return (
+      <MorpheusSVG
+        expression={FALLBACK_EXPRESSION[variant]}
+        size={size}
+        className={`drop-shadow-[0_18px_40px_rgba(99,102,241,0.30)] ${className}`}
+      />
+    );
+  }
+
   return (
     <motion.img
       src={MORPHEUS_IMAGE_SRC[variant]}
@@ -55,6 +79,7 @@ export default function MorpheusImage({
       height={size}
       loading={priority ? "eager" : "lazy"}
       decoding="async"
+      onError={() => setHasImageError(true)}
       initial={{ opacity: 0, scale: 0.92, y: 8 }}
       animate={{ opacity: 1, scale: 1, y: 0 }}
       transition={{ type: "spring", stiffness: 220, damping: 18 }}

--- a/frontend/app/components/MorpheusImage.tsx
+++ b/frontend/app/components/MorpheusImage.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export type MorpheusImageVariant =
+  | "home"
+  | "compose"
+  | "voice"
+  | "analysis"
+  | "empty"
+  | "praise";
+
+const MORPHEUS_IMAGE_SRC: Record<MorpheusImageVariant, string> = {
+  home: "/images/morpheus/morpheus-home.jpg",
+  compose: "/images/morpheus/morpheus-compose.jpg",
+  voice: "/images/morpheus/morpheus-voice.jpg",
+  analysis: "/images/morpheus/morpheus-analysis.jpg",
+  empty: "/images/morpheus/morpheus-empty.jpg",
+  praise: "/images/morpheus/morpheus-praise.jpg",
+};
+
+const ALT_BY_VARIANT: Record<MorpheusImageVariant, string> = {
+  home: "手を振って夢の記録へ案内するモルペウス",
+  compose: "夢のノートを開いて書くことを応援するモルペウス",
+  voice: "マイクの前で夢の話を聞いているモルペウス",
+  analysis: "夢の本を読んで分析しているモルペウス",
+  empty: "月と雲の上で次の夢を待っているモルペウス",
+  praise: "星を掲げて夢の記録をほめるモルペウス",
+};
+
+type MorpheusImageProps = {
+  variant?: MorpheusImageVariant;
+  size?: number;
+  className?: string;
+  priority?: boolean;
+};
+
+/**
+ * 添付されたモルペウス画像を画面別に表示する共通コンポーネント。
+ *
+ * 画像ファイルは frontend/public/images/morpheus/ に配置する。
+ * SVG版のモルペウスより大きく、生成画像の可愛さをそのまま画面へ出す用途。
+ */
+export default function MorpheusImage({
+  variant = "home",
+  size = 180,
+  className = "",
+  priority = false,
+}: MorpheusImageProps) {
+  return (
+    <motion.img
+      src={MORPHEUS_IMAGE_SRC[variant]}
+      alt={ALT_BY_VARIANT[variant]}
+      width={size}
+      height={size}
+      loading={priority ? "eager" : "lazy"}
+      decoding="async"
+      initial={{ opacity: 0, scale: 0.92, y: 8 }}
+      animate={{ opacity: 1, scale: 1, y: 0 }}
+      transition={{ type: "spring", stiffness: 220, damping: 18 }}
+      className={`object-contain drop-shadow-[0_18px_40px_rgba(99,102,241,0.30)] ${className}`}
+    />
+  );
+}


### PR DESCRIPTION
## 概要

添付していただいた可愛いモルペウス画像を、SVGで描き直すのではなく、画像アセットとして各画面に配置するための実装です。

## 変更内容

- `MorpheusImage.tsx` を追加
  - `home / compose / voice / analysis / empty / praise` の6種類を画面別に呼び出せる共通コンポーネント
  - alt テキストも用途別に設定

- `MorpheusHero.tsx` を画像版モルペウス対応に変更
  - これまでの `MorpheusSVG` ではなく `MorpheusImage` を表示
  - `imageVariant` prop を追加
  - `/home` などのヒーロー表示で添付画像を大きく表示できるように変更

- `MorpheusGuide.tsx` の画面別プリセットを画像版に対応
  - `MorpheusGuideCompose`: `morpheus-compose.jpg`
  - `MorpheusGuideEmpty`: `morpheus-empty.jpg`
  - 分析用・ほめる用の補助プリセットも追加

- `DreamRecorderFloating.tsx` を画像版に変更
  - 音声入力中は `morpheus-voice.jpg`
  - 解析中は `morpheus-analysis.jpg`
  - SVGアイコンより、添付画像の可愛さが見える表示に変更

- `docs/morpheus-image-assets.md` を追加
  - 画像ファイルの配置先と用途マップを記載

## 画像配置が必要です

このGitHub連携では PNG/JPG などの画像バイナリを直接コミットする操作が安定しないため、画像ファイル本体は別途配置が必要です。

配置先:

```text
frontend/public/images/morpheus/
  morpheus-home.jpg
  morpheus-compose.jpg
  morpheus-voice.jpg
  morpheus-analysis.jpg
  morpheus-empty.jpg
  morpheus-praise.jpg
```

前回作成した `morpheus_app_assets_package.zip` の中身をこの場所へコピーすれば動きます。

## 確認ポイント

- `/home` のヒーローで `morpheus-home.jpg` が大きく表示されること
- `/dream/new` の上部で `morpheus-compose.jpg` が表示されること
- 音声入力ボタン付近で `morpheus-voice.jpg` が表示されること
- 夢が0件の空状態で `morpheus-empty.jpg` が表示されること
- `npm run lint`
- `npm test`

## 補足

既存の `MorpheusSVG` は削除せず残しています。小さいフローティング補助やフォールバックとして使えるためです。