### PR TITLE
chore: Sentry DSNを環境変数化する

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -135,6 +135,7 @@ services:
       args:
         NODE_ENV: production
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
+        NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN}
     
     # 🔧 本番環境変数
     environment:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -16,6 +16,13 @@ NEXT_PUBLIC_API_URL=http://localhost:3001
 # サーバーサイドからの内部API接続用URL（Docker環境では service名:port）
 INTERNAL_API_URL=http://backend:3001
 
+
+# ========================================
+# 🔍 Sentry エラー監視
+# ========================================
+# Sentry プロジェクトの DSN (Data Source Name)
+# Sentry ダッシュボード → Settings → Projects → Client Keys で確認できます
+NEXT_PUBLIC_SENTRY_DSN=your_sentry_dsn_here
 # ========================================
 # 🛠️ 開発環境設定
 # ========================================

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,6 +7,13 @@ RUN yarn install --frozen-lockfile --network-timeout 1000000
 # Stage 2: ビルドステージ
 FROM node:20-alpine AS builder
 WORKDIR /app
+
+# NEXT_PUBLIC_* はビルド時にバンドルへ埋め込まれるため ARG/ENV で受け取る
+ARG NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_SENTRY_DSN
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
+
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN yarn build

--- a/frontend/instrumentation-client.ts
+++ b/frontend/instrumentation-client.ts
@@ -5,16 +5,15 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://38aa8c3f6fc09459a77d941107b8c530@o4510693712855040.ingest.us.sentry.io/4510693744115712",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
   // Enable logs to be sent to Sentry
   enableLogs: true,
 
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
+  // PII（個人識別情報）の自動送信は無効化。エラー調査に必要な場合のみ有効化する。
+  sendDefaultPii: false,
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/frontend/sentry.edge.config.ts
+++ b/frontend/sentry.edge.config.ts
@@ -6,7 +6,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://38aa8c3f6fc09459a77d941107b8c530@o4510693712855040.ingest.us.sentry.io/4510693744115712",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
@@ -14,7 +14,6 @@ Sentry.init({
   // Enable logs to be sent to Sentry
   enableLogs: true,
 
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
+  // PII（個人識別情報）の自動送信は無効化。エラー調査に必要な場合のみ有効化する。
+  sendDefaultPii: false,
 });

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -5,7 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://38aa8c3f6fc09459a77d941107b8c530@o4510693712855040.ingest.us.sentry.io/4510693744115712",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
@@ -13,7 +13,6 @@ Sentry.init({
   // Enable logs to be sent to Sentry
   enableLogs: true,
 
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
+  // PII（個人識別情報）の自動送信は無効化。エラー調査に必要な場合のみ有効化する。
+  sendDefaultPii: false,
 });


### PR DESCRIPTION
### Summary

- Sentry DSN直書きを `process.env.NEXT_PUBLIC_SENTRY_DSN` に置き換え
- `sendDefaultPii: true` → `false`（PII自動送信を無効化）
- `frontend/.env.example` に `NEXT_PUBLIC_SENTRY_DSN` プレースホルダーを追加

#### 変更ファイルと内容

| ファイル | 変更内容 |
|---|---|
| `frontend/instrumentation-client.ts` | DSN環境変数化・sendDefaultPii無効化 |
| `frontend/sentry.edge.config.ts` | DSN環境変数化・sendDefaultPii無効化 |
| `frontend/sentry.server.config.ts` | DSN環境変数化・sendDefaultPii無効化 |
| `frontend/.env.example` | `NEXT_PUBLIC_SENTRY_DSN=your_sentry_dsn_here` を追加 |

#### sendDefaultPii について

`true` のままだとIPアドレス・Cookie・ユーザーエージェント等のPIIがSentryに自動送信される。
夢日記アプリとして個人情報保護の観点から `false` に変更。
エラー調査で詳細が必要な場合のみ一時的に有効化することをコメントに明記。

### Not included

- Sentry設定の機能変更なし（DSN・tracesSampleRate・enableLogsは維持）
- Phase 5変更なし
- Dependabot対応なし
- migration なし

### Test

- TypeScriptチェック: Sentry設定ファイル3件にエラーなし
- 既存の `AuthContext.test.tsx` に pre-existing な tsc エラーあり（今回の変更とは無関係）