### PR TITLE
fix: DreamFormのサブスクリプションリンク修正 + パスワードリセットE2Eテスト追加

### DIFF
--- a/frontend/__tests__/components/DreamForm.test.js
+++ b/frontend/__tests__/components/DreamForm.test.js
@@ -31,6 +31,13 @@ jest.mock("framer-motion", () => {
 jest.mock("@/lib/apiClient", () => ({
   getEmotions: jest.fn(),
   previewAnalysis: jest.fn(),
+  ApiError: class ApiError extends Error {
+    constructor(message, status, data) {
+      super(message);
+      this.status = status;
+      this.data = data;
+    }
+  },
 }));
 
 jest.mock("@/lib/toast", () => ({
@@ -41,6 +48,7 @@ jest.mock("@/lib/toast", () => ({
 }));
 
 const { getEmotions, previewAnalysis } = require("@/lib/apiClient");
+const { ApiError } = require("@/lib/apiClient");
 const { toast } = require("@/lib/toast");
 
 describe("DreamForm", () => {
@@ -272,5 +280,24 @@ describe("DreamForm", () => {
     expect(screen.getByText("#不安")).toBeInTheDocument();
     expect(screen.getByText("#嬉しい")).toBeInTheDocument();
     expect(toast.success).toHaveBeenCalledWith("モルペウスが おへんじ したよ！");
+  });
+
+  it("links free analysis limit users to the premium subscription page", async () => {
+    getEmotions.mockResolvedValueOnce([]);
+    previewAnalysis.mockRejectedValueOnce(
+      new ApiError("limit reached", 403, { limit_reached: true })
+    );
+    const user = userEvent.setup();
+
+    render(<DreamForm onSubmit={jest.fn()} />);
+
+    await user.type(screen.getByLabelText("どんな おはなし？"), "空を飛ぶ夢");
+    await user.click(screen.getByRole("button", { name: /モルペウスに\s*きく/ }));
+
+    const upgradeLink = await screen.findByRole("link", {
+      name: /プレミアムで無制限に使う/,
+    });
+    expect(upgradeLink).toHaveAttribute("href", "/subscription");
+    expect(screen.getByText("今月の無料分析回数を使い切ったよ")).toBeInTheDocument();
   });
 });

--- a/frontend/app/components/DreamForm.tsx
+++ b/frontend/app/components/DreamForm.tsx
@@ -270,7 +270,7 @@ export default function DreamForm({
                 今月の無料分析回数を使い切ったよ
               </p>
               <a
-                href="/donation"
+                href="/subscription"
                 className="px-4 py-2 rounded-full font-bold text-sm bg-gradient-to-r from-sky-500 to-indigo-500 text-white shadow-md hover:opacity-90 transition-opacity flex items-center gap-2"
               >
                 <span>✨</span>

--- a/frontend/e2e/password-reset-flow.spec.ts
+++ b/frontend/e2e/password-reset-flow.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("パスワードリセットフロー", () => {
+  test.beforeEach(async ({ page }) => {
+    // 未認証状態をモック（認証済みユーザーへのリダイレクトを防ぐ）
+    await page.route("**/auth/verify", async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Unauthorized" }),
+      });
+    });
+  });
+
+  // ─── フォーム表示 ───────────────────────────────────────────────
+
+  test("パスワードリセットフォームが表示される", async ({ page }) => {
+    await page.goto("/forgot-password");
+
+    await expect(
+      page.getByRole("heading", { name: "パスワードのリセット" })
+    ).toBeVisible();
+    await expect(page.getByLabel("メールアドレス")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "リセットリンクを送信" })
+    ).toBeVisible();
+  });
+
+  test("ログインページの「パスワードを わすれたとき」リンクが forgot-password に遷移する", async ({
+    page,
+  }) => {
+    await page.goto("/login");
+
+    await page.getByRole("link", { name: "パスワードを わすれたとき" }).click();
+
+    await expect(page).toHaveURL("/forgot-password");
+    await expect(
+      page.getByRole("heading", { name: "パスワードのリセット" })
+    ).toBeVisible();
+  });
+
+  // ─── バリデーション（クライアント側） ───────────────────────────
+
+  test("メールアドレスが空のまま送信するとエラーが表示される", async ({
+    page,
+  }) => {
+    await page.goto("/forgot-password");
+
+    await page.getByRole("button", { name: "リセットリンクを送信" }).click();
+
+    await expect(page.getByText("メールアドレスを入力してください。")).toBeVisible();
+  });
+
+  test("不正なメールアドレス形式で送信するとエラーが表示される", async ({
+    page,
+  }) => {
+    await page.goto("/forgot-password");
+
+    await page.getByLabel("メールアドレス").fill("invalid-email");
+    await page.getByRole("button", { name: "リセットリンクを送信" }).click();
+
+    await expect(
+      page.getByText("有効なメールアドレスを入力してください。")
+    ).toBeVisible();
+  });
+
+  // ─── 送信中ローディング ─────────────────────────────────────────
+
+  test("送信中はボタンが「送信中...」になる", async ({ page }) => {
+    // レスポンスを意図的に遅延させてローディング状態を観察する
+    await page.route("**/password_resets", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "ok" }),
+      });
+    });
+
+    await page.goto("/forgot-password");
+    await page.getByLabel("メールアドレス").fill("user@example.com");
+
+    await page.getByRole("button", { name: "リセットリンクを送信" }).click();
+
+    // ボタンテキストが「送信中...」に変わり、disabled になること
+    const sendingButton = page.getByRole("button", { name: "送信中..." });
+    await expect(sendingButton).toBeVisible();
+    await expect(sendingButton).toBeDisabled();
+  });
+
+  // ─── API 通信（モック） ─────────────────────────────────────────
+
+  test("送信成功時に成功メッセージが表示され、入力欄がクリアされる", async ({
+    page,
+  }) => {
+    await page.route("**/password_resets", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "ok" }),
+      });
+    });
+
+    await page.goto("/forgot-password");
+    await page.getByLabel("メールアドレス").fill("user@example.com");
+    await page.getByRole("button", { name: "リセットリンクを送信" }).click();
+
+    await expect(
+      page.getByText(
+        "パスワードリセットの手順をメールで送信しました。メールをご確認ください。"
+      )
+    ).toBeVisible();
+
+    // 送信後に入力欄がクリアされること
+    await expect(page.getByLabel("メールアドレス")).toHaveValue("");
+  });
+
+  test("API がエラーを返したときサーバーのエラーメッセージが表示される", async ({
+    page,
+  }) => {
+    await page.route("**/password_resets", async (route) => {
+      await route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "ユーザーが見つかりません。" }),
+      });
+    });
+
+    await page.goto("/forgot-password");
+    await page.getByLabel("メールアドレス").fill("notfound@example.com");
+    await page.getByRole("button", { name: "リセットリンクを送信" }).click();
+
+    await expect(
+      page.getByText("ユーザーが見つかりません。")
+    ).toBeVisible();
+  });
+
+  test("API がエラーをJSONで返せなかったときフォールバックメッセージが表示される", async ({
+    page,
+  }) => {
+    await page.route("**/password_resets", async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "text/plain",
+        body: "Internal Server Error",
+      });
+    });
+
+    await page.goto("/forgot-password");
+    await page.getByLabel("メールアドレス").fill("user@example.com");
+    await page.getByRole("button", { name: "リセットリンクを送信" }).click();
+
+    await expect(
+      page.getByText("リクエストの処理中にエラーが発生しました。")
+    ).toBeVisible();
+  });
+
+  // ─── ナビゲーション ─────────────────────────────────────────────
+
+  test("「ログイン画面へ戻る」リンクでログインページに戻れる", async ({
+    page,
+  }) => {
+    await page.goto("/forgot-password");
+
+    await page.getByRole("link", { name: "ログイン画面へ戻る" }).click();
+
+    await expect(page).toHaveURL("/login");
+  });
+});


### PR DESCRIPTION
## Summary

- **DreamForm バグ修正**: 無料AI分析の上限に達したときのアップグレードCTAが `/donation`（古いページ）を指していた。`/subscription` に修正
- **ApiError モック追加**: `DreamForm.test.js` に `ApiError` クラスのモック定義を追加（テストの安定性向上）
- **パスワードリセット E2E テスト新設**: `e2e/password-reset-flow.spec.ts` — 9シナリオ、全通過

## Test coverage added

| シナリオ | 内容 |
|---|---|
| フォーム表示 | `/forgot-password` でフォームが表示される |
| ログインページからのリンク | 「パスワードを わすれたとき」クリックで遷移 |
| 空メールでエラー | クライアント側バリデーション |
| 不正メール形式でエラー | クライアント側バリデーション |
| ローディング状態 | 送信中はボタンが「送信中...」かつ disabled |
| 送信成功 | 成功メッセージ表示 + 入力欄クリア |
| APIエラー（JSON） | サーバーのエラーメッセージを表示 |
| APIエラー（非JSON） | フォールバックメッセージを表示 |
| ログイン画面へ戻る | ナビゲーションリンクが機能する |

## Test plan
- [ ] CI の Playwright が 9 tests passed で通ること
- [ ] CI の Jest が通ること
- [ ] Vercel preview デプロイで `/forgot-password` が正常に表示されること
- [ ] `/dream/new` で AI分析上限到達時に `/subscription` へ遷移することを手動確認