### PR TITLE
Clarify trial image generation copy

### DIFF
--- a/frontend/app/trial/page.tsx
+++ b/frontend/app/trial/page.tsx
@@ -151,7 +151,7 @@ export default function TrialPage() {
         <MorpheusSmall
           expression="curious"
           title="夢を記録してみましょう"
-          message="夢の内容を書いて「AIにきいてみる」を押すと、感情と意味を読み解きます。登録すると声での記録や夢の画像化にも対応します。"
+          message="夢の内容を書いて「AIにきいてみる」を押すと、感情と意味を読み解きます。登録後は、声での記録や夢からのAI画像生成も試せます。"
         />
       </div>
 
@@ -305,7 +305,7 @@ export default function TrialPage() {
                       </div>
                     )}
                     <p className="text-xs text-slate-500">
-                      🖼️ 登録するとAIがこの夢を画像にしてくれます
+                      🖼️ 登録後は保存した夢からAI画像生成も試せます
                     </p>
                   </div>
                 )}
@@ -355,7 +355,7 @@ export default function TrialPage() {
             体験版のAI分析は <span className="text-sky-400 font-medium">3回</span> まで
           </p>
           <p className="text-xs text-slate-500 mb-4">
-            体験用アカウントが自動で作成されます。登録すると声での記録・画像生成など全機能が使えます。
+            体験用アカウントが自動で作成されます。登録後は継続保存、声での記録、夢からのAI画像生成に進めます。
           </p>
           <Link
             href="/register"


### PR DESCRIPTION
## 変更概要

- `/trial` ページのYumeTree体験コピーを調整しました。
- 「登録すると画像化される」「全機能が使える」と読める強めの表現を、未ログインユーザーに誤解が出にくいように「登録後は試せる / 進める」表現へ変更しました。
- 変更対象は `frontend/app/trial/page.tsx` のコピーのみです。

## 変更しないこと

- ロジック変更なし
- API変更なし
- DB変更なし
- 認証変更なし
- Stripe変更なし
- OpenAI API呼び出し変更なし

## 確認

- TypeScript: `yarn tsc --noEmit` は `tsconfig.tsbuildinfo` 書き込みEPERMで停止したため、`yarn tsc --noEmit --incremental false` で確認済み
- Playwright: `npx playwright test e2e/trial-flow.spec.ts --project=chromium` が `8 passed`

## 補足

- 実行時に出ていた `pyenv rehash` 警告、Playwright中の `PendingDreamsMonitor` fetch警告、Morpheus画像のLCP警告は既存挙動であり、今回のコピー変更由来ではありません。