### PR TITLE
feat: パスワード強度バーを登録フォームに追加

### DIFF
--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -16,6 +16,20 @@ const hiddenEmailStyle = {
 const defaultRegisterError =
   "うまく はじめられなかったよ。もういちど ためしてね。";
 
+function getPasswordStrength(pw: string): { level: 1 | 2 | 3 | null; label: string; color: string } {
+  if (pw.length < 8) return { level: null, label: "", color: "" };
+  const hasLetter = /[a-zA-Z]/.test(pw);
+  const hasNumber = /[0-9]/.test(pw);
+  const hasSymbol = /[!@#$%^&*()\-_=+[\]{};':",.<>/?\\|]/.test(pw);
+  if (hasLetter && hasNumber && (hasSymbol || pw.length >= 12)) {
+    return { level: 3, label: "強い", color: "bg-green-500" };
+  }
+  if (hasLetter && hasNumber) {
+    return { level: 2, label: "普通", color: "bg-yellow-400" };
+  }
+  return { level: 1, label: "弱い", color: "bg-red-400" };
+}
+
 export default function Register() {
   const [email, setEmail] = useState("");
   const [showEmail, setShowEmail] = useState(true);
@@ -200,6 +214,27 @@ export default function Register() {
                 {showPassword ? "🙈" : "👁"}
               </button>
             </div>
+            {password.length >= 8 && (() => {
+              const strength = getPasswordStrength(password);
+              return strength.level ? (
+                <div className="mt-2 flex items-center gap-2" aria-live="polite">
+                  <div className="flex flex-1 gap-1">
+                    {([1, 2, 3] as const).map((seg) => (
+                      <div
+                        key={seg}
+                        className={`h-1.5 flex-1 rounded-full transition-colors duration-300 ${
+                          strength.level! >= seg ? strength.color : "bg-muted"
+                        }`}
+                      />
+                    ))}
+                  </div>
+                  <span className={`text-xs font-medium ${
+                    strength.level === 3 ? "text-green-500" :
+                    strength.level === 2 ? "text-yellow-500" : "text-red-400"
+                  }`}>{strength.label}</span>
+                </div>
+              ) : null;
+            })()}
             {password.length > 0 ? (
               <ul id="password-hint" className="mt-2 ml-1 space-y-1 text-xs" aria-label="パスワードの条件">
                 {[


### PR DESCRIPTION
## Summary
- 既存の条件チェックリスト（✓/○）に加えて、3段階の色付き強度バーを追加
- 8文字に達した時点でバーが表示される
  - 🔴 弱い: 8文字以上のみ
  - 🟡 普通: 英字 + 数字あり
  - 🟢 強い: 英字 + 数字 + 記号あり、または12文字以上

## Changes
- `frontend/app/register/page.tsx`: `getPasswordStrength` 関数を追加、入力欄直下に3セグメントバーを表示

## Test plan
- [ ] パスワード未入力時はバー非表示
- [ ] 8文字未満はバー非表示
- [ ] 8文字以上・英字のみ → 赤バー「弱い」
- [ ] 英字＋数字 → 黄バー「普通」
- [ ] 英字＋数字＋記号 → 緑バー「強い」
- [ ] Jest / Playwright CI 通過