### PR TITLE
feat: パスワード強度インジケーターを登録フォームに追加

### DIFF
--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -200,9 +200,24 @@ export default function Register() {
                 {showPassword ? "🙈" : "👁"}
               </button>
             </div>
-            <p id="password-hint" className="text-xs text-muted-foreground mt-1 ml-1">
-              8文字以上・英字と数字をそれぞれ含む
-            </p>
+            {password.length > 0 ? (
+              <ul id="password-hint" className="mt-2 ml-1 space-y-1 text-xs" aria-label="パスワードの条件">
+                {[
+                  { ok: password.length >= 8, label: "8もじ いじょう" },
+                  { ok: /[a-zA-Z]/.test(password), label: "えいじ（a〜z）を ふくむ" },
+                  { ok: /[0-9]/.test(password), label: "すうじ（0〜9）を ふくむ" },
+                ].map(({ ok, label }) => (
+                  <li key={label} className={`flex items-center gap-1.5 transition-colors ${ok ? "text-green-500" : "text-muted-foreground"}`}>
+                    <span aria-hidden="true" className="font-bold">{ok ? "✓" : "○"}</span>
+                    {label}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p id="password-hint" className="text-xs text-muted-foreground mt-1 ml-1">
+                8文字以上・英字と数字をそれぞれ含む
+              </p>
+            )}
           </div>
           <div>
             <label


### PR DESCRIPTION
## Summary

- 登録フォームのパスワード入力欄に、条件をリアルタイムで表示するチェックリストを追加
- 1文字入力した時点から表示開始（空欄時は従来の静的ヒント文を表示）
- 3条件を満たすと ○(グレー) → ✓(グリーン) に変化

| 条件 | 表示 |
|---|---|
| 8もじ いじょう | ○ → ✓ |
| えいじ（a〜z）を ふくむ | ○ → ✓ |
| すうじ（0〜9）を ふくむ | ○ → ✓ |

## 実装の特徴
- 新しい state・import・ライブラリは一切不要
- 既存の `password` state から条件を派生させるだけ
- `transition-colors` で滑らかに色が変わる
- `aria-label` で読み上げ対応済み

## Test plan
- [ ] 登録フォームを開き、パスワード欄に1文字入力するとチェックリストが表示される
- [ ] 8文字以上で1つ目が緑になる
- [ ] 英字を入れると2つ目が緑になる
- [ ] 数字を入れると3つ目が緑になる
- [ ] パスワードを全部消すと静的ヒント文に戻る