### PR TITLE
fix: 画像スタイルを油絵→クリーンデジタルイラストに変更・詳細画面モルペウスを右下に移動

### DIFF
--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -333,11 +333,12 @@ class DreamsController < ApplicationController
     def build_image_prompt(content, analysis)
       style = image_style_for_age_group(@current_user&.age_group)
       parts = []
-      parts << "Create a beautiful, peaceful, and wonder-filled dreamscape illustration. #{style}"
+      parts << "Create a beautiful, peaceful, and wonder-filled dream illustration for a children-friendly dream journal app. #{style}"
       parts << "Dream content: #{content.truncate(300)}"
       parts << "Emotional theme: #{analysis.truncate(100)}" if analysis.present?
       parts << "Focus the composition on ONE specific memorable detail from this dream — a unique object, person, landscape, or magical moment. Let the colors and lighting reflect the emotional mood of this exact dream rather than a generic dream template."
       parts << "Any dark, scary, or intense elements must be transformed into soft, symbolic, and poetic visual metaphors — never literal horror. The final image must feel safe, comforting, and age-appropriate. No threatening faces, no gore, no dark shadows. Mood: gentle and magical."
+      parts << "Art style requirements: clean digital illustration only — flat or semi-flat, clear outlines, bright warm colors, simple readable composition that works well on a smartphone screen. Avoid: oil painting, painterly texture, heavy brush strokes, watercolor wash, impressionist or expressionist style, photo-realism."
       parts << "No text or letters."
       parts.join(" ").truncate(900)
     end
@@ -345,15 +346,15 @@ class DreamsController < ApplicationController
     def image_style_for_age_group(age_group)
       case age_group
       when "child_small", "child"
-        "Soft watercolor style, pastel colors, child-friendly, gentle and peaceful atmosphere."
+        "Clean digital illustration, soft pastel colors, simple rounded shapes, child-friendly and cheerful."
       when "preteen"
-        "Colorful storybook illustration style, slightly adventurous, vivid but friendly colors."
+        "Clean digital illustration, colorful and vivid, slightly adventurous, friendly and energetic."
       when "teen"
-        "Stylized digital art, cinematic lighting, vivid colors, cool and dramatic dreamlike mood."
+        "Clean digital illustration, dynamic composition, vivid colors, cool and stylish dreamlike mood."
       when "adult"
-        "Surrealist oil painting style, rich detail, deep colors, sophisticated and dreamlike atmosphere."
+        "Clean digital illustration, detailed but clear outlines, warm sophisticated tones, elegant and dreamlike."
       else
-        "Soft watercolor style, gentle colors, peaceful dreamlike atmosphere."
+        "Clean digital illustration, soft warm colors, simple and clear composition, pleasant dreamlike mood."
       end
     end
 

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -722,7 +722,7 @@ RSpec.describe 'Dreams API', type: :request do
 
         context 'child ユーザー' do
           let(:age_user) { create(:user, age_group: 'child') }
-          include_examples 'プロンプトにスタイルが含まれる', 'watercolor'
+          include_examples 'プロンプトにスタイルが含まれる', 'pastel colors'
         end
 
         context 'child_small ユーザー' do
@@ -732,22 +732,22 @@ RSpec.describe 'Dreams API', type: :request do
 
         context 'preteen ユーザー' do
           let(:age_user) { create(:user, age_group: 'preteen') }
-          include_examples 'プロンプトにスタイルが含まれる', 'storybook'
+          include_examples 'プロンプトにスタイルが含まれる', 'adventurous'
         end
 
         context 'teen ユーザー' do
           let(:age_user) { create(:user, age_group: 'teen') }
-          include_examples 'プロンプトにスタイルが含まれる', 'cinematic'
+          include_examples 'プロンプトにスタイルが含まれる', 'cool and stylish'
         end
 
         context 'adult ユーザー' do
           let(:age_user) { create(:user, age_group: 'adult') }
-          include_examples 'プロンプトにスタイルが含まれる', 'Surrealist'
+          include_examples 'プロンプトにスタイルが含まれる', 'sophisticated'
         end
 
         context 'age_group がデフォルト（child）のユーザー' do
           let(:age_user) { create(:user) }
-          include_examples 'プロンプトにスタイルが含まれる', 'watercolor'
+          include_examples 'プロンプトにスタイルが含まれる', 'pleasant'
         end
       end
     end

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -747,7 +747,7 @@ RSpec.describe 'Dreams API', type: :request do
 
         context 'age_group がデフォルト（child）のユーザー' do
           let(:age_user) { create(:user) }
-          include_examples 'プロンプトにスタイルが含まれる', 'pleasant'
+          include_examples 'プロンプトにスタイルが含まれる', 'child-friendly'
         end
       end
     end

--- a/frontend/app/components/MorpheusGuide.tsx
+++ b/frontend/app/components/MorpheusGuide.tsx
@@ -164,8 +164,8 @@ export function MorpheusGuideDetail() {
       imageVariant="reward"
       title="すてきな夢だね。"
       message="ちゃんと記録できてえらいよ。分析結果も見てみてね。"
-      size={118}
-      positionClassName="bottom-6 left-4 sm:bottom-10 sm:left-8"
+      size={140}
+      positionClassName="bottom-6 right-4 sm:bottom-10 sm:right-8"
     />
   );
 }


### PR DESCRIPTION
## 問題の原因

`image_style_for_age_group` メソッドに直接油絵・水彩スタイルが書かれていた。

| 年齢グループ | 修正前 | 修正後 |
|---|---|---|
| child/child_small | Soft watercolor style | Clean digital illustration, soft pastel colors |
| preteen | Colorful storybook illustration | Clean digital illustration, colorful and vivid |
| teen | Stylized digital art | Clean digital illustration, dynamic composition |
| **adult** | **Surrealist oil painting style** ← 原因 | Clean digital illustration, warm sophisticated tones |
| default | Soft watercolor style | Clean digital illustration, soft warm colors |

## 変更内容

### backend/app/controllers/dreams_controller.rb
- 全年齢グループのスタイルを `Clean digital illustration` ベースに統一
- `build_image_prompt` に明示的な回避指示を追加：
  `Avoid: oil painting, painterly texture, heavy brush strokes, watercolor wash, impressionist or expressionist style`
- スマホ画面で見やすい構図を要求する指示を追加

### frontend/app/components/MorpheusGuide.tsx
- `MorpheusGuideDetail` の位置を `left-4` → `right-4`（他画面と統一）
- サイズを 118px → 140px に拡大

## API モデルの現状確認（変更なし）

| 用途 | モデル | 評価 |
|---|---|---|
| 夢分析テキスト | gpt-4o-mini | ✅ コスパ最良 |
| 月次サマリー | gpt-4o-mini | ✅ |
| 音声文字起こし | whisper-1 | ✅ 現役 |
| 画像生成 | gpt-image-1 | ✅ 最新 |

モデルは全て適切。問題はプロンプトの指示内容のみ。

## Test plan
- [ ] 成人ユーザーで夢の絵を生成し、油絵・水彩ではなくデジタルイラスト風になること
- [ ] 子どもユーザーで生成し、パステル調のシンプルなイラストになること
- [ ] 詳細画面でモルペウスが右下に表示される
- [ ] モルペウスのサイズが以前より大きく見える

🤖 Generated with [Claude Code](https://claude.com/claude-code)