### PR TITLE
feat: 夢詳細に画像シェアカードUIを追加

### DIFF
--- a/frontend/__tests__/components/DreamDetailPage.test.tsx
+++ b/frontend/__tests__/components/DreamDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import DreamDetailPage from "@/app/dream/[id]/page";
 
 jest.mock("react", () => {
@@ -14,6 +14,19 @@ jest.mock("next/navigation", () => ({
   useRouter: () => ({
     push: jest.fn(),
   }),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({
+    alt,
+    fill,
+    unoptimized,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & {
+    fill?: boolean;
+    unoptimized?: boolean;
+  }) => <img alt={alt} {...props} />,
 }));
 
 jest.mock("@/app/components/DeleteButton", () => ({
@@ -103,9 +116,46 @@ describe("DreamDetailPage", () => {
 
     expect(
       screen.getAllByText("🔮 モルペウスの ゆめうらない")[0]
-    ).toBeInTheDocument();
+    ).toBeTruthy();
     expect(
       screen.getByText("むかしの けいしきの うらない")
-    ).toBeInTheDocument();
+    ).toBeTruthy();
+  });
+
+  it("does not render dream content inside the share card", () => {
+    useDream.mockReturnValue({
+      dream: {
+        id: 1,
+        title: "星空を走る夢",
+        content: "これは共有カードに出してはいけない夢本文です",
+        created_at: "2025-01-01T00:00:00.000Z",
+        updated_at: "2025-01-01T00:00:00.000Z",
+        userId: 1,
+        emotions: [{ id: 1, name: "楽しい" }],
+        analysis_json: {
+          analysis: "楽しい気持ちが強い夢です",
+          emotion_tags: ["楽しい"],
+        },
+        generated_image_url: "data:image/png;base64,ZmFrZQ==",
+      },
+      error: null,
+      isLoading: false,
+      isUpdating: false,
+      updateDream: jest.fn(),
+      deleteDream: jest.fn(),
+    });
+
+    render(<DreamDetailPage params={{ id: "1" } as never} />);
+
+    const shareCard = screen.getByTestId("dream-share-card");
+
+    expect(within(shareCard).getByText("YumeTree")).toBeTruthy();
+    expect(within(shareCard).getByText("ユメツリー")).toBeTruthy();
+    expect(within(shareCard).getByText("星空を走る夢")).toBeTruthy();
+    expect(
+      within(shareCard).queryByText(
+        "これは共有カードに出してはいけない夢本文です"
+      )
+    ).toBeNull();
   });
 });

--- a/frontend/app/components/DreamShareCard.tsx
+++ b/frontend/app/components/DreamShareCard.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Image from "next/image";
+import { EmotionTag } from "./EmotionTag";
+
+type DreamShareCardProps = {
+  imageUrl: string;
+  title: string;
+  recordedAt: string;
+  emotionLabels: string[];
+  imageAlt: string;
+};
+
+function formatDate(dateInput: string): string {
+  const date = new Date(dateInput);
+  if (Number.isNaN(date.getTime())) return "";
+
+  return date.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "Asia/Tokyo",
+  });
+}
+
+export default function DreamShareCard({
+  imageUrl,
+  title,
+  recordedAt,
+  emotionLabels,
+  imageAlt,
+}: DreamShareCardProps) {
+  const formattedDate = formatDate(recordedAt);
+
+  return (
+    <section
+      aria-label="夢画像シェアカード"
+      data-testid="dream-share-card"
+      className="mt-6 overflow-hidden rounded-lg border border-sky-200/70 bg-gradient-to-br from-sky-50 via-white to-amber-50 text-slate-900 shadow-lg"
+    >
+      <div className="relative aspect-square overflow-hidden bg-slate-100">
+        <Image
+          src={imageUrl}
+          alt={`${imageAlt} シェアカード`}
+          fill
+          sizes="(max-width: 768px) 100vw, 768px"
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+
+      <div className="space-y-4 p-5">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs font-bold uppercase text-sky-700">
+            YumeTree
+          </p>
+          <p className="text-xs font-semibold text-slate-500">ユメツリー</p>
+        </div>
+
+        <div>
+          {formattedDate && (
+            <p className="text-sm font-medium text-slate-500">
+              {formattedDate}
+            </p>
+          )}
+          <h2 className="mt-1 text-2xl font-bold leading-tight text-slate-950">
+            {title}
+          </h2>
+        </div>
+
+        {emotionLabels.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {emotionLabels.slice(0, 4).map((label, index) => (
+              <EmotionTag key={`${label}-${index}`} label={label} />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/dream/[id]/page.tsx
+++ b/frontend/app/dream/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import DreamForm from "../../components/DreamForm";
 import DeleteButton from "../../components/DeleteButton";
+import DreamShareCard from "../../components/DreamShareCard";
 import {
   EmotionTag,
   getChildFriendlyEmotionLabel,
@@ -408,6 +409,13 @@ export default function DreamDetailPage({
             {imageError && (
               <p className="text-xs text-destructive">{imageError}</p>
             )}
+            <DreamShareCard
+              imageUrl={generatedImageUrl}
+              title={dream.title}
+              recordedAt={dream.created_at}
+              emotionLabels={displayTags}
+              imageAlt={copy.imageAlt}
+            />
           </div>
         ) : (
           <div className="flex flex-col items-center gap-3 py-6 rounded-xl border border-dashed border-border bg-muted/20">


### PR DESCRIPTION
### Summary

- 夢詳細ページにAI生成画像を使ったシェアカードUIを追加
- 共有カードにはAI生成画像・夢タイトル・記録日・感情タグ・YumeTree表記のみ表示
- 夢本文は共有カードに含めない
- 画像が生成済みの夢だけ共有カードを表示

### Not included

- PNG保存機能なし
- html2canvas / dom-to-image導入なし
- package追加なし
- DB変更なし
- API変更なし
- 認証変更なし
- Stripe変更なし
- OpenAI API変更なし
- SNS共有なし

### Test

- `./node_modules/.bin/jest __tests__/components/DreamDetailPage.test.tsx --runInBand` ✅ 2 passed
- `./node_modules/.bin/playwright test e2e/dream-detail-flow.spec.ts --project=chromium` ✅ 7 passed
- `yarn tsc --noEmit --incremental false` は既存の ThemeToggle.test.tsx / apiClient.test.ts の型エラーで失敗。今回変更ファイル由来ではない