### PR TITLE
fix: E2EテストのCI 20分タイムアウトを修正（standalone output）

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -35,7 +35,7 @@ const nextConfig = {
   },
   // 本番環境で必要なファイルのみを .next/standalone に出力する
   // E2Eテスト時は `next start` を使うため standalone を無効にする
-  output: process.env.NEXT_PUBLIC_E2E ? undefined : "standalone",
+  output: process.env.NEXT_PUBLIC_E2E === "1" ? undefined : "standalone",
   compiler: {
     removeConsole: isProd ? { exclude: ["error"] } : false,
   },

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -34,7 +34,8 @@ const nextConfig = {
     ],
   },
   // 本番環境で必要なファイルのみを .next/standalone に出力する
-  output: "standalone",
+  // E2Eテスト時は `next start` を使うため standalone を無効にする
+  output: process.env.NEXT_PUBLIC_E2E ? undefined : "standalone",
   compiler: {
     removeConsole: isProd ? { exclude: ["error"] } : false,
   },


### PR DESCRIPTION
## 原因

`next.config.mjs` に `output: "standalone"` が設定されている状態で、CIが `yarn start`（= `next start`）を実行していた。

Next.js の仕様として、`output: "standalone"` ビルド後は `next start` は動作せず、`node .next/standalone/server.js` を使う必要がある。
この不整合により、サーバーが正しくリクエストを処理できず、Playwright テストが全31件ハングして20分タイムアウトしていた。

## 修正

`next.config.mjs` の `output` を条件付きに変更：

```js
output: process.env.NEXT_PUBLIC_E2E ? undefined : "standalone",
```

- `NEXT_PUBLIC_E2E=1`（E2Eビルド時）: standalone を無効 → `next start` が通常ビルドで動作
- 本番（Vercel / `NEXT_PUBLIC_E2E` 未設定）: standalone を維持 → デプロイ挙動は変わらない

CIワークフロー（`.github/workflows/e2e-test.yml`）はすでに `NEXT_PUBLIC_E2E: "1"` を build・start 両ステップに設定しているため、ワークフロー側の変更は不要。

## Test plan

- [ ] CIのE2E jobが20分以内に完了することを確認
- [ ] 本番Vercelデプロイが引き続き standalone ビルドを使っていることを確認
- [ ] `yarn tsc --noEmit` エラーなし ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)