### PR TITLE
fix: ai_usage_logs のRLSを有効化する

### DIFF
--- a/backend/db/migrate/20260528044316_enable_rls_on_ai_usage_logs.rb
+++ b/backend/db/migrate/20260528044316_enable_rls_on_ai_usage_logs.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Supabase セキュリティアドバイザーの RLS 警告を解消するマイグレーション
+#
+# 【背景】
+# public.ai_usage_logs テーブルに RLS が有効化されておらず、
+# Supabase Security Advisor に警告が出ていた。
+#
+# 【設計方針】
+# このアプリは Rails API のみが DB に接続する設計のため、
+# PostgREST（Supabase の直接接続口）からのアクセスは全遮断が正しい。
+# RLS を有効化し、ポリシーを追加しないことで「デフォルト拒否（Default Deny）」を実現。
+#
+# 【影響範囲】
+# Rails は postgres ロール（スーパーユーザー / BYPASSRLS 権限あり）で接続するため
+# RLS 有効化後も既存処理（ログ記録・レート制限カウント）に影響なし。
+# フロントエンドから Supabase への直接アクセスはないため anon / authenticated ロール用
+# ポリシーの追加は不要。
+#
+# 【注意】
+# schema.rb（Ruby形式）は RLS 設定を記録しない。
+# このmigrationでバージョン管理する。
+class EnableRlsOnAiUsageLogs < ActiveRecord::Migration[7.1]
+  def up
+    # RLS を有効化（ポリシーなし = 全行を拒否 = Default Deny）
+    execute "ALTER TABLE public.ai_usage_logs ENABLE ROW LEVEL SECURITY;"
+
+    # Rails サービスアカウントは BYPASSRLS 権限を持つため引き続き全アクセス可能
+    # Supabase PostgREST / anon ロールからのアクセスは遮断される
+  end
+
+  def down
+    execute "ALTER TABLE public.ai_usage_logs DISABLE ROW LEVEL SECURITY;"
+  end
+end


### PR DESCRIPTION
## Summary

- Supabase Security Advisor の `public.ai_usage_logs` RLS無効警告を解消する
- `ALTER TABLE public.ai_usage_logs ENABLE ROW LEVEL SECURITY;` をmigrationで管理する
- policyは追加しない（Default Deny）

## 背景

Supabase Security Advisor が `public.ai_usage_logs` の RLS 未設定を警告していた。
コードベースを調査した結果、以下を確認した。

- `ai_usage_logs` は Rails backend のみが利用（AIレート制限ログ）
- フロントエンドから Supabase への直接アクセスはない（`@supabase/supabase-js` 未使用）
- Rails は `postgres` ロール（スーパーユーザー / BYPASSRLS 権限あり）で接続する

## 設計方針

RLS を有効化し、ポリシーを追加しないことで「デフォルト拒否（Default Deny）」を実現する。

- Rails（postgres ロール）は BYPASSRLS 権限を持つため、RLS 有効化後も既存処理に影響なし
  - `AiUsageLog.create!`（ログ記録）: 影響なし
  - `.today_for_user(...).count`（日次上限チェック）: 影響なし
  - `.this_month_for_user(...).count`（月次上限チェック）: 影響なし
- `anon` / `authenticated` ロールからの想定外アクセスを遮断する
- `USING (true)` のような広い許可ポリシーは追加しない

## 変更ファイル

- `backend/db/migrate/20260528044316_enable_rls_on_ai_usage_logs.rb`（新規）

## 注意事項

`schema.rb`（Ruby形式）は RLS 設定を記録しない。
そのため `schema.rb` に変化はないが、migration がバージョン管理の記録となる。
既存の `20260424000000_enable_rls_on_dream_image_generations.rb` と同じパターン。

## 本番適用手順

1. このPRをマージする
2. Render の自動デプロイで `rails db:migrate` が実行される
3. Supabase Security Advisor の警告が解消されることを確認する

## ローカルテスト

Docker 未起動のためローカルでの `db:migrate` / RSpec は未実行。
CI（RSpec / Jest / Playwright）で確認する。
