### PR TITLE
fix: forgot-password フォームに noValidate を追加

### DIFF
--- a/frontend/app/(auth)/forgot-password/page.tsx
+++ b/frontend/app/(auth)/forgot-password/page.tsx
@@ -62,6 +62,7 @@ export default function ForgotPasswordPage() {
     <div className="flex items-center justify-center min-h-screen bg-background text-foreground px-4 sm:px-6 lg:px-8">
       <form
         onSubmit={handleSubmit}
+        noValidate
         className="bg-card p-6 sm:p-8 md:p-10 rounded-lg shadow-lg w-full max-w-md border border-border"
       >
         <h2 className="text-2xl md:text-3xl font-semibold mb-4 md:mb-6 text-center text-card-foreground">


### PR DESCRIPTION
## Summary

`/forgot-password` の `<form>` に `noValidate` を追加。

`type="email" required` の HTML5 ネイティブバリデーションが React の `handleSubmit` より先に発火するため、メールアドレスが空または不正な形式のとき、ブラウザのポップアップが表示されて日本語のカスタムエラーメッセージが出ない問題を修正。`/register` で実施済みの同一修正を適用。

## Test plan

- [ ] 空のまま送信 → 「メールアドレスを入力してください。」が表示されること（ブラウザポップアップではなく）
- [ ] 不正なメール形式で送信 → 「有効なメールアドレスを入力してください。」が表示されること