### PR TITLE
fix: Rails 8.0 enum deprecation warning を解消

### DIFF
--- a/backend/app/models/dream.rb
+++ b/backend/app/models/dream.rb
@@ -9,7 +9,7 @@ class Dream < ApplicationRecord
   validates :content, presence: true, length: { maximum: 1000 }
 
   # analysis_status カラムを enum として定義し、メソッド名の衝突を避けるためにプレフィックスを付けます
-  enum analysis_status: { pending: 'pending', done: 'done', failed: 'failed' }, _prefix: :analysis
+  enum :analysis_status, { pending: 'pending', done: 'done', failed: 'failed' }, prefix: :analysis
 
   # よく使うクエリパターンをスコープとして定義する
   # current_user.dreams.with_image のように使う


### PR DESCRIPTION
## 概要
- `Dream` モデルの `analysis_status` enum 定義をRails 8.0対応のポジショナル引数形式へ変更しました
- enumのプレフィックス指定を旧形式の `_prefix:` から新形式の `prefix:` に変更しました

## 変更内容
```ruby
# before
enum analysis_status: { pending: 'pending', done: 'done', failed: 'failed' }, _prefix: :analysis

# after
enum :analysis_status, { pending: 'pending', done: 'done', failed: 'failed' }, prefix: :analysis
```

## 確認
- `ruby -c backend/app/models/dream.rb` 相当の構文チェック: `Syntax OK`

## 補足
- 同ファイル内の enum 定義は `analysis_status` のみでした
- 変更範囲は `backend/app/models/dream.rb` の1行のみです