### PR TITLE
feat: フリープランの月次AI分析残数をホームページに表示

### DIFF
--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -51,6 +51,30 @@ class DreamsController < ApplicationController
     }
   end
 
+  # GET /dreams/analysis_quota
+  def analysis_quota
+    if current_user.premium?
+      render json: { unlimited: true, used: nil, limit: nil, remaining: nil }
+    elsif current_user.trial_user?
+      remaining = [TRIAL_ANALYSIS_LIMIT - current_user.trial_analysis_count, 0].max
+      render json: {
+        trial:     true,
+        used:      current_user.trial_analysis_count,
+        limit:     TRIAL_ANALYSIS_LIMIT,
+        remaining: remaining
+      }
+    else
+      current_user.reset_monthly_analysis_count_if_needed!
+      used  = current_user.monthly_analysis_count
+      limit = FREE_ANALYSIS_MONTHLY_LIMIT
+      render json: {
+        used:      used,
+        limit:     limit,
+        remaining: [limit - used, 0].max
+      }
+    end
+  end
+
   # GET /dreams/:id
   def show
     render json: @dream.as_json(

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -21,7 +21,8 @@ Rails.application.routes.draw do
       post :preview_analysis
       get :my_dreams
       get :statuses # 一括ステータス取得用
-      get :image_quota # 画像生成残数
+      get :image_quota    # 画像生成残数
+      get :analysis_quota # 月次AI分析残数
       # /dreams/month/2023-05 のような形式でアクセス
       get 'month/:year_month', to: 'dreams#by_month_index', as: :by_month
       post 'month/:year_month/ai_summary', to: 'monthly_summaries#create'

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -782,4 +782,47 @@ RSpec.describe 'Dreams API', type: :request do
       it_behaves_like 'unauthorized request', :get, '/dreams/image_quota'
     end
   end
+
+  describe 'GET /dreams/analysis_quota' do
+    context 'フリープランユーザーの場合' do
+      before { user.update!(monthly_analysis_count: 3) }
+
+      it '使用数・上限・残数を返す' do
+        authenticated_get '/dreams/analysis_quota', user
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response['used']).to eq(3)
+        expect(json_response['limit']).to eq(User::FREE_ANALYSIS_MONTHLY_LIMIT)
+        expect(json_response['remaining']).to eq(User::FREE_ANALYSIS_MONTHLY_LIMIT - 3)
+      end
+    end
+
+    context 'プレミアムユーザーの場合' do
+      let!(:premium_user) { create(:user, premium: true) }
+
+      it 'unlimited: true を返す' do
+        authenticated_get '/dreams/analysis_quota', premium_user
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response['unlimited']).to be true
+      end
+    end
+
+    context 'トライアルユーザーの場合' do
+      let!(:trial_user) { create(:user, trial_user: true, trial_analysis_count: 1) }
+
+      it 'trial: true と残数を返す' do
+        authenticated_get '/dreams/analysis_quota', trial_user
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response['trial']).to be true
+        expect(json_response['used']).to eq(1)
+        expect(json_response['remaining']).to eq(DreamsController::TRIAL_ANALYSIS_LIMIT - 1)
+      end
+    end
+
+    context '認証されていない場合' do
+      it_behaves_like 'unauthorized request', :get, '/dreams/analysis_quota'
+    end
+  end
 end

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -785,7 +785,7 @@ RSpec.describe 'Dreams API', type: :request do
 
   describe 'GET /dreams/analysis_quota' do
     context 'フリープランユーザーの場合' do
-      before { user.update!(monthly_analysis_count: 3) }
+      before { user.update!(monthly_analysis_count: 3, monthly_analysis_count_reset_at: Time.current.beginning_of_month) }
 
       it '使用数・上限・残数を返す' do
         authenticated_get '/dreams/analysis_quota', user

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { Dream, Emotion, AgeGroup } from "@/app/types";
 import { useAuth } from "@/context/AuthContext";
 import apiClient from "@/lib/apiClient";
-import { getEmotions } from "@/lib/apiClient";
+import { getEmotions, getAnalysisQuota, AnalysisQuota } from "@/lib/apiClient";
 import { getJSTYearMonthKey } from "@/lib/date";
 import DreamList from "@/app/components/DreamList";
 import { DreamListSkeleton } from "@/app/components/DreamCardSkeleton";
@@ -122,6 +122,7 @@ export default function HomePage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [emotions, setEmotions] = useState<Emotion[]>([]);
   const [isSearchPanelOpen, setIsSearchPanelOpen] = useState(false);
+  const [analysisQuota, setAnalysisQuota] = useState<AnalysisQuota | null>(null);
 
   const fetchDreams = useCallback(async () => {
     if (authStatus !== "authenticated") {
@@ -177,6 +178,16 @@ export default function HomePage() {
         // 感情タグ取得失敗は非致命的: 検索フォームを通常表示するだけ
       });
   }, []);
+
+  // 月次AI分析残数をフリープランユーザーのみ取得
+  useEffect(() => {
+    if (authStatus !== "authenticated" || user?.premium) return;
+    getAnalysisQuota()
+      .then(setAnalysisQuota)
+      .catch(() => {
+        // 非致命的: バッジを表示しないだけ
+      });
+  }, [authStatus, user?.premium]);
 
   // dream-createdイベントをリッスン（夢が新規作成されたときにリストを更新）
   useEffect(() => {
@@ -330,6 +341,48 @@ export default function HomePage() {
 
         {/* 感情タグ統計 */}
         <DreamStatsWidget dreams={dreams} />
+
+        {/* 月次AI分析残数バッジ（フリープランのみ） */}
+        {analysisQuota && !analysisQuota.unlimited && !analysisQuota.trial && (
+          <div className="bg-card border border-border rounded-xl p-4 w-full mb-4">
+            <h3 className="font-bold text-card-foreground mb-2 flex items-center gap-2">
+              <span>✨</span>
+              <span>今月のAI分析</span>
+            </h3>
+            <div className="flex items-center gap-3 mb-2">
+              <div className="flex-1 bg-muted rounded-full h-2 overflow-hidden">
+                <div
+                  className={`h-full rounded-full transition-all duration-700 ${
+                    analysisQuota.remaining === 0
+                      ? "bg-destructive"
+                      : analysisQuota.remaining! <= 2
+                      ? "bg-amber-400"
+                      : "bg-primary"
+                  }`}
+                  style={{
+                    width: `${Math.min(((analysisQuota.used ?? 0) / (analysisQuota.limit ?? 10)) * 100, 100)}%`,
+                  }}
+                />
+              </div>
+              <span className="text-xs text-muted-foreground shrink-0">
+                {analysisQuota.used ?? 0} / {analysisQuota.limit ?? 10}
+              </span>
+            </div>
+            {analysisQuota.remaining === 0 ? (
+              <p className="text-xs text-destructive">
+                今月の上限に達しました。
+                <Link href="/subscription" className="underline ml-1">プレミアムで無制限に</Link>
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                残り{" "}
+                <span className={`font-bold ${analysisQuota.remaining! <= 2 ? "text-amber-500" : "text-foreground"}`}>
+                  {analysisQuota.remaining}回
+                </span>
+              </p>
+            )}
+          </div>
+        )}
 
         {/* 月別アーカイブリンク */}
         <div className="bg-card text-card-foreground shadow-md rounded-xl p-4 mb-4 border border-border w-full">

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -48,21 +48,13 @@ const SettingsPage = () => {
   const [isSavingProfile, setIsSavingProfile] = useState(false);
   const [isToneOpen, setIsToneOpen] = useState(false);
 
-  // 初回レンダー時は user === null (checking中)なので、verify 完了後に再同期する
+  // verify 完了後 (user が null → 実データ) に state を同期する
   useEffect(() => {
     if (!user) return;
     setProfileUsername(user.username ?? "");
     setProfileAgeGroup(user.age_group ?? "child");
     setProfileTone(user.analysis_tone ?? "auto");
   }, [user?.id, user?.username, user?.age_group, user?.analysis_tone]);
-
-  // 初回レンダー時は user === null (checking中)なので、verify 完了後に再同期する
-  useEffect(() => {
-    if (!user) return;
-    setProfileUsername(user.username ?? "");
-    setProfileAgeGroup(user.age_group ?? "child");
-    setProfileTone(user.analysis_tone ?? "auto");
-  }, [user?.id]);
 
   const handleSaveProfile = async () => {
     if (!profileUsername.trim()) {

--- a/frontend/lib/apiClient.ts
+++ b/frontend/lib/apiClient.ts
@@ -315,6 +315,18 @@ export async function previewAnalysis(
   );
 }
 
+export type AnalysisQuota = {
+  unlimited?: boolean;
+  trial?: boolean;
+  used: number | null;
+  limit: number | null;
+  remaining: number | null;
+};
+
+export async function getAnalysisQuota(): Promise<AnalysisQuota> {
+  return apiFetch<AnalysisQuota>("/dreams/analysis_quota");
+}
+
 export async function verifyAuth(): Promise<{ user: User } | null> {
   try {
     const response = await apiFetch<{ user: BackendUser }>("/auth/verify");


### PR DESCRIPTION
## Summary

- `GET /dreams/analysis_quota` エンドポイントを追加（`image_quota` と同パターン）
- ホームページサイドバーにフリープランユーザー向けの月次AI分析残数バッジを追加
- settings/page.tsx の重複 `useEffect` バグを修正

## Changes

### Backend
- `DreamsController#analysis_quota` — フリープラン/プレミアム/トライアルで異なるレスポンスを返す
- `GET /dreams/analysis_quota` をルートに追加
- RSpec: フリープラン・プレミアム・トライアル・未認証の4ケースを追加

### Frontend
- `getAnalysisQuota()` と `AnalysisQuota` 型を `apiClient.ts` に追加
- ホームページサイドバー: フリープランのみ残数バッジを表示（残り2回以下→警告色、0回→赤+プレミアムリンク）
- settings/page.tsx: 重複 `useEffect`（verify完了後の state 再同期）を1つに統合

## Test plan

- [ ] フリープランユーザーでホームページを開き、サイドバーに「今月のAI分析 X/10」バッジが表示されること
- [ ] プレミアムユーザーでホームページを開き、バッジが表示されないこと
- [ ] CI (Jest / RSpec / Playwright) がパスすること