### PR TITLE
fix(deps): postcss を resolutions で 8.5.13 に強制アップグレード（Dependabot #135）

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -83,6 +83,7 @@
     "js-yaml": "^4.1.1",
     "minimatch": "^10.2.4",
     "picomatch": "^4.0.4",
+    "postcss": "^8.5.13",
     "test-exclude": "^7.0.1",
     "rollup": "^4.59.0",
     "flatted": "^3.4.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2781,7 +2781,7 @@ anymatch@^3.1.3:
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
   dependencies:
     normalize-path "^3.0.0"
-    picomatch "^4.0.4"
+    picomatch "^2.0.4"
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -5110,7 +5110,7 @@ ms@^2.1.3:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.11, nanoid@^3.3.6:
+nanoid@^3.3.11:
   version "3.3.11"
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
@@ -5408,16 +5408,7 @@ postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.31:
-  version "8.4.31"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz"
-  integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
-  dependencies:
-    nanoid "^3.3.6"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
-postcss@^8.5.13, postcss@^8.5.6:
+postcss@8.4.31, postcss@^8.5.13, postcss@^8.5.6:
   version "8.5.13"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.13.tgz#6cfaf647f2e7ef69850208eccd849e0d3f65d420"
   integrity sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==
@@ -5876,7 +5867,7 @@ slash@^3.0.0:
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-source-map-js@^1.0.2, source-map-js@^1.2.1:
+source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==


### PR DESCRIPTION
## Summary

- Next.js がトランジティブに持ち込む `postcss@8.4.31` に XSS 脆弱性（Dependabot alert #135 / medium）が残存していた
- `frontend/package.json` の `resolutions` に `"postcss": "^8.5.13"` を追加して全インスタンスを安全バージョンに固定
- `yarn.lock` の `postcss@8.4.31` エントリが `8.5.13` に解決されたことを確認済み
- `yarn check:resolutions` パス確認済み

## Test plan

- [ ] CI（Jest / Playwright / RSpec）がすべて pass すること
- [ ] `yarn check:resolutions` が pass すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)