### PR TITLE
fix: audio/monthly_summaryサービスをグローバルOpenAIクライアントに統一

### DIFF
--- a/backend/app/services/audio_analysis_service.rb
+++ b/backend/app/services/audio_analysis_service.rb
@@ -10,10 +10,12 @@ class AudioAnalysisService
     @file_source = file_source
     @age_group = age_group
     @analysis_tone = analysis_tone
-    @client = OpenAI::Client.new(access_token: ENV.fetch("OPENAI_API_KEY"))
+    @client = $openai_client
   end
 
   def call
+    return { error: "AI分析サービスの設定が不足しています。時間をおいてもう一度お試しください。" } unless @client
+
     validate_file!
 
     transcript_text = transcribe_audio

--- a/backend/app/services/monthly_summary_service.rb
+++ b/backend/app/services/monthly_summary_service.rb
@@ -42,7 +42,12 @@ class MonthlySummaryService
       この月の夢を振り返って、モルペウスとしてやさしいひとことを送ってください。
     MSG
 
-    client = OpenAI::Client.new(access_token: ENV.fetch('OPENAI_API_KEY'))
+    client = $openai_client
+    unless client
+      Rails.logger.error "MonthlySummaryService: OPENAI_API_KEY is not configured"
+      return { error: "AI分析サービスの設定が不足しています。時間をおいてもう一度お試しください。" }
+    end
+
     response = client.chat(parameters: {
       model: ENV["OPENAI_CHAT_MODEL"].presence || "gpt-4o-mini",
       messages: [


### PR DESCRIPTION
## Summary

- `AudioAnalysisService` と `MonthlySummaryService` が `ENV.fetch("OPENAI_API_KEY")` で直接 `OpenAI::Client` を生成していたため、APIキー未設定時に `KeyError`（500エラー）が発生していた
- `$openai_client`（initializer で設定済みのグローバルクライアント）を使うよう変更
- クライアントが `nil` の場合は 500 ではなくユーザー向けエラーメッセージを返すよう統一
- `DreamAnalysisService` が昨日修正済みの実装パターンに揃えた

## 変更ファイル

- `backend/app/services/audio_analysis_service.rb` — 音声文字起こし・分析
- `backend/app/services/monthly_summary_service.rb` — 月次サマリー生成

## 背景

`ruby-openai 8.3.0`（Dependabot PR #260）のマージ後、`bundle install` が未実行の環境でローカルサーバーが不安定になっていた。合わせてこの修正を適用しOSエラーを統一。

## Test plan

- [ ] `bundle exec rspec spec/services/dream_analysis_service_spec.rb` 通過確認（既存テスト）
- [ ] ローカルで `bundle install` 後、音声分析・月次サマリーが正常動作することを確認
