### PR TITLE
chore: Dependabot 設定を追加（npm / bundler / GitHub Actions）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+updates:
+  # フロントエンド（Next.js / npm）
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+    groups:
+      react-ecosystem:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react*"
+      next:
+        patterns:
+          - "next"
+
+  # バックエンド（Rails / Bundler）
+  - package-ecosystem: "bundler"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary

`.github/dependabot.yml` を追加し、3つのエコシステムで依存関係の自動更新PRを有効化します。

| エコシステム | 対象 | 頻度 | グループ化 |
|---|---|---|---|
| npm | `/frontend` | 毎週月曜 09:00 JST | React系・Nextをまとめる |
| bundler | `/backend` | 毎週月曜 09:00 JST | なし |
| github-actions | `/` | 毎月月曜 09:00 JST | なし |

## 設定の補足
- `open-pull-requests-limit: 5` — PRが溜まりすぎないよう上限設定
- `labels` — `dependencies` + `frontend/backend/github-actions` でフィルタリング可能
- React と Next.js はグループ化してPR数を削減

## Test plan
- [ ] マージ後、GitHub リポジトリの Insights → Dependency graph → Dependabot で設定が認識されるか確認
- [ ] 翌週月曜以降に依存関係の更新PRが自動で来ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)