### PR TITLE
chore: 競合分析ドキュメントをgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ docs/ux-improvement-roadmap.md
 
 # Codex/AI エージェント設定（公開禁止）
 AGENTS.md
+
+# 競合分析・戦略メモ（個人判断・手の内を含むため非公開）
+docs/competitive-analysis.md


### PR DESCRIPTION
## Summary

- `docs/competitive-analysis.md` を `.gitignore` に追加
- 競合戦略・個人の判断・手の内を含むため GitHub 非公開とする
- ファイル自体はローカルに残しており、個人メモとして継続活用