### PR TITLE
feat: 画像保存に向けた画像プロキシAPIを追加

### DIFF
--- a/frontend/__tests__/app/api/image-proxy/route.test.ts
+++ b/frontend/__tests__/app/api/image-proxy/route.test.ts
@@ -1,0 +1,181 @@
+import { GET } from "@/app/api/image-proxy/route";
+
+const fetchMock = jest.fn<typeof fetch>();
+const originalResponse = global.Response;
+
+const ALLOWED_URL =
+  "https://oaidalleapiprodscus.blob.core.windows.net/private/img-test.png";
+
+function makeRequest(url?: string): Request {
+  const qs = url ? `?url=${encodeURIComponent(url)}` : "";
+  return {
+    url: `http://localhost/api/image-proxy${qs}`,
+  } as unknown as Request;
+}
+
+class MockResponse {
+  status: number;
+  headers: { get: (key: string) => string | null };
+
+  constructor(
+    _body: unknown,
+    init?: { status?: number; headers?: Record<string, string> }
+  ) {
+    this.status = init?.status ?? 200;
+    const rawHeaders = init?.headers ?? {};
+    // ヘッダー名を小文字化して正規化する
+    const normalized = Object.fromEntries(
+      Object.entries(rawHeaders).map(([k, v]) => [k.toLowerCase(), v])
+    );
+    this.headers = { get: (key: string) => normalized[key.toLowerCase()] ?? null };
+  }
+}
+
+function makeImageResponse(contentType = "image/png"): Response {
+  return {
+    ok: true,
+    headers: {
+      get: (key: string) => (key === "content-type" ? contentType : null),
+    },
+    arrayBuffer: async () => new ArrayBuffer(8),
+  } as unknown as Response;
+}
+
+describe("GET /api/image-proxy", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    global.Response = MockResponse as unknown as typeof Response;
+  });
+
+  afterAll(() => {
+    global.Response = originalResponse;
+  });
+
+  describe("正常系", () => {
+    it("許可ドメインのURLなら画像を取得して返す", async () => {
+      fetchMock.mockResolvedValue(makeImageResponse());
+
+      const res = await GET(makeRequest(ALLOWED_URL));
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        ALLOWED_URL,
+        expect.objectContaining({ headers: { Accept: "image/*" } })
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("image/png");
+      expect(res.headers.get("cache-control")).toBe("private, max-age=300");
+      expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    });
+
+    it("Content-Type が image/jpeg のときそのまま返す", async () => {
+      fetchMock.mockResolvedValue(makeImageResponse("image/jpeg"));
+
+      const res = await GET(makeRequest(ALLOWED_URL));
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("image/jpeg");
+    });
+
+    it("upstream の Content-Type が image/ 以外なら image/png にフォールバックする", async () => {
+      fetchMock.mockResolvedValue(makeImageResponse("text/html"));
+
+      const res = await GET(makeRequest(ALLOWED_URL));
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("image/png");
+    });
+  });
+
+  describe("400: url パラメータ不正", () => {
+    it("url パラメータが未指定なら 400", async () => {
+      const res = await GET(makeRequest());
+      expect(res.status).toBe(400);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("URLとしてパースできない文字列なら 400", async () => {
+      const res = await GET(makeRequest("not a url at all"));
+      expect(res.status).toBe(400);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("403: SSRF・許可外ドメイン拒否", () => {
+    it("http URL なら 403", async () => {
+      const res = await GET(
+        makeRequest("http://oaidalleapiprodscus.blob.core.windows.net/img.png")
+      );
+      expect(res.status).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("data: URL なら 403（https: ではないため）", async () => {
+      const res = await GET(makeRequest("data:image/png;base64,abc"));
+      expect(res.status).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("localhost なら 403", async () => {
+      const res = await GET(makeRequest("https://localhost/img.png"));
+      expect(res.status).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("127.0.0.1 なら 403", async () => {
+      const res = await GET(makeRequest("https://127.0.0.1/img.png"));
+      expect(res.status).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("192.168.x.x なら 403", async () => {
+      const res = await GET(makeRequest("https://192.168.1.1/img.png"));
+      expect(res.status).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("10.x.x.x なら 403", async () => {
+      const res = await GET(makeRequest("https://10.0.0.1/img.png"));
+      expect(res.status).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("172.16.x.x（プライベートIP）なら 403", async () => {
+      const res = await GET(makeRequest("https://172.16.0.1/img.png"));
+      expect(res.status).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("許可外のパブリックドメインなら 403", async () => {
+      const res = await GET(makeRequest("https://evil.example.com/img.png"));
+      expect(res.status).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("許可ドメインをサブドメインに含む攻撃URLなら 403", async () => {
+      const res = await GET(
+        makeRequest(
+          "https://oaidalleapiprodscus.blob.core.windows.net.evil.com/img.png"
+        )
+      );
+      expect(res.status).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("502: upstream エラー", () => {
+    it("upstream の fetch が例外を投げたら 502", async () => {
+      fetchMock.mockRejectedValue(new Error("network error"));
+
+      const res = await GET(makeRequest(ALLOWED_URL));
+      expect(res.status).toBe(502);
+    });
+
+    it("upstream が non-2xx を返したら 502", async () => {
+      fetchMock.mockResolvedValue({ ok: false } as unknown as Response);
+
+      const res = await GET(makeRequest(ALLOWED_URL));
+      expect(res.status).toBe(502);
+    });
+  });
+});

--- a/frontend/__tests__/app/api/image-proxy/route.test.ts
+++ b/frontend/__tests__/app/api/image-proxy/route.test.ts
@@ -177,5 +177,26 @@ describe("GET /api/image-proxy", () => {
       const res = await GET(makeRequest(ALLOWED_URL));
       expect(res.status).toBe(502);
     });
+
+    it("upstream がリダイレクトを返したら 502（redirect: error でSSRFバイパスを防ぐ）", async () => {
+      // redirect: "error" のとき fetch はリダイレクトで TypeError を投げる
+      fetchMock.mockRejectedValue(new TypeError("Failed to fetch: redirect"));
+
+      const res = await GET(makeRequest(ALLOWED_URL));
+      expect(res.status).toBe(502);
+    });
+  });
+
+  describe("fetch オプションの検証", () => {
+    it("redirect: error を指定して fetch を呼ぶ", async () => {
+      fetchMock.mockResolvedValue(makeImageResponse());
+
+      await GET(makeRequest(ALLOWED_URL));
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        ALLOWED_URL,
+        expect.objectContaining({ redirect: "error" })
+      );
+    });
   });
 });

--- a/frontend/app/api/image-proxy/route.ts
+++ b/frontend/app/api/image-proxy/route.ts
@@ -1,0 +1,80 @@
+// Sentry OpenTelemetry との互換性のため、Node.js Runtime を使用
+export const runtime = "nodejs";
+
+// SSRF対策: 許可するホスト一覧
+// generated_image_url で実際に使用されるOpenAI画像CDNのドメインのみ許可する
+// 参照: frontend/app/dream/[id]/page.tsx の isOpenAiImage 判定ロジック
+const ALLOWED_HOSTS = new Set([
+  "oaidalleapiprodscus.blob.core.windows.net",
+]);
+
+// SSRF対策: プライベートIP・localhost・リンクローカルを拒否する
+function isPrivateOrLocalhost(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  return (
+    h === "localhost" ||
+    h === "127.0.0.1" ||
+    h === "::1" ||
+    h === "[::1]" ||
+    h.startsWith("10.") ||
+    /^172\.(1[6-9]|2[0-9]|3[01])\./.test(h) ||
+    h.startsWith("192.168.") ||
+    h.startsWith("169.254.") ||
+    /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(h)
+  );
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const { searchParams } = new URL(request.url);
+  const rawUrl = searchParams.get("url");
+
+  if (!rawUrl) {
+    return new Response("Missing url parameter", { status: 400 });
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return new Response("Invalid url", { status: 400 });
+  }
+
+  if (parsed.protocol !== "https:") {
+    return new Response("Only https URLs are allowed", { status: 403 });
+  }
+
+  if (isPrivateOrLocalhost(parsed.hostname)) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  if (!ALLOWED_HOSTS.has(parsed.hostname)) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  try {
+    const upstream = await fetch(rawUrl, {
+      headers: { Accept: "image/*" },
+    });
+
+    if (!upstream.ok) {
+      return new Response("Failed to fetch image", { status: 502 });
+    }
+
+    const contentType = upstream.headers.get("content-type") ?? "image/png";
+    const safeContentType = contentType.startsWith("image/")
+      ? contentType
+      : "image/png";
+    const body = await upstream.arrayBuffer();
+
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "Content-Type": safeContentType,
+        "Cache-Control": "private, max-age=300",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  } catch {
+    return new Response("Failed to fetch image", { status: 502 });
+  }
+}

--- a/frontend/app/api/image-proxy/route.ts
+++ b/frontend/app/api/image-proxy/route.ts
@@ -54,6 +54,7 @@ export async function GET(request: Request): Promise<Response> {
   try {
     const upstream = await fetch(rawUrl, {
       headers: { Accept: "image/*" },
+      redirect: "error",
     });
 
     if (!upstream.ok) {


### PR DESCRIPTION
## Summary

- Phase 4-2の前準備として画像プロキシAPI `/api/image-proxy` を追加
- html-to-image で外部AI画像をPNG化する際の CORS 問題（tainted canvas）に対応するための土台
- 許可ドメインのみ fetch するように制限し、SSRF 攻撃を防ぐ

## Not included

- PNG保存機能なし
- html-to-image 導入なし
- DreamShareCard 変更なし
- DB / API バックエンド変更なし
- OpenAI API 変更なし
- package.json / yarn.lock 変更なし

## 実装詳細

### セキュリティ対策（SSRF）

| チェック | 内容 |
|---------|------|
| url 未指定 | 400 |
| URLパース失敗 | 400 |
| https: 以外 | 403 |
| localhost / 127.0.0.1 / ::1 | 403 |
| プライベートIP（10.x / 172.16-31.x / 192.168.x） | 403 |
| リンクローカル（169.254.x） | 403 |
| 許可外ドメイン | 403 |
| upstream 失敗 | 502 |

### 許可ドメイン

`oaidalleapiprodscus.blob.core.windows.net`（YumeTreeで実際に使用中のOpenAI画像CDN）

### レスポンス

- `Content-Type`: upstream のものをそのまま使用（`image/` 以外なら `image/png` にフォールバック）
- `Cache-Control: private, max-age=300`
- `X-Content-Type-Options: nosniff`

## Test

```
Tests: 16 passed, 16 total

正常系:
  ✓ 許可ドメインのURLなら画像を取得して返す
  ✓ Content-Type が image/jpeg のときそのまま返す
  ✓ upstream の Content-Type が image/ 以外なら image/png にフォールバックする

400:
  ✓ url パラメータが未指定なら 400
  ✓ URLとしてパースできない文字列なら 400

403:
  ✓ http URL なら 403
  ✓ data: URL なら 403
  ✓ localhost なら 403
  ✓ 127.0.0.1 なら 403
  ✓ 192.168.x.x なら 403
  ✓ 10.x.x.x なら 403
  ✓ 172.16.x.x なら 403
  ✓ 許可外のパブリックドメインなら 403
  ✓ 許可ドメインをサブドメインに含む攻撃URLなら 403

502:
  ✓ upstream の fetch が例外を投げたら 502
  ✓ upstream が non-2xx を返したら 502
```

TypeScript: エラーなし
既存テスト（DreamDetailPage / DreamShareCard）: 影響なし