### PR TITLE
ux: 残っていたモルペウス表示を画像版に整える

### DIFF
--- a/frontend/app/components/DreamList.tsx
+++ b/frontend/app/components/DreamList.tsx
@@ -3,11 +3,11 @@
 import { Dream } from "@/app/types";
 import React from "react";
 import Link from "next/link";
-import Image from "next/image";
 import DreamCard from "./DreamCard";
 import { motion } from "framer-motion";
 import { Button } from "./ui/button";
 import { MorpheusGuideEmpty } from "./MorpheusGuide";
+import MorpheusImage from "./MorpheusImage";
 
 interface DreamListProps {
   dreams: Dream[];
@@ -65,13 +65,13 @@ const DreamList = ({ dreams, isSearchActive = false, ageGroup }: DreamListProps)
                   <div className="absolute -bottom-2 left-1/2 -translate-x-1/2 w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-slate-700/60" />
                 </div>
                 {/* モルペウス画像 */}
-                <Image
-                  src="/images/morpheus.png"
-                  alt="モルペウス"
-                  width={72}
-                  height={72}
-                  className="opacity-90 drop-shadow-[0_4px_12px_rgba(56,189,248,0.3)]"
-                />
+                <div className="rounded-2xl bg-white/80 p-1 shadow-sm ring-1 ring-sky-100 dark:bg-white/10 dark:ring-white/10">
+                  <MorpheusImage
+                    variant="search"
+                    size={88}
+                    className="drop-shadow-[0_8px_20px_rgba(56,189,248,0.30)]"
+                  />
+                </div>
               </div>
               <p className="text-sm text-muted-foreground mb-5">
                 べつの ことばで さがしてみよう！

--- a/frontend/app/components/DreamStatsWidget.tsx
+++ b/frontend/app/components/DreamStatsWidget.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import Image from "next/image";
 import { Dream } from "@/app/types";
 import { getChildFriendlyEmotionLabel } from "./EmotionTag";
 import { getJSTYearMonthKey } from "@/lib/date";
+import MorpheusImage from "./MorpheusImage";
 
 interface DreamStatsWidgetProps {
   dreams: Dream[];
@@ -96,17 +96,13 @@ export default function DreamStatsWidget({ dreams }: DreamStatsWidgetProps) {
 
       {/* モルペウスの今週サマリー */}
       {weekTop && (
-        <div className="flex items-center gap-2 bg-slate-800/60 dark:bg-slate-800/60 bg-slate-100 rounded-xl p-3 border border-slate-700/40 dark:border-slate-700/40 border-slate-200">
-          <Image
-            src="/images/morpheus.png"
-            alt="モルペウス"
-            width={36}
-            height={36}
-            className="opacity-90 shrink-0"
-          />
-          <p className="text-xs leading-relaxed text-slate-200 dark:text-slate-200 text-slate-700">
+        <div className="flex items-center gap-3 rounded-2xl border border-sky-200/60 bg-sky-50/80 p-3 dark:border-sky-500/20 dark:bg-slate-800/70">
+          <div className="shrink-0 rounded-xl bg-white/80 p-1 shadow-sm ring-1 ring-sky-100 dark:bg-white/10 dark:ring-white/10">
+            <MorpheusImage variant="analysis" size={54} />
+          </div>
+          <p className="text-xs leading-relaxed text-slate-700 dark:text-slate-200">
             今週いちばん多い きもちは{" "}
-            <span className="font-bold text-sky-300 dark:text-sky-300 text-sky-600">
+            <span className="font-bold text-sky-600 dark:text-sky-300">
               「{weekTop[0]}」
             </span>{" "}
             だったよ！

--- a/frontend/app/components/DreamStreakBadge.tsx
+++ b/frontend/app/components/DreamStreakBadge.tsx
@@ -2,7 +2,7 @@
 
 import { Dream } from "@/app/types";
 import { getJSTDateStr, getJSTYearMonthKey } from "@/lib/date";
-import MorpheusSVG, { type MorpheusExpression } from "./MorpheusSVG";
+import MorpheusImage, { type MorpheusImageVariant } from "./MorpheusImage";
 
 interface DreamStreakBadgeProps {
   dreams: Dream[];
@@ -61,6 +61,13 @@ function calcStreak(dreams: Dream[]): { current: number; longest: number } {
   return { current, longest };
 }
 
+function getMorpheusVariant(current: number): MorpheusImageVariant {
+  if (current === 0) return "empty";
+  if (current < 3) return "search";
+  if (current < 7) return "praise";
+  return "reward";
+}
+
 /**
  * 夢日記の連続記録バッジコンポーネント
  * ストリーク・月間カウント・バッジを表示
@@ -70,8 +77,7 @@ export default function DreamStreakBadge({ dreams }: DreamStreakBadgeProps) {
 
   const { current, longest } = calcStreak(dreams);
   const moonProgress = Math.min(current, 30) / 30;
-  const morpheusExpression: MorpheusExpression =
-    current === 0 ? "sleeping" : current < 3 ? "curious" : current < 7 ? "cheerful" : "proud";
+  const morpheusVariant = getMorpheusVariant(current);
 
   // 今月のカウント
   const currentJSTMonth = getJSTYearMonthKey(new Date());
@@ -131,8 +137,8 @@ export default function DreamStreakBadge({ dreams }: DreamStreakBadgeProps) {
               : "さいしょの 1こを かくと、月がひかりはじめるよ。"}
           </p>
         </div>
-        <div className="hidden sm:block">
-          <MorpheusSVG expression={morpheusExpression} size={68} />
+        <div className="hidden sm:block rounded-2xl bg-white/80 p-1 shadow-sm ring-1 ring-sky-100 dark:bg-white/10 dark:ring-white/10">
+          <MorpheusImage variant={morpheusVariant} size={76} />
         </div>
       </div>
 

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { clientLogin } from "@/lib/apiClient";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
-import MorpheusSmall from "@/app/components/MorpheusSmall";
+import MorpheusHero from "@/app/components/MorpheusHero";
 import { MorpheusGuideLogin } from "@/app/components/MorpheusGuide";
 
 const hiddenEmailStyle = {
@@ -74,11 +74,15 @@ export default function Login() {
   };
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-background text-foreground px-4 sm:px-6 lg:px-8">
+    <div className="flex items-center justify-center min-h-screen bg-background text-foreground px-4 sm:px-6 lg:px-8 py-8">
       <div className="w-full max-w-md">
-        <MorpheusSmall
-          message="おかえり！ゆめの世界へ ようこそ"
-          className="mb-4"
+        <MorpheusHero
+          title="おかえり！"
+          message="今日も来てくれてうれしいよ。つづきから、ゆめの世界へ入ろう。"
+          imageVariant="login"
+          variant="compose"
+          size={150}
+          className="mb-5"
         />
       <form
         onSubmit={handleSubmit}


### PR DESCRIPTION
## 概要

PR #212 後の画面確認で、まだ一部に旧 `morpheus.png` / `MorpheusSVG` が残っていたため、追加で整えます。

あわせて、ログイン画面のモルペウスが小さく見えていたため、ログイン上部を小型ガイドから大きめの `MorpheusHero` に変更し、見栄えを改善しました。

## 変更内容

- `login/page.tsx`
  - `MorpheusSmall` を廃止し、上部に `MorpheusHero` を配置
  - `imageVariant="login"`、`size={150}` でモルペウスを大きく表示
  - ログインフォーム前の導入感を強化

- `DreamStatsWidget.tsx`
  - 「今週いちばん多い きもち」内の旧 `/images/morpheus.png` を削除
  - `MorpheusImage variant="analysis"` に変更
  - 背景と余白も画像版に馴染むように調整

- `DreamStreakBadge.tsx`
  - 「きろく」カード内の `MorpheusSVG` を削除
  - 連続日数に応じて `empty / search / praise / reward` を切り替える `MorpheusImage` に変更

## 確認ポイント

- `/login` で上部モルペウスが以前より大きく、見栄えよく表示されること
- `/home` サイドバーの「今月のきもち」下部が旧 `morpheus.png` ではなく画像版になること
- `/home` サイドバーの「きろく」カードが旧SVGではなく画像版になること
- 画像がない場合でも `MorpheusImage` 側のフォールバックでUIが壊れないこと

## 補足

今回の修正では新しい画像ファイルは追加していません。PR #212 で追加した10枚構成をそのまま利用します。