### PR TITLE
fix: resolve pre-existing TypeScript errors in Jest 30 test files

### DIFF
--- a/frontend/__tests__/app/api/auth/verify/route.test.ts
+++ b/frontend/__tests__/app/api/auth/verify/route.test.ts
@@ -2,7 +2,7 @@ import { GET } from "@/app/api/auth/verify/route";
 
 const originalEnv = process.env;
 const originalResponse = global.Response;
-const fetchMock = jest.fn();
+const fetchMock = jest.fn<typeof fetch>();
 
 describe("GET /api/auth/verify", () => {
   beforeEach(() => {
@@ -12,7 +12,7 @@ describe("GET /api/auth/verify", () => {
       INTERNAL_API_URL: "https://api.example.com",
     };
     fetchMock.mockReset();
-    global.fetch = fetchMock;
+    global.fetch = fetchMock as unknown as typeof fetch;
     global.Response = {
       json: (body: unknown, init?: ResponseInit) =>
         ({
@@ -31,7 +31,7 @@ describe("GET /api/auth/verify", () => {
     fetchMock.mockResolvedValue({
       status: 200,
       json: async () => ({ user: { id: 1 } }),
-    });
+    } as unknown as Response);
 
     const response = await GET({
       headers: { get: () => "access_token=token-value" },

--- a/frontend/__tests__/components/DreamDetailPage.test.tsx
+++ b/frontend/__tests__/components/DreamDetailPage.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import DreamDetailPage from "@/app/dream/[id]/page";
 
 jest.mock("react", () => {
-  const actual = jest.requireActual("react");
+  const actual = jest.requireActual("react") as Record<string, unknown>;
   return {
     ...actual,
     use: (value: unknown) => value,

--- a/frontend/__tests__/lib/apiClient.test.ts
+++ b/frontend/__tests__/lib/apiClient.test.ts
@@ -5,7 +5,7 @@ describe("apiFetch timeout policy", () => {
 
   beforeEach(() => {
     jest.spyOn(global, "setTimeout");
-    global.fetch = jest.fn().mockRejectedValue(new Error("network down")) as typeof fetch;
+    global.fetch = jest.fn<() => Promise<Response>>().mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
   });
 
   afterEach(() => {
@@ -26,12 +26,12 @@ describe("apiFetch timeout policy", () => {
   });
 
   it("preserves plain-text error bodies when the upstream response is not JSON", async () => {
-    global.fetch = jest.fn().mockResolvedValue({
+    global.fetch = jest.fn<() => Promise<Response>>().mockResolvedValue({
       ok: false,
       status: 502,
-      json: jest.fn().mockRejectedValue(new Error("invalid json")),
-      text: jest.fn().mockResolvedValue("upstream connect error or disconnect/reset before headers"),
-    } as unknown as Response) as typeof fetch;
+      json: jest.fn<() => Promise<unknown>>().mockRejectedValue(new Error("invalid json")),
+      text: jest.fn<() => Promise<string>>().mockResolvedValue("upstream connect error or disconnect/reset before headers"),
+    } as unknown as Response) as unknown as typeof fetch;
 
     await expect(apiFetch("/dreams")).rejects.toThrow(
       "upstream connect error or disconnect/reset before headers"

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,4 +1,4 @@
-import "@testing-library/jest-dom";
+import "@testing-library/jest-dom/jest-globals";
 
 // Mock framer-motion to prevent JSDOM issues
 jest.mock("framer-motion", () => {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -21,7 +21,8 @@
       "node",
       "react",
       "react-dom",
-      "next"
+      "next",
+      "@testing-library/jest-dom"
     ],
     "plugins": [
       {


### PR DESCRIPTION
## Summary

- `jest.setup.ts`: `@testing-library/jest-dom` → `/jest-globals` entry point（Jest 30 の型拡張に必要）
- `tsconfig.json`: `types` 配列に `@testing-library/jest-dom` を追加
- `apiClient.test.ts` / `route.test.ts`: `jest.fn<Promise<X>>()` → `jest.fn<() => Promise<X>>()` / `jest.fn<typeof fetch>()`（Jest 30 は `FunctionLike` 制約が必要）
- `DreamDetailPage.test.tsx`: `jest.requireActual` の結果を `Record<string, unknown>` にキャストしてスプレッド型エラーを解消

## Root cause

Jest 30 では `jest.fn<T>` の型パラメータが `FunctionLike`（関数型）であることを要求するようになった。以前は戻り値の型（`Promise<Response>` など）を渡しても動作していたが、TS エラーとして検出される。

また `@testing-library/jest-dom` v6 の標準インポートは `@types/jest` を拡張するが、Jest 30 の型システムには対応していない。`/jest-globals` サブパスが Jest 30 対応のエントリポイント。

## Test plan

- [x] `npx tsc --noEmit` でエラー 0
- [x] `yarn test` で 13 スイート・57 テスト全てパス