### PR TITLE
feat: Trial導線改善 + E2Eテスト追加（登録・トライアルフロー）

### DIFF
--- a/frontend/app/trial/page.tsx
+++ b/frontend/app/trial/page.tsx
@@ -15,6 +15,7 @@ type AnalysisResult = {
 };
 
 const MAX_TRIAL_DREAMS = 7;
+const MAX_TRIAL_ANALYSES = 3;
 
 export default function TrialPage() {
   const { authStatus, login } = useAuth();
@@ -32,6 +33,8 @@ export default function TrialPage() {
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [analysisError, setAnalysisError] = useState("");
+  const [analysisCount, setAnalysisCount] = useState(0);
+  const [analysisLimitReached, setAnalysisLimitReached] = useState(false);
 
   // checking中はボタンを無効化するためのフラグ
   const isAuthChecking = authStatus === "checking";
@@ -105,15 +108,15 @@ export default function TrialPage() {
           analysis: result,
         },
       ]);
+      setAnalysisCount((prev) => prev + 1);
       setTitle("");
       setDescription("");
     } catch (err: unknown) {
       const message =
         err instanceof Error ? err.message : "分析に失敗しました";
       if (message.includes("分析上限")) {
-        setAnalysisError(
-          "おためしの ぶんせきは ここまでだよ。とうろくすると もっと つかえるよ！"
-        );
+        setAnalysisLimitReached(true);
+        setAnalysisError("");
       } else {
         setAnalysisError("ぶんせきに しっぱい しちゃった。もういちど ためしてね。");
       }
@@ -190,7 +193,7 @@ export default function TrialPage() {
           <p className="text-sm text-amber-400 mb-3">{analysisError}</p>
         )}
 
-        <div className="flex flex-col sm:flex-row gap-3">
+        <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center">
           {/* メインCTA: AI分析 */}
           <button
             type="button"
@@ -198,6 +201,7 @@ export default function TrialPage() {
             disabled={
               isAnalyzing ||
               isAuthChecking ||
+              analysisLimitReached ||
               dreams.length >= MAX_TRIAL_DREAMS ||
               !description.trim()
             }
@@ -241,6 +245,16 @@ export default function TrialPage() {
           >
             かくだけ（ぶんせきなし）
           </button>
+
+          {/* 残り回数バッジ */}
+          {!analysisLimitReached && (
+            <span className="text-xs text-slate-400 sm:ml-1">
+              残りAI分析:{" "}
+              <span className={`font-bold ${MAX_TRIAL_ANALYSES - analysisCount <= 1 ? "text-amber-400" : "text-sky-400"}`}>
+                {Math.max(0, MAX_TRIAL_ANALYSES - analysisCount)}回
+              </span>
+            </span>
+          )}
         </div>
       </div>
 
@@ -297,6 +311,32 @@ export default function TrialPage() {
         )}
       </div>
 
+      {/* 分析上限到達時のアップグレードカード */}
+      {analysisLimitReached && (
+        <div className="mb-6 p-5 bg-gradient-to-br from-sky-900/50 to-blue-900/50 border border-sky-500/40 rounded-2xl text-center shadow-lg shadow-sky-500/10">
+          <p className="text-base font-bold text-white mb-1">
+            おためし ぶんせきを つかいきったよ！
+          </p>
+          <p className="text-sm text-sky-200 mb-4">
+            とうろくすると、ぶんせきが ずっと つかえるよ。
+          </p>
+          <Link
+            href="/register"
+            className="
+              inline-flex items-center gap-2 px-7 py-3
+              bg-gradient-to-r from-sky-500 to-blue-600
+              hover:from-sky-400 hover:to-blue-500
+              text-white font-bold text-sm rounded-xl
+              shadow-lg shadow-sky-500/30
+              transition-all duration-200
+            "
+          >
+            <Sparkles size={16} />
+            いますぐ とうろくする
+          </Link>
+        </div>
+      )}
+
       {/* 注意書き + 登録CTA */}
       <div className="p-4 bg-slate-800/30 border border-slate-700/30 rounded-2xl text-center">
         <p className="text-sm text-slate-400 mb-1">
@@ -309,9 +349,10 @@ export default function TrialPage() {
           href="/register"
           className="
             inline-flex items-center gap-2 px-6 py-2.5
-            bg-slate-700/50 hover:bg-slate-700/70
-            text-slate-200 font-bold text-sm rounded-xl
-            border border-slate-600/40 hover:border-sky-500/40
+            bg-gradient-to-r from-violet-500 to-purple-600
+            hover:from-violet-400 hover:to-purple-500
+            text-white font-bold text-sm rounded-xl
+            shadow-lg shadow-violet-500/20
             transition-all duration-200
           "
         >

--- a/frontend/e2e/registration-flow.spec.ts
+++ b/frontend/e2e/registration-flow.spec.ts
@@ -1,0 +1,180 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("ユーザー登録フロー", () => {
+  test.beforeEach(async ({ page }) => {
+    // 未認証状態をモック（登録ページへのリダイレクトを防ぐ）
+    await page.route("**/auth/verify", async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Unauthorized" }),
+      });
+    });
+  });
+
+  test("登録フォームが表示される", async ({ page }) => {
+    await page.goto("/register");
+
+    await expect(page.locator("#register-username")).toBeVisible();
+    await expect(page.locator("#register-email")).toBeVisible();
+    await expect(page.locator("#register-password")).toBeVisible();
+    await expect(page.locator("#register-password-confirmation")).toBeVisible();
+    await expect(page.getByRole("button", { name: "はじめる" })).toBeVisible();
+  });
+
+  test("パスワード強度バー：8文字未満では非表示", async ({ page }) => {
+    await page.goto("/register");
+
+    await page.locator("#register-password").fill("abc1");
+    await expect(page.getByText("弱い")).not.toBeVisible();
+    await expect(page.getByText("普通")).not.toBeVisible();
+    await expect(page.getByText("強い")).not.toBeVisible();
+  });
+
+  test("パスワード強度バー：英字のみ8文字以上は「弱い」", async ({ page }) => {
+    await page.goto("/register");
+
+    await page.locator("#register-password").fill("abcdefgh");
+    await expect(page.getByText("弱い")).toBeVisible();
+  });
+
+  test("パスワード強度バー：英字+数字は「普通」", async ({ page }) => {
+    await page.goto("/register");
+
+    await page.locator("#register-password").fill("abcdef12");
+    await expect(page.getByText("普通")).toBeVisible();
+  });
+
+  test("パスワード強度バー：英字+数字+記号は「強い」", async ({ page }) => {
+    await page.goto("/register");
+
+    await page.locator("#register-password").fill("abcdef1!");
+    await expect(page.getByText("強い")).toBeVisible();
+  });
+
+  test("パスワード強度バー：12文字以上の英字+数字は「強い」", async ({ page }) => {
+    await page.goto("/register");
+
+    await page.locator("#register-password").fill("abcdefgh1234");
+    await expect(page.getByText("強い")).toBeVisible();
+  });
+
+  test("パスワード条件チェックリストが表示される", async ({ page }) => {
+    await page.goto("/register");
+
+    await page.locator("#register-password").fill("a");
+
+    await expect(page.getByText("8もじ いじょう")).toBeVisible();
+    await expect(page.getByText("えいじ（a〜z）を ふくむ")).toBeVisible();
+    await expect(page.getByText("すうじ（0〜9）を ふくむ")).toBeVisible();
+  });
+
+  test("空フィールドで送信するとエラーが表示される", async ({ page }) => {
+    await page.goto("/register");
+
+    await page.getByRole("button", { name: "はじめる" }).click();
+
+    await expect(page.locator("#error-message")).toContainText(
+      "まだ はいっていない ところが あるよ"
+    );
+  });
+
+  test("利用規約に同意しないと送信できない", async ({ page }) => {
+    await page.goto("/register");
+
+    await page.locator("#register-username").fill("testuser");
+    await page.locator("#register-email").fill("test@example.com");
+    await page.locator("#register-password").fill("Password1");
+    await page.locator("#register-password-confirmation").fill("Password1");
+    // 利用規約チェックボックスには触れない
+
+    await page.getByRole("button", { name: "はじめる" }).click();
+
+    await expect(page.locator("#error-message")).toContainText(
+      "はじめる まえに、きまりを たしかめてね"
+    );
+  });
+
+  test("パスワード不一致のときエラーが表示される", async ({ page }) => {
+    await page.goto("/register");
+
+    await page.locator("#register-username").fill("testuser");
+    await page.locator("#register-email").fill("test@example.com");
+    await page.locator("#register-password").fill("Password1");
+    await page.locator("#register-password-confirmation").fill("DifferentPass1");
+    await page.getByRole("checkbox").check();
+
+    await page.getByRole("button", { name: "はじめる" }).click();
+
+    await expect(page.locator("#error-message")).toContainText(
+      "パスワードが ちがっているみたい"
+    );
+  });
+
+  test("不正なメールアドレス形式のときエラーが表示される", async ({ page }) => {
+    await page.goto("/register");
+
+    await page.locator("#register-username").fill("testuser");
+    await page.locator("#register-email").fill("not-an-email");
+    await page.locator("#register-password").fill("Password1");
+    await page.locator("#register-password-confirmation").fill("Password1");
+    await page.getByRole("checkbox").check();
+
+    await page.getByRole("button", { name: "はじめる" }).click();
+
+    await expect(page.locator("#error-message")).toContainText(
+      "メールアドレスの かたちを もういちど"
+    );
+  });
+
+  test("登録成功でホームページに遷移する", async ({ page }) => {
+    await page.route("**/auth/register", async (route) => {
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          user: { id: 1, email: "new@example.com", username: "newuser" },
+        }),
+      });
+    });
+
+    // 登録後の認証検証（登録直後のリダイレクト先 /home で verify が呼ばれる）
+    await page.route("**/auth/verify", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          user: { id: 1, email: "new@example.com", username: "newuser" },
+        }),
+      });
+    });
+
+    // 夢一覧と感情マスターをモック（/home ページで呼ばれる）
+    await page.route("**/dreams**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+    await page.route("**/emotions", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.goto("/register");
+
+    await page.locator("#register-username").fill("newuser");
+    await page.locator("#register-email").fill("new@example.com");
+    await page.locator("#register-password").fill("Password1");
+    await page.locator("#register-password-confirmation").fill("Password1");
+    await page.getByRole("checkbox").check();
+
+    await page.getByRole("button", { name: "はじめる" }).click();
+
+    await expect(page).toHaveURL("/home");
+  });
+});

--- a/frontend/e2e/trial-flow.spec.ts
+++ b/frontend/e2e/trial-flow.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect } from "@playwright/test";
+
+const MOCK_ANALYSIS = {
+  analysis: "空を飛ぶ夢は、自由への願望や解放感を象徴しています。",
+  emotion_tags: ["自由", "希望"],
+};
+
+test.describe("トライアルページ：お試し体験フロー", () => {
+  test.beforeEach(async ({ page }) => {
+    // 未認証状態をモック
+    await page.route("**/auth/verify", async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Unauthorized" }),
+      });
+    });
+  });
+
+  test("ページが表示され残りAI分析回数バッジが初期3回を示す", async ({
+    page,
+  }) => {
+    await page.goto("/trial");
+
+    await expect(page.getByRole("heading", { name: "お試し体験" })).toBeVisible();
+    await expect(page.getByText("残りAI分析:")).toBeVisible();
+    await expect(page.getByText("3回")).toBeVisible();
+  });
+
+  test("説明なしでAIボタンを押すとエラーが表示される", async ({ page }) => {
+    await page.goto("/trial");
+
+    await page.getByRole("button", { name: "AIにきいてみる" }).click();
+
+    await expect(
+      page.getByText("ゆめの おはなしを かいてね")
+    ).toBeVisible();
+  });
+
+  test("AI分析が成功すると夢リストに追加され残り回数が減る", async ({
+    page,
+  }) => {
+    // トライアルログインをモック
+    await page.route("**/auth/trial_login", async (route) => {
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          user: { id: 99, email: "trial_test@example.com", username: "trial_99" },
+        }),
+      });
+    });
+
+    // AI分析をモック
+    await page.route("**/dreams/preview_analysis", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_ANALYSIS),
+      });
+    });
+
+    await page.goto("/trial");
+
+    await page.locator("#title").fill("空を飛ぶ夢");
+    await page.locator("#description").fill("大空を自由に飛んでいた。");
+
+    await page.getByRole("button", { name: "AIにきいてみる" }).click();
+
+    // 分析結果が表示される
+    await expect(page.getByText("モルペウスの分析")).toBeVisible();
+    await expect(
+      page.getByText("空を飛ぶ夢は、自由への願望や解放感を象徴しています。")
+    ).toBeVisible();
+    await expect(page.getByText("自由")).toBeVisible();
+
+    // 夢リストが1件になる
+    await expect(page.getByText("かいた ゆめ (1/7)")).toBeVisible();
+
+    // 残り回数が2回になる
+    await expect(page.getByText("2回")).toBeVisible();
+  });
+
+  test("分析3回後にアップグレードカードが表示される", async ({ page }) => {
+    await page.route("**/auth/trial_login", async (route) => {
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          user: { id: 99, email: "trial_test@example.com", username: "trial_99" },
+        }),
+      });
+    });
+
+    let analysisCallCount = 0;
+    await page.route("**/dreams/preview_analysis", async (route) => {
+      analysisCallCount++;
+      if (analysisCallCount > 3) {
+        // バックエンドが上限エラーを返す
+        await route.fulfill({
+          status: 403,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "分析上限に達しました" }),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(MOCK_ANALYSIS),
+        });
+      }
+    });
+
+    await page.goto("/trial");
+
+    // 3回分析を実行する
+    for (let i = 1; i <= 3; i++) {
+      await page.locator("#description").fill(`ゆめ ${i} の内容`);
+      await page.getByRole("button", { name: "AIにきいてみる" }).click();
+      await expect(page.getByText("かいた ゆめ")).toBeVisible();
+    }
+
+    // 4回目でバックエンドが上限エラーを返す
+    await page.locator("#description").fill("4回目のゆめ");
+    await page.getByRole("button", { name: "AIにきいてみる" }).click();
+
+    // アップグレードカードが表示される
+    await expect(
+      page.getByText("おためし ぶんせきを つかいきったよ！")
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /いますぐ とうろくする/ })
+    ).toBeVisible();
+  });
+
+  test("アップグレードカードの登録リンクが /register に遷移する", async ({
+    page,
+  }) => {
+    await page.route("**/auth/trial_login", async (route) => {
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          user: { id: 99, email: "trial_test@example.com", username: "trial_99" },
+        }),
+      });
+    });
+
+    await page.route("**/dreams/preview_analysis", async (route) => {
+      await route.fulfill({
+        status: 403,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "分析上限に達しました" }),
+      });
+    });
+
+    await page.goto("/trial");
+
+    await page.locator("#description").fill("ゆめの内容");
+    await page.getByRole("button", { name: "AIにきいてみる" }).click();
+
+    const registerLink = page.getByRole("link", { name: /いますぐ とうろくする/ });
+    await expect(registerLink).toBeVisible();
+    await expect(registerLink).toHaveAttribute("href", "/register");
+  });
+
+  test("下部の登録CTAボタンが /register に遷移する", async ({ page }) => {
+    await page.goto("/trial");
+
+    const ctaLink = page.getByRole("link", { name: "とうろくして ずっと のこす" });
+    await expect(ctaLink).toBeVisible();
+    await expect(ctaLink).toHaveAttribute("href", "/register");
+  });
+
+  test("分析なしで記録だけできる", async ({ page }) => {
+    await page.goto("/trial");
+
+    await page.locator("#title").fill("タイトルだけ");
+    await page.locator("#description").fill("内容を書いた");
+
+    await page.getByRole("button", { name: "かくだけ（ぶんせきなし）" }).click();
+
+    await expect(page.getByText("かいた ゆめ (1/7)")).toBeVisible();
+    await expect(page.getByText("タイトルだけ")).toBeVisible();
+    // AI分析結果は表示されない
+    await expect(page.getByText("モルペウスの分析")).not.toBeVisible();
+  });
+});

--- a/frontend/e2e/trial-flow.spec.ts
+++ b/frontend/e2e/trial-flow.spec.ts
@@ -27,14 +27,12 @@ test.describe("トライアルページ：お試し体験フロー", () => {
     await expect(page.getByText("3回")).toBeVisible();
   });
 
-  test("説明なしでAIボタンを押すとエラーが表示される", async ({ page }) => {
+  test("説明なしではAIボタンが無効になる", async ({ page }) => {
     await page.goto("/trial");
 
-    await page.getByRole("button", { name: "AIにきいてみる" }).click();
-
     await expect(
-      page.getByText("ゆめの おはなしを かいてね")
-    ).toBeVisible();
+      page.getByRole("button", { name: "AIにきいてみる" })
+    ).toBeDisabled();
   });
 
   test("AI分析が成功すると夢リストに追加され残り回数が減る", async ({
@@ -72,7 +70,7 @@ test.describe("トライアルページ：お試し体験フロー", () => {
     await expect(
       page.getByText("空を飛ぶ夢は、自由への願望や解放感を象徴しています。")
     ).toBeVisible();
-    await expect(page.getByText("自由")).toBeVisible();
+    await expect(page.getByText("自由", { exact: true })).toBeVisible();
 
     // 夢リストが1件になる
     await expect(page.getByText("かいた ゆめ (1/7)")).toBeVisible();
@@ -117,7 +115,7 @@ test.describe("トライアルページ：お試し体験フロー", () => {
     for (let i = 1; i <= 3; i++) {
       await page.locator("#description").fill(`ゆめ ${i} の内容`);
       await page.getByRole("button", { name: "AIにきいてみる" }).click();
-      await expect(page.getByText("かいた ゆめ")).toBeVisible();
+      await expect(page.getByText(`かいた ゆめ (${i}/7)`)).toBeVisible();
     }
 
     // 4回目でバックエンドが上限エラーを返す


### PR DESCRIPTION
## Summary

- **Trial導線改善**: 残りAI分析回数バッジ、上限到達時のアップグレードカード、登録CTAのグラデーション化
- **E2Eテスト追加**: 登録フロー（パスワード強度バーを含む）とトライアルフローをカバー

## 変更内容

### `frontend/app/trial/page.tsx`
- `MAX_TRIAL_ANALYSES = 3` 定数を追加（`MAX_TRIAL_DREAMS` とは別管理）
- `analysisCount` / `analysisLimitReached` state を追加
- ボタン行に「残りAI分析: ○回」バッジを表示（残り1回でアンバー色）
- AI上限到達時にスカイ系グラデーションのアップグレードカードを表示
- 下部登録CTAをバイオレット系グラデーションに変更

### `frontend/e2e/registration-flow.spec.ts` (新規)
- パスワード強度バー（弱い/普通/強い/12文字以上）の動作確認
- バリデーションエラー（空フィールド・利用規約未同意・パスワード不一致・不正メール）
- 登録成功 → `/home` 遷移

### `frontend/e2e/trial-flow.spec.ts` (新規)
- 初期表示（残り3回バッジ）
- AI分析成功フロー（夢追加・回数デクリメント）
- 上限到達時のアップグレードカード表示
- 分析なし記録フロー

## Test plan
- [ ] CI（ESLint / TypeScript / Jest）がパスすること
- [ ] E2Eテストがローカルで通ること（`yarn e2e`）