### PR TITLE
feat: 月次サマリーに月3回のフェアユース制限を追加

### DIFF
--- a/backend/app/controllers/monthly_summaries_controller.rb
+++ b/backend/app/controllers/monthly_summaries_controller.rb
@@ -1,5 +1,6 @@
 class MonthlySummariesController < ApplicationController
   YEAR_MONTH_FORMAT = /\A\d{4}-(0[1-9]|1[0-2])\z/
+  MONTHLY_SUMMARY_LIMIT = 3
 
   def create
     unless current_user.premium?
@@ -11,12 +12,24 @@ class MonthlySummariesController < ApplicationController
       return render json: { error: '年月の形式が正しくありません（YYYY-MM）。' }, status: :bad_request
     end
 
+    monthly_count = AiUsageLog.this_month_for_user(current_user, 'monthly_summary').count
+    if monthly_count >= MONTHLY_SUMMARY_LIMIT
+      return render json: {
+        error: "今月の月次サマリー上限（#{MONTHLY_SUMMARY_LIMIT}回）に達しました。来月またお試しください。",
+        limit_reached: true,
+        monthly_summary_count: monthly_count,
+        monthly_summary_limit: MONTHLY_SUMMARY_LIMIT
+      }, status: :too_many_requests
+    end
+
     result = MonthlySummaryService.generate(current_user, year_month)
 
     if result[:error]
       status = result[:error].include?('夢がありません') ? :not_found : :internal_server_error
       return render json: { error: result[:error] }, status: status
     end
+
+    AiUsageLog.create!(user: current_user, feature: 'monthly_summary')
 
     render json: { summary: result[:summary] }, status: :ok
   end

--- a/backend/app/models/ai_usage_log.rb
+++ b/backend/app/models/ai_usage_log.rb
@@ -10,4 +10,10 @@ class AiUsageLog < ApplicationRecord
     where(user: user, feature: feature)
       .where(created_at: Time.current.beginning_of_day..)
   }
+
+  # 指定ユーザーの今月の利用ログ
+  scope :this_month_for_user, ->(user, feature) {
+    where(user: user, feature: feature)
+      .where(created_at: Time.current.beginning_of_month..)
+  }
 end

--- a/backend/spec/requests/monthly_summaries_spec.rb
+++ b/backend/spec/requests/monthly_summaries_spec.rb
@@ -66,6 +66,56 @@ RSpec.describe 'MonthlySummaries API', type: :request do
         expect(response).to have_http_status(:ok)
         expect(JSON.parse(response.body)['summary']).to eq('モルペウスの月次サマリーテスト文章')
       end
+
+      it '成功時に ai_usage_log が 1 件増える' do
+        user = create(:user, premium: true)
+
+        allow(MonthlySummaryService).to receive(:generate)
+          .and_return({ summary: 'テスト' })
+
+        expect {
+          authenticated_post '/dreams/month/2026-04/ai_summary', user
+        }.to change { AiUsageLog.where(user: user, feature: 'monthly_summary').count }.by(1)
+      end
+    end
+
+    context 'プレミアム会員・月次サマリーのフェアユース制限' do
+      it '今月2回利用済みでも 200 を返す' do
+        user = create(:user, premium: true)
+        create_list(:ai_usage_log, 2, user: user, feature: 'monthly_summary')
+
+        allow(MonthlySummaryService).to receive(:generate)
+          .and_return({ summary: 'テスト' })
+
+        authenticated_post '/dreams/month/2026-04/ai_summary', user
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '今月3回達成で 429 を返す' do
+        user = create(:user, premium: true)
+        create_list(:ai_usage_log, 3, user: user, feature: 'monthly_summary')
+
+        authenticated_post '/dreams/month/2026-04/ai_summary', user
+
+        expect(response).to have_http_status(:too_many_requests)
+        body = JSON.parse(response.body)
+        expect(body['limit_reached']).to be true
+        expect(body['monthly_summary_limit']).to eq(3)
+      end
+
+      it '先月のログは今月の制限にカウントしない' do
+        user = create(:user, premium: true)
+        create_list(:ai_usage_log, 3, user: user, feature: 'monthly_summary',
+                    created_at: 1.month.ago)
+
+        allow(MonthlySummaryService).to receive(:generate)
+          .and_return({ summary: 'テスト' })
+
+        authenticated_post '/dreams/month/2026-04/ai_summary', user
+
+        expect(response).to have_http_status(:ok)
+      end
     end
 
     context 'サービスがエラーを返す場合' do


### PR DESCRIPTION
## 概要

ai_usage_logsテーブルの`monthly_summary`フィーチャーを使い、月次サマリー生成を月3回に制限します。

## 変更内容

### backend/app/models/ai_usage_log.rb
- `this_month_for_user` スコープを追加（今月の利用ログを取得）

### backend/app/controllers/monthly_summaries_controller.rb
- `MONTHLY_SUMMARY_LIMIT = 3` 定数を追加
- サマリー生成前に今月のカウントを確認、3回以上なら429を返す
- 生成成功後に `AiUsageLog.create!` でログを記録

## テスト追加（monthly_summaries_spec.rb）

| テスト | 期待動作 |
|---|---|
| 今月2回利用済みでリクエスト | 200 OK（通過） |
| 今月3回達成でリクエスト | 429 Too Many Requests |
| 先月3回あっても今月はリセット | 200 OK（日付境界確認） |
| 成功時にai_usage_logが+1 | ログ記録確認 |

## テスト計画
- CI RSpec通過確認（monthly_summaries_specの新規テスト含む）