### PR TITLE
ux: Trial上限到達時のアップグレード導線を強化

### DIFF
--- a/frontend/app/trial/page.tsx
+++ b/frontend/app/trial/page.tsx
@@ -317,9 +317,14 @@ export default function TrialPage() {
           <p className="text-base font-bold text-white mb-1">
             おためし ぶんせきを つかいきったよ！
           </p>
-          <p className="text-sm text-sky-200 mb-4">
-            とうろくすると、ぶんせきが ずっと つかえるよ。
+          <p className="text-sm text-sky-200 mb-1">
+            とうろくすると こんなことが できるよ！
           </p>
+          <ul className="text-sm text-sky-100/80 mb-4 space-y-1 text-left inline-block">
+            <li>✨ AIぶんせきが <span className="font-bold text-white">まいつき10かい</span> つかえる</li>
+            <li>🌙 ゆめを <span className="font-bold text-white">ずっと きろく</span> できる</li>
+            <li>🖼️ ゆめの <span className="font-bold text-white">イラスト生成</span> も つかえる</li>
+          </ul>
           <Link
             href="/register"
             className="
@@ -337,28 +342,30 @@ export default function TrialPage() {
         </div>
       )}
 
-      {/* 注意書き + 登録CTA */}
-      <div className="p-4 bg-slate-800/30 border border-slate-700/30 rounded-2xl text-center">
-        <p className="text-sm text-slate-400 mb-1">
-          おためしの ぶんせきは <span className="text-sky-400 font-medium">3かい</span> まで
-        </p>
-        <p className="text-xs text-slate-500 mb-4">
-          おためしアカウントが じどうで つくられるよ。とうろくすると ぜんぶの きのうが つかえるよ。
-        </p>
-        <Link
-          href="/register"
-          className="
-            inline-flex items-center gap-2 px-6 py-2.5
-            bg-gradient-to-r from-violet-500 to-purple-600
-            hover:from-violet-400 hover:to-purple-500
-            text-white font-bold text-sm rounded-xl
-            shadow-lg shadow-violet-500/20
-            transition-all duration-200
-          "
-        >
-          とうろくして ずっと のこす
-        </Link>
-      </div>
+      {/* 注意書き + 登録CTA（上限到達時は非表示） */}
+      {!analysisLimitReached && (
+        <div className="p-4 bg-slate-800/30 border border-slate-700/30 rounded-2xl text-center">
+          <p className="text-sm text-slate-400 mb-1">
+            おためしの ぶんせきは <span className="text-sky-400 font-medium">3かい</span> まで
+          </p>
+          <p className="text-xs text-slate-500 mb-4">
+            おためしアカウントが じどうで つくられるよ。とうろくすると ぜんぶの きのうが つかえるよ。
+          </p>
+          <Link
+            href="/register"
+            className="
+              inline-flex items-center gap-2 px-6 py-2.5
+              bg-gradient-to-r from-violet-500 to-purple-600
+              hover:from-violet-400 hover:to-purple-500
+              text-white font-bold text-sm rounded-xl
+              shadow-lg shadow-violet-500/20
+              transition-all duration-200
+            "
+          >
+            とうろくして ずっと のこす
+          </Link>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/e2e/trial-flow.spec.ts
+++ b/frontend/e2e/trial-flow.spec.ts
@@ -170,6 +170,43 @@ test.describe("トライアルページ：お試し体験フロー", () => {
     await expect(ctaLink).toHaveAttribute("href", "/register");
   });
 
+  test("分析上限到達時に下部CTAが非表示になりアップグレードカードのみ表示される", async ({
+    page,
+  }) => {
+    await page.route("**/auth/trial_login", async (route) => {
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          user: { id: 99, email: "trial_test@example.com", username: "trial_99" },
+        }),
+      });
+    });
+
+    await page.route("**/dreams/preview_analysis", async (route) => {
+      await route.fulfill({
+        status: 403,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "分析上限に達しました" }),
+      });
+    });
+
+    await page.goto("/trial");
+
+    await page.locator("#description").fill("ゆめの内容");
+    await page.getByRole("button", { name: "AIにきいてみる" }).click();
+
+    // アップグレードカードが表示される
+    await expect(
+      page.getByText("おためし ぶんせきを つかいきったよ！")
+    ).toBeVisible();
+
+    // 下部CTAは非表示になる
+    await expect(
+      page.getByRole("link", { name: "とうろくして ずっと のこす" })
+    ).not.toBeVisible();
+  });
+
   test("分析なしで記録だけできる", async ({ page }) => {
     await page.goto("/trial");
 


### PR DESCRIPTION
## Summary

- アップグレードカードの説明文を具体的なメリット3点に変更（月10回AI分析・永続記録・イラスト生成）
- 分析上限到達時に下部登録CTAを非表示にし、アップグレードカードへ視線を集中させる
- E2E: 上限到達時に下部CTAが非表示になることを検証するテストを追加

## Test plan

- [ ] `/trial` にアクセスし、下部CTAが表示されていること
- [ ] AI分析を上限（3回）まで使い切るとアップグレードカードが表示されること
- [ ] アップグレードカードに3つのメリット箇条書きが表示されること
- [ ] 上限到達後は「とうろくして ずっと のこす」ボタンが非表示になること
- [ ] 「いますぐ とうろくする」リンクが `/register` に遷移すること
- [ ] CI (Playwright) がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)