### PR TITLE
fix: route client API calls through /proxy rewrite to fix cookie auth on Vercel

### DIFF
--- a/frontend/__tests__/lib/api-config.test.ts
+++ b/frontend/__tests__/lib/api-config.test.ts
@@ -24,18 +24,20 @@ describe("api-config", () => {
     );
   });
 
-  it("uses the Render production URL as fallback when NEXT_PUBLIC_API_URL is unset", () => {
-    process.env.NODE_ENV = "production";
+  it("uses /proxy rewrite on Vercel production so cookies are sent same-origin", () => {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = "production";
 
-    expect(createApiUrl("/auth/login")).toBe(
-      "https://dreamjournal-app.onrender.com/auth/login"
-    );
+    expect(getApiUrl()).toBe("/proxy");
+    expect(createApiUrl("/auth/login")).toBe("/proxy/auth/login");
   });
 
   it("returns empty string for Vercel preview to avoid silently hitting production backend", () => {
-    process.env.NODE_ENV = "production";
     process.env.NEXT_PUBLIC_VERCEL_ENV = "preview";
 
     expect(getApiUrl()).toBe("");
+  });
+
+  it("falls back to localhost when no env vars are set", () => {
+    expect(getApiUrl()).toBe("http://localhost:3001");
   });
 });

--- a/frontend/lib/api-config.ts
+++ b/frontend/lib/api-config.ts
@@ -24,21 +24,29 @@ export function getApiUrl(): string {
       process.env.INTERNAL_API_URL || "https://dreamjournal-app.onrender.com"
     );
   } else {
-    // Client-side: Use NEXT_PUBLIC_API_URL if set, otherwise use default logic
+    // Client-side (browser)
+    //
+    // Vercel production: always use the same-origin /proxy/ rewrite so that
+    // auth cookies are set on the Vercel domain and sent on every subsequent
+    // request.  Direct cross-origin calls to Render break cookie auth because
+    // browsers apply SameSite restrictions and refuse to attach cookies to
+    // third-party requests.  NEXT_PUBLIC_API_URL is intentionally ignored here
+    // to prevent it from pointing the browser at Render directly.
+    if (process.env.NEXT_PUBLIC_VERCEL_ENV === "production") {
+      return "/proxy";
+    }
+
+    // Vercel preview: return empty string so requests are clearly misconfigured
+    // rather than silently hitting production data.
+    if (process.env.NEXT_PUBLIC_VERCEL_ENV === "preview") {
+      return "";
+    }
+
+    // Non-Vercel deployments (self-hosted, Docker): honour the explicit URL.
     if (process.env.NEXT_PUBLIC_API_URL) {
       return normalizeBaseUrl(process.env.NEXT_PUBLIC_API_URL);
     }
 
-    // NEXT_PUBLIC_API_URL 未設定時のフォールバック
-    // rewriteに依存しないよう本番URLを直接使う（rewriteはai-summaryの動的ルートを壊す）
-    // Vercel preview は NODE_ENV=production で動くため、production 判定だけでは不十分。
-    // preview デプロイが NEXT_PUBLIC_API_URL 未設定のまま本番 Render を叩かないよう空文字を返す。
-    if (process.env.NODE_ENV === "production") {
-      if (process.env.NEXT_PUBLIC_VERCEL_ENV === "preview") {
-        return "";
-      }
-      return "https://dreamjournal-app.onrender.com";
-    }
     return "http://localhost:3001";
   }
 }

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -12,6 +12,19 @@ const nextConfig = {
   turbopack: {
     root: __dirname,
   },
+  async rewrites() {
+    // /proxy/:path* → Render backend (same-origin proxy for auth cookies).
+    // Uses /proxy/ prefix specifically to avoid clashing with Next.js route handlers
+    // under /api/ (e.g. /api/ai-summary/[id], /api/auth/verify, /api/checkout).
+    return {
+      afterFiles: [
+        {
+          source: "/proxy/:path*",
+          destination: "https://dreamjournal-app.onrender.com/:path*",
+        },
+      ],
+    };
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary

- **Root cause**: After PR #199 removed the catch-all `/api/:path*` rewrite, client-side API calls were sent directly from the browser to `https://dreamjournal-app.onrender.com`. Browsers block cross-origin cookies (SameSite=Lax) on those requests, so every authenticated call returned 401.
- **Fix**: Add a `/proxy/:path*` afterFiles rewrite in `next.config.mjs` that transparently proxies requests to Render. The `/proxy/` prefix (not `/api/`) avoids clashing with the existing Next.js route handlers under `/api/` (ai-summary, auth/verify, checkout).
- **`api-config.ts`**: Client-side logic now checks `NEXT_PUBLIC_VERCEL_ENV === "production"` first and returns `"/proxy"`, ignoring `NEXT_PUBLIC_API_URL` to prevent dashboard config from bypassing the proxy. Preview deployments return `""` to surface misconfigurations rather than silently hitting production.

## Changed files

| File | Change |
|---|---|
| `frontend/next.config.mjs` | Added `/proxy/:path*` → Render `afterFiles` rewrite |
| `frontend/lib/api-config.ts` | Client-side: check `NEXT_PUBLIC_VERCEL_ENV` before `NEXT_PUBLIC_API_URL` |
| `frontend/__tests__/lib/api-config.test.ts` | Updated tests to match new Vercel-production → `/proxy` behavior |

## Test plan

- [x] `yarn test __tests__/lib/api-config.test.ts` — 4 tests pass
- [ ] Deploy to Vercel and verify login/dream fetch no longer returns 401
- [ ] Confirm cookies are attached on requests to `/proxy/...` in browser DevTools → Network

🤖 Generated with [Claude Code](https://claude.com/claude-code)