### PR TITLE
feat: 夢画像シェアカードにリンクコピー機能を追加

### DIFF
--- a/frontend/__tests__/components/DreamShareCard.test.tsx
+++ b/frontend/__tests__/components/DreamShareCard.test.tsx
@@ -60,6 +60,7 @@ describe("DreamShareCard", () => {
   const realCreateElement = document.createElement.bind(document);
   // mockDecode は各テストで参照できるよう describe スコープで宣言
   let mockDecode: ReturnType<typeof jest.fn>;
+  let writeTextMock: ReturnType<typeof jest.fn>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -76,11 +77,22 @@ describe("DreamShareCard", () => {
       writable: true,
       configurable: true,
     });
+    writeTextMock = jest.fn().mockImplementation(() => Promise.resolve());
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: writeTextMock },
+      writable: true,
+      configurable: true,
+    });
   });
 
   afterEach(() => {
     URL.createObjectURL = originalCreateObjectURL;
     URL.revokeObjectURL = originalRevokeObjectURL;
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
     // プロトタイプに追加した decode モックを毎テスト後に削除する
     delete (HTMLImageElement.prototype as unknown as Record<string, unknown>).decode;
   });
@@ -102,16 +114,68 @@ describe("DreamShareCard", () => {
       expect(screen.getByText("画像として保存")).toBeTruthy();
     });
 
-    it("保存ボタンはシェアカードのDOM外にある", () => {
+    it("「リンクをコピー」ボタンが表示される", () => {
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      expect(screen.getByTestId("copy-link-button")).toBeTruthy();
+      expect(screen.getByText("リンクをコピー")).toBeTruthy();
+    });
+
+    it("操作ボタンはシェアカードのDOM外にある", () => {
       render(<DreamShareCard {...DEFAULT_PROPS} />);
       const card = screen.getByTestId("dream-share-card");
       expect(card.contains(screen.getByTestId("save-image-button"))).toBe(false);
+      expect(card.contains(screen.getByTestId("copy-link-button"))).toBe(false);
     });
 
     it("夢本文はカードDOMに含まれない（propsとして受け取らない）", () => {
       render(<DreamShareCard {...DEFAULT_PROPS} />);
       const card = screen.getByTestId("dream-share-card");
       expect(card).toBeTruthy();
+    });
+  });
+
+  describe("リンクコピー", () => {
+    it("リンクコピーボタンをクリックすると現在のURLをクリップボードにコピーする", async () => {
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      fireEvent.click(screen.getByTestId("copy-link-button"));
+
+      await waitFor(() => {
+        expect(writeTextMock).toHaveBeenCalledWith(window.location.href);
+      });
+    });
+
+    it("コピー対象URLに夢本文は含まれない", async () => {
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      fireEvent.click(screen.getByTestId("copy-link-button"));
+
+      await waitFor(() => {
+        expect(writeTextMock).toHaveBeenCalled();
+      });
+      expect(writeTextMock.mock.calls[0][0]).not.toContain(
+        "これは共有カードに出してはいけない夢本文です"
+      );
+    });
+
+    it("コピー成功時に成功トーストを表示する", async () => {
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      fireEvent.click(screen.getByTestId("copy-link-button"));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith("リンクをコピーしました");
+      });
+    });
+
+    it("コピー失敗時にエラートーストを表示する", async () => {
+      writeTextMock.mockRejectedValue(new Error("clipboard error"));
+
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      fireEvent.click(screen.getByTestId("copy-link-button"));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          "リンクのコピーに失敗しました"
+        );
+      });
     });
   });
 

--- a/frontend/app/components/DreamShareCard.tsx
+++ b/frontend/app/components/DreamShareCard.tsx
@@ -57,6 +57,18 @@ export default function DreamShareCard({
 
   const proxyUrl = `/api/image-proxy?url=${encodeURIComponent(imageUrl)}`;
 
+  const handleCopyLink = async () => {
+    try {
+      if (!navigator.clipboard?.writeText) {
+        throw new Error("clipboard unavailable");
+      }
+      await navigator.clipboard.writeText(window.location.href);
+      toast.success("リンクをコピーしました");
+    } catch {
+      toast.error("リンクのコピーに失敗しました");
+    }
+  };
+
   const handleSave = async () => {
     if (!cardRef.current || isSaving) return;
     setIsSaving(true);
@@ -160,7 +172,15 @@ export default function DreamShareCard({
         </div>
       </section>
 
-      <div className="mt-3 flex justify-end">
+      <div className="mt-3 flex flex-wrap justify-end gap-2">
+        <button
+          type="button"
+          onClick={handleCopyLink}
+          data-testid="copy-link-button"
+          className="rounded-md border border-sky-200 bg-white px-4 py-2 text-sm font-semibold text-sky-700 shadow-sm hover:bg-sky-50"
+        >
+          リンクをコピー
+        </button>
         <button
           type="button"
           onClick={handleSave}


### PR DESCRIPTION
### Summary
- DreamShareCardにリンクコピー機能を追加
- 現在の夢詳細ページURLをクリップボードにコピー
- 成功/失敗をtoastで通知
- PNG保存対象には操作ボタンを含めない

### Not included
- 公開共有URLなし
- SNS共有なし
- DB変更なし
- Rails API変更なし
- 認証変更なし
- Stripe変更なし
- OpenAI API変更なし
- Phase 5メンバー機能なし

### Test
- `npx jest __tests__/components/DreamShareCard.test.tsx --runInBand` — 21 passed
- `npx jest __tests__/components/DreamDetailPage.test.tsx --runInBand` — 2 passed
- `npx playwright test e2e/dream-detail-flow.spec.ts --project=chromium` — 7 passed
- `yarn tsc --noEmit --incremental false` — passed