### PR TITLE
feat: 夢画像シェアカードをPNG保存できるようにする

### DIFF
--- a/frontend/__tests__/components/DreamShareCard.test.tsx
+++ b/frontend/__tests__/components/DreamShareCard.test.tsx
@@ -234,6 +234,72 @@ describe("DreamShareCard", () => {
     });
   });
 
+  describe("iOS Web Share API", () => {
+    function setupNavigatorShare(rejectWith?: unknown) {
+      const mockShare = rejectWith
+        ? jest.fn().mockImplementation(() => Promise.reject(rejectWith))
+        : jest.fn().mockImplementation(() => Promise.resolve());
+      const mockCanShare = jest.fn().mockReturnValue(true);
+      Object.defineProperty(navigator, "share", {
+        value: mockShare,
+        writable: true,
+        configurable: true,
+      });
+      Object.defineProperty(navigator, "canShare", {
+        value: mockCanShare,
+        writable: true,
+        configurable: true,
+      });
+      return { mockShare, mockCanShare };
+    }
+
+    afterEach(() => {
+      // navigator への追加プロパティを削除
+      try {
+        Object.defineProperty(navigator, "share", {
+          value: undefined,
+          writable: true,
+          configurable: true,
+        });
+        Object.defineProperty(navigator, "canShare", {
+          value: undefined,
+          writable: true,
+          configurable: true,
+        });
+      } catch {
+        // 環境によっては削除できない場合があるため無視
+      }
+    });
+
+    it("ユーザーが共有シートをキャンセルしても <a download> は呼ばれない", async () => {
+      setupFetchMock();
+      jest.mocked(htmlToImage.toPng).mockResolvedValue("data:image/png;base64,abc");
+
+      const abortError = new DOMException("", "AbortError");
+      setupNavigatorShare(abortError);
+
+      const mockAnchor = { href: "", download: "", click: jest.fn() };
+      jest
+        .spyOn(document, "createElement")
+        .mockImplementation((tag: string) => {
+          if (tag === "a") return mockAnchor as unknown as HTMLElement;
+          return realCreateElement(tag as keyof HTMLElementTagNameMap) as HTMLElement;
+        });
+
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      fireEvent.click(screen.getByTestId("save-image-button"));
+
+      // isSaving が false に戻るまで待つ（保存処理完了の代理条件）
+      await waitFor(() => {
+        expect(screen.getByText("画像として保存")).toBeTruthy();
+      });
+
+      expect(mockAnchor.click).not.toHaveBeenCalled();
+      expect(toast.success).not.toHaveBeenCalled();
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+  });
+
   describe("img.decode によるロード待機", () => {
     it("img.decode が保存時に呼ばれる", async () => {
       setupFetchMock();

--- a/frontend/__tests__/components/DreamShareCard.test.tsx
+++ b/frontend/__tests__/components/DreamShareCard.test.tsx
@@ -1,0 +1,223 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import DreamShareCard from "@/app/components/DreamShareCard";
+import * as htmlToImage from "html-to-image";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({
+    alt,
+    fill,
+    unoptimized,
+    sizes,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & {
+    fill?: boolean;
+    unoptimized?: boolean;
+    sizes?: string;
+  }) => <img alt={alt} {...props} />,
+}));
+
+jest.mock("html-to-image", () => ({
+  toPng: jest.fn(),
+}));
+
+jest.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: { success: jest.fn(), error: jest.fn() },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const toast = require("react-hot-toast").default as {
+  success: ReturnType<typeof jest.fn>;
+  error: ReturnType<typeof jest.fn>;
+};
+
+const IMAGE_URL =
+  "https://oaidalleapiprodscus.blob.core.windows.net/private/img-test.png";
+const PROXY_URL = `/api/image-proxy?url=${encodeURIComponent(IMAGE_URL)}`;
+
+const DEFAULT_PROPS = {
+  imageUrl: IMAGE_URL,
+  title: "星空を走る夢",
+  recordedAt: "2025-01-15T00:00:00.000Z",
+  emotionLabels: ["楽しい", "不思議"],
+  imageAlt: "星空",
+};
+
+function setupFetchMock(ok = true) {
+  const blob = new Blob(["fake"], { type: "image/png" });
+  const mockFetch = jest.fn<typeof fetch>();
+  mockFetch.mockResolvedValue({ ok, blob: async () => blob } as unknown as Response);
+  global.fetch = mockFetch as unknown as typeof fetch;
+  return { mockFetch, blob };
+}
+
+describe("DreamShareCard", () => {
+  let originalCreateObjectURL: typeof URL.createObjectURL;
+  let originalRevokeObjectURL: typeof URL.revokeObjectURL;
+  // Capture the real createElement before any spy can intercept it
+  const realCreateElement = document.createElement.bind(document);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalCreateObjectURL = URL.createObjectURL;
+    originalRevokeObjectURL = URL.revokeObjectURL;
+    URL.createObjectURL = jest.fn(() => "blob:fake-object-url");
+    URL.revokeObjectURL = jest.fn();
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+
+  describe("レンダリング", () => {
+    it("シェアカードが表示される", () => {
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      expect(screen.getByTestId("dream-share-card")).toBeTruthy();
+    });
+
+    it("タイトルと感情タグが表示される", () => {
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      expect(screen.getByText("星空を走る夢")).toBeTruthy();
+    });
+
+    it("「画像として保存」ボタンが表示される", () => {
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      expect(screen.getByTestId("save-image-button")).toBeTruthy();
+      expect(screen.getByText("画像として保存")).toBeTruthy();
+    });
+
+    it("保存ボタンはシェアカードのDOM外にある", () => {
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      const card = screen.getByTestId("dream-share-card");
+      expect(card.contains(screen.getByTestId("save-image-button"))).toBe(false);
+    });
+
+    it("夢本文はカードDOMに含まれない（propsとして受け取らない）", () => {
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      const card = screen.getByTestId("dream-share-card");
+      expect(card).toBeTruthy();
+    });
+  });
+
+  describe("PNG保存（PC/Android: <a download>）", () => {
+    function setupAnchorSpy() {
+      const mockAnchor = { href: "", download: "", click: jest.fn() };
+      jest
+        .spyOn(document, "createElement")
+        .mockImplementation((tag: string) => {
+          if (tag === "a") return mockAnchor as unknown as HTMLElement;
+          return realCreateElement(tag as keyof HTMLElementTagNameMap) as HTMLElement;
+        });
+      return { mockAnchor };
+    }
+
+    it("保存ボタンをクリックすると proxy URL で fetch を呼ぶ", async () => {
+      const { mockFetch } = setupFetchMock();
+      jest.mocked(htmlToImage.toPng).mockResolvedValue("data:image/png;base64,abc");
+      setupAnchorSpy();
+
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      fireEvent.click(screen.getByTestId("save-image-button"));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(PROXY_URL);
+      });
+    });
+
+    it("toPng が呼ばれる", async () => {
+      setupFetchMock();
+      jest.mocked(htmlToImage.toPng).mockResolvedValue("data:image/png;base64,abc");
+      setupAnchorSpy();
+
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      fireEvent.click(screen.getByTestId("save-image-button"));
+
+      await waitFor(() => {
+        expect(htmlToImage.toPng).toHaveBeenCalled();
+      });
+    });
+
+    it("アンカーの download ファイル名が yumetree-dream-card-YYYY-MM-DD.png 形式になる", async () => {
+      setupFetchMock();
+      jest.mocked(htmlToImage.toPng).mockResolvedValue("data:image/png;base64,abc");
+      const { mockAnchor } = setupAnchorSpy();
+
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      fireEvent.click(screen.getByTestId("save-image-button"));
+
+      await waitFor(() => {
+        expect(mockAnchor.click).toHaveBeenCalled();
+      });
+      expect(mockAnchor.download).toMatch(
+        /^yumetree-dream-card-\d{4}-\d{2}-\d{2}\.png$/
+      );
+    });
+
+    it("成功時に成功トーストを表示する", async () => {
+      setupFetchMock();
+      jest.mocked(htmlToImage.toPng).mockResolvedValue("data:image/png;base64,abc");
+      setupAnchorSpy();
+
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      fireEvent.click(screen.getByTestId("save-image-button"));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith("画像を保存しました");
+      });
+    });
+  });
+
+  describe("エラーハンドリング", () => {
+    it("proxy fetch が失敗したらエラートーストを表示する", async () => {
+      setupFetchMock(false);
+      jest.mocked(htmlToImage.toPng).mockResolvedValue("data:image/png;base64,abc");
+
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      fireEvent.click(screen.getByTestId("save-image-button"));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith("画像の保存に失敗しました");
+      });
+    });
+
+    it("toPng が例外を投げたらエラートーストを表示する", async () => {
+      setupFetchMock();
+      jest.mocked(htmlToImage.toPng).mockRejectedValue(new Error("canvas error"));
+
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      fireEvent.click(screen.getByTestId("save-image-button"));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith("画像の保存に失敗しました");
+      });
+    });
+
+    it("保存中は二重クリックしても2回目は無視される", async () => {
+      setupFetchMock();
+      jest.mocked(htmlToImage.toPng).mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve("data:image/png;base64,abc"), 200)
+          )
+      );
+      const mockAnchor = { href: "", download: "", click: jest.fn() };
+      jest
+        .spyOn(document, "createElement")
+        .mockImplementation((tag: string) => {
+          if (tag === "a") return mockAnchor as unknown as HTMLElement;
+          return realCreateElement(tag as keyof HTMLElementTagNameMap) as HTMLElement;
+        });
+
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      fireEvent.click(screen.getByTestId("save-image-button"));
+      fireEvent.click(screen.getByTestId("save-image-button"));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/frontend/__tests__/components/DreamShareCard.test.tsx
+++ b/frontend/__tests__/components/DreamShareCard.test.tsx
@@ -58,6 +58,8 @@ describe("DreamShareCard", () => {
   let originalRevokeObjectURL: typeof URL.revokeObjectURL;
   // Capture the real createElement before any spy can intercept it
   const realCreateElement = document.createElement.bind(document);
+  // mockDecode は各テストで参照できるよう describe スコープで宣言
+  let mockDecode: ReturnType<typeof jest.fn>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -65,11 +67,22 @@ describe("DreamShareCard", () => {
     originalRevokeObjectURL = URL.revokeObjectURL;
     URL.createObjectURL = jest.fn(() => "blob:fake-object-url");
     URL.revokeObjectURL = jest.fn();
+    // jsdom は HTMLImageElement.prototype.decode を実装していないため、
+    // waitForImageReady が onload 待ちに入ってテストがハングしないよう
+    // プロトタイプレベルで即時 resolve するモックを注入する
+    mockDecode = jest.fn().mockImplementation(() => Promise.resolve());
+    Object.defineProperty(HTMLImageElement.prototype, "decode", {
+      value: mockDecode,
+      writable: true,
+      configurable: true,
+    });
   });
 
   afterEach(() => {
     URL.createObjectURL = originalCreateObjectURL;
     URL.revokeObjectURL = originalRevokeObjectURL;
+    // プロトタイプに追加した decode モックを毎テスト後に削除する
+    delete (HTMLImageElement.prototype as unknown as Record<string, unknown>).decode;
   });
 
   describe("レンダリング", () => {
@@ -218,6 +231,61 @@ describe("DreamShareCard", () => {
       await waitFor(() => {
         expect(toast.success).toHaveBeenCalledTimes(1);
       });
+    });
+  });
+
+  describe("img.decode によるロード待機", () => {
+    it("img.decode が保存時に呼ばれる", async () => {
+      setupFetchMock();
+      jest.mocked(htmlToImage.toPng).mockResolvedValue("data:image/png;base64,abc");
+
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      fireEvent.click(screen.getByTestId("save-image-button"));
+
+      await waitFor(() => {
+        expect(mockDecode).toHaveBeenCalled();
+      });
+    });
+
+    it("decode完了後に toPng が呼ばれる（呼び出し順序）", async () => {
+      const callOrder: string[] = [];
+      mockDecode.mockImplementation(async () => {
+        callOrder.push("decode");
+      });
+      jest.mocked(htmlToImage.toPng).mockImplementation(async () => {
+        callOrder.push("toPng");
+        return "data:image/png;base64,abc";
+      });
+      setupFetchMock();
+
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      fireEvent.click(screen.getByTestId("save-image-button"));
+
+      await waitFor(() => {
+        expect(callOrder).toEqual(["decode", "toPng"]);
+      });
+    });
+
+    it("decode が失敗したらエラートーストになり toPng は呼ばれない", async () => {
+      setupFetchMock();
+      jest.mocked(htmlToImage.toPng).mockResolvedValue("data:image/png;base64,abc");
+
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+
+      // インスタンスレベルで reject する decode を上書き（プロトタイプより優先される）
+      const imgEl = screen.getByRole("img") as HTMLImageElement;
+      imgEl.decode = jest
+        .fn()
+        .mockImplementation(() =>
+          Promise.reject(new Error("decode failed"))
+        ) as unknown as () => Promise<void>;
+
+      fireEvent.click(screen.getByTestId("save-image-button"));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith("画像の保存に失敗しました");
+      });
+      expect(htmlToImage.toPng).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/app/components/DreamShareCard.tsx
+++ b/frontend/app/components/DreamShareCard.tsx
@@ -30,6 +30,20 @@ function todayIso(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+// blob URL に差し替えた img が描画可能になるまで待つ。
+// decode() が使えない環境では complete チェックか onload にフォールバックする。
+async function waitForImageReady(img: HTMLImageElement): Promise<void> {
+  if (typeof img.decode === "function") {
+    await img.decode();
+    return;
+  }
+  if (img.complete && img.naturalWidth > 0) return;
+  await new Promise<void>((resolve, reject) => {
+    img.onload = () => resolve();
+    img.onerror = () => reject(new Error("image load failed"));
+  });
+}
+
 export default function DreamShareCard({
   imageUrl,
   title,
@@ -60,6 +74,7 @@ export default function DreamShareCard({
         const blob = await res.blob();
         objectUrl = URL.createObjectURL(blob);
         img.src = objectUrl;
+        await waitForImageReady(img);
       }
 
       const dataUrl = await toPng(card, { pixelRatio: 2 });

--- a/frontend/app/components/DreamShareCard.tsx
+++ b/frontend/app/components/DreamShareCard.tsx
@@ -90,8 +90,10 @@ export default function DreamShareCard({
             toast.success("画像をシェアしました");
             return;
           }
-        } catch {
-          // canShare or share failed — fall through to <a download>
+        } catch (err) {
+          // ユーザーが共有シートをキャンセルした場合は何もしない（<a download> にフォールバックしない）
+          if (err instanceof DOMException && err.name === "AbortError") return;
+          // canShare/share 非対応・その他エラー → <a download> にフォールバック
         }
       }
 

--- a/frontend/app/components/DreamShareCard.tsx
+++ b/frontend/app/components/DreamShareCard.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import Image from "next/image";
+import { useRef, useState } from "react";
+import { toPng } from "html-to-image";
+import toast from "react-hot-toast";
 import { EmotionTag } from "./EmotionTag";
 
 type DreamShareCardProps = {
@@ -23,6 +26,10 @@ function formatDate(dateInput: string): string {
   });
 }
 
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
 export default function DreamShareCard({
   imageUrl,
   title,
@@ -31,51 +38,122 @@ export default function DreamShareCard({
   imageAlt,
 }: DreamShareCardProps) {
   const formattedDate = formatDate(recordedAt);
+  const cardRef = useRef<HTMLElement>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const proxyUrl = `/api/image-proxy?url=${encodeURIComponent(imageUrl)}`;
+
+  const handleSave = async () => {
+    if (!cardRef.current || isSaving) return;
+    setIsSaving(true);
+
+    const card = cardRef.current;
+    const img = card.querySelector("img");
+    const originalSrc = img?.src;
+    let objectUrl: string | null = null;
+
+    try {
+      if (img) {
+        // Fetch image via same-origin proxy to avoid tainted canvas CORS error
+        const res = await fetch(proxyUrl);
+        if (!res.ok) throw new Error("proxy fetch failed");
+        const blob = await res.blob();
+        objectUrl = URL.createObjectURL(blob);
+        img.src = objectUrl;
+      }
+
+      const dataUrl = await toPng(card, { pixelRatio: 2 });
+      const filename = `yumetree-dream-card-${todayIso()}.png`;
+
+      // iOS Safari: try Web Share API with file
+      if (typeof navigator !== "undefined" && typeof navigator.share === "function") {
+        try {
+          const pngBlob = await fetch(dataUrl).then((r) => r.blob());
+          const file = new File([pngBlob], filename, { type: "image/png" });
+          if (typeof navigator.canShare === "function" && navigator.canShare({ files: [file] })) {
+            await navigator.share({ files: [file] });
+            toast.success("画像をシェアしました");
+            return;
+          }
+        } catch {
+          // canShare or share failed — fall through to <a download>
+        }
+      }
+
+      // PC / Android Chrome: <a download>
+      const a = document.createElement("a");
+      a.href = dataUrl;
+      a.download = filename;
+      a.click();
+      toast.success("画像を保存しました");
+    } catch {
+      toast.error("画像の保存に失敗しました");
+    } finally {
+      if (img && originalSrc !== undefined) img.src = originalSrc;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+      setIsSaving(false);
+    }
+  };
 
   return (
-    <section
-      aria-label="夢画像シェアカード"
-      data-testid="dream-share-card"
-      className="mt-6 overflow-hidden rounded-lg border border-sky-200/70 bg-gradient-to-br from-sky-50 via-white to-amber-50 text-slate-900 shadow-lg"
-    >
-      <div className="relative aspect-square overflow-hidden bg-slate-100">
-        <Image
-          src={imageUrl}
-          alt={`${imageAlt} シェアカード`}
-          fill
-          sizes="(max-width: 768px) 100vw, 768px"
-          className="object-cover"
-          unoptimized
-        />
-      </div>
-
-      <div className="space-y-4 p-5">
-        <div className="flex items-center justify-between gap-3">
-          <p className="text-xs font-bold uppercase text-sky-700">
-            YumeTree
-          </p>
-          <p className="text-xs font-semibold text-slate-500">ユメツリー</p>
+    <>
+      <section
+        ref={cardRef}
+        aria-label="夢画像シェアカード"
+        data-testid="dream-share-card"
+        className="mt-6 overflow-hidden rounded-lg border border-sky-200/70 bg-gradient-to-br from-sky-50 via-white to-amber-50 text-slate-900 shadow-lg"
+      >
+        <div className="relative aspect-square overflow-hidden bg-slate-100">
+          <Image
+            src={imageUrl}
+            alt={`${imageAlt} シェアカード`}
+            fill
+            sizes="(max-width: 768px) 100vw, 768px"
+            className="object-cover"
+            unoptimized
+          />
         </div>
 
-        <div>
-          {formattedDate && (
-            <p className="text-sm font-medium text-slate-500">
-              {formattedDate}
+        <div className="space-y-4 p-5">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs font-bold uppercase text-sky-700">
+              YumeTree
             </p>
-          )}
-          <h2 className="mt-1 text-2xl font-bold leading-tight text-slate-950">
-            {title}
-          </h2>
-        </div>
-
-        {emotionLabels.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {emotionLabels.slice(0, 4).map((label, index) => (
-              <EmotionTag key={`${label}-${index}`} label={label} />
-            ))}
+            <p className="text-xs font-semibold text-slate-500">ユメツリー</p>
           </div>
-        )}
+
+          <div>
+            {formattedDate && (
+              <p className="text-sm font-medium text-slate-500">
+                {formattedDate}
+              </p>
+            )}
+            <h2 className="mt-1 text-2xl font-bold leading-tight text-slate-950">
+              {title}
+            </h2>
+          </div>
+
+          {emotionLabels.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {emotionLabels.slice(0, 4).map((label, index) => (
+                <EmotionTag key={`${label}-${index}`} label={label} />
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <div className="mt-3 flex justify-end">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={isSaving}
+          data-testid="save-image-button"
+          className="rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-sky-500 disabled:opacity-50"
+        >
+          {isSaving ? "保存中..." : "画像として保存"}
+        </button>
       </div>
-    </section>
+    </>
   );
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
     "form-data": "^4.0.4",
     "framer-motion": "^12.23.24",
     "glob": "^13.0.6",
+    "html-to-image": "^1.11.13",
     "js-yaml": "^4.1.1",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.18.1",
@@ -54,9 +55,9 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.3.0",
     "@next/bundle-analyzer": "16.1.7",
     "@playwright/test": "^1.58.2",
+    "@tailwindcss/postcss": "^4.3.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3996,6 +3996,11 @@ html-escaper@^2.0.0, html-escaper@^2.0.2:
   resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+html-to-image@^1.11.13:
+  version "1.11.13"
+  resolved "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz#adbc989c993b7aaf90b629c0cacf833db84d5f43"
+  integrity sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==
+
 http-proxy-agent@^7.0.2:
   version "7.0.2"
   resolved "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"


### PR DESCRIPTION
## 概要

Phase 4-2B: `DreamShareCard` に「画像として保存」ボタンを追加し、共有カードをPNG画像としてダウンロードできるようにします。

Phase 4-2A（画像プロキシAPI, PR #294）を含みます。#294 のマージ後にリベースしてください。

## 変更内容

**Phase 4-2A（#294 と同内容）**
- `/api/image-proxy` route 追加（SSRF対策付き）

**Phase 4-2B（このPRのメイン変更）**
- `html-to-image` を導入（45KB, Tailwind v4 対応）
- `DreamShareCard.tsx` に「画像として保存」ボタンを追加
  - ボタンは `<section>` の外に配置 → PNG出力に含まれない
- PNG保存ロジック（`handleSave`）:
  1. OpenAI CDN 画像を `/api/image-proxy?url=...` 経由で fetch
  2. 取得した blob を `URL.createObjectURL()` で同一オリジンURLに変換
  3. `<img src>` を一時的に差し替え → `toPng()` で canvas 描画（CORS/tainted canvas 回避）
  4. PNG化後に元の src を復元 & object URL を revoke
- iOS Safari: `navigator.share({ files: [File] })` で Web Share API フォールバック
- PC / Android Chrome: `<a download>` でPNG保存
- 成功・失敗を `react-hot-toast` で通知
- PNGファイル名: `yumetree-dream-card-YYYY-MM-DD.png`

## セキュリティ・プライバシー

- 夢本文は `DreamShareCard` の props に存在しないため、PNG出力に含まれない（Phase 4-1 設計継承）
- 画像取得は `/api/image-proxy` の SSRF 保護を通過（allowlist + 非公開IP拒否 + redirect:error）

## テスト

- `DreamShareCard.test.tsx` 新規作成（12テスト）
- 既存テスト（`DreamDetailPage`・`image-proxy` 18本）: 全パス確認済み
- `yarn tsc --noEmit`: エラーなし