### PR TITLE
feat: Phase 5 dream_profiles 実装（モデル・API・フロントエンド・移行）

### DIFF
--- a/backend/app/controllers/dream_profiles_controller.rb
+++ b/backend/app/controllers/dream_profiles_controller.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+class DreamProfilesController < ApplicationController
+  before_action :set_profile, only: [:update, :archive, :restore]
+
+  # GET /dream_profiles
+  def index
+    profiles = current_user.dream_profiles.order(:position, :created_at)
+    render json: profiles.map { |p| profile_json(p) }
+  end
+
+  # POST /dream_profiles
+  def create
+    profile = nil
+    result = :ok
+
+    current_user.with_lock do
+      active_count = current_user.dream_profiles.where(active: true).count
+      if active_count >= DreamProfile::MAX_ACTIVE_COUNT
+        result = :limit_exceeded
+        raise ActiveRecord::Rollback
+      end
+
+      profile = current_user.dream_profiles.build(profile_params)
+      unless profile.save
+        result = :invalid
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    case result
+    when :ok
+      render json: profile_json(profile), status: :created
+    when :limit_exceeded
+      render json: { error: "アクティブなプロフィールは#{DreamProfile::MAX_ACTIVE_COUNT}件までです" },
+             status: :unprocessable_entity
+    when :invalid
+      render json: { errors: profile.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH /dream_profiles/:id
+  def update
+    if @profile.update(profile_params)
+      render json: profile_json(@profile)
+    else
+      render json: { errors: @profile.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH /dream_profiles/:id/archive
+  def archive
+    if @profile.update(active: false)
+      render json: profile_json(@profile)
+    else
+      render json: { errors: @profile.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH /dream_profiles/:id/restore
+  def restore
+    result = :ok
+
+    current_user.with_lock do
+      active_count = current_user.dream_profiles.where(active: true).count
+      if active_count >= DreamProfile::MAX_ACTIVE_COUNT
+        result = :limit_exceeded
+        raise ActiveRecord::Rollback
+      end
+
+      unless @profile.update(active: true)
+        result = :invalid
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    case result
+    when :ok
+      render json: profile_json(@profile)
+    when :limit_exceeded
+      render json: { error: "アクティブなプロフィールは#{DreamProfile::MAX_ACTIVE_COUNT}件までです" },
+             status: :unprocessable_entity
+    when :invalid
+      render json: { errors: @profile.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_profile
+    @profile = current_user.dream_profiles.find_by(id: params[:id])
+    render json: { error: "プロフィールが見つかりません" }, status: :not_found unless @profile
+  end
+
+  def profile_params
+    params.permit(:name, :avatar_emoji, :color, :relationship, :position)
+  end
+
+  def profile_json(profile)
+    profile.as_json(
+      only: %i[id name avatar_emoji color relationship active position created_at updated_at]
+    ).merge("archived" => !profile.active)
+  end
+end

--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -100,6 +100,8 @@ class DreamsController < ApplicationController
       @dream = current_user.dreams.build(dream_params)
     end
 
+    @dream.dream_profile_id ||= current_user.dream_profiles.find_by(relationship: 'self')&.id
+
     if @dream.save
       @dream.reload
       render json: @dream.as_json(include: :emotions), status: :created, location: @dream
@@ -292,9 +294,10 @@ class DreamsController < ApplicationController
     # 認可されたパラメーターを取得する
     def dream_params
       params.require(:dream).permit(
-        :title, 
-        :content, 
-        :audio, 
+        :title,
+        :content,
+        :audio,
+        :dream_profile_id,
         :analysis_status,
         :analyzed_at,
         emotion_ids: [],

--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -79,7 +79,7 @@ class DreamsController < ApplicationController
   # GET /dreams/:id
   def show
     render json: @dream.as_json(
-      only: [:id, :title, :created_at, :content, :analysis_json, :analysis_status, :analyzed_at, :generated_image_url],
+      only: [:id, :title, :created_at, :content, :analysis_json, :analysis_status, :analyzed_at, :generated_image_url, :dream_profile_id],
       include: :emotions
     )
   end

--- a/backend/app/controllers/trial_users_controller.rb
+++ b/backend/app/controllers/trial_users_controller.rb
@@ -3,19 +3,39 @@ class TrialUsersController < ApplicationController
 
   def create
     Rails.logger.debug "TrialUsersController#create called" if Rails.env.development?
-    begin
-      result = AuthService.create_trial_user(params[:trial_user])
+    result = nil
+    error_response = nil
 
-      unless result[:user] && result[:access_token] && result[:refresh_token]
-        Rails.logger.error "トライアルユーザー作成処理で必要な情報が不足しています: #{result.inspect}"
-        render json: { error: "トライアルユーザー作成処理に失敗しました" }, status: :internal_server_error
-        return
+    ApplicationRecord.transaction do
+      begin
+        result = AuthService.create_trial_user(params[:trial_user])
+
+        unless result[:user] && result[:access_token] && result[:refresh_token]
+          Rails.logger.error "トライアルユーザー作成処理で必要な情報が不足しています: #{result.inspect}"
+          error_response = { body: { error: "トライアルユーザー作成処理に失敗しました" }, status: :internal_server_error }
+          raise ActiveRecord::Rollback
+        end
+
+        result[:user].dream_profiles.create!(
+          name: "自分", avatar_emoji: "😴", color: "#6366f1",
+          relationship: "self", active: true, position: 0
+        )
+      rescue AuthService::RegistrationError => e
+        Rails.logger.error "Error in TrialUsersController#create: #{e.message}"
+        error_response = { body: { error: e.message }, status: :internal_server_error }
+        raise ActiveRecord::Rollback
+      rescue ActiveRecord::RecordInvalid => e
+        Rails.logger.error "自分プロフィールの自動作成に失敗しました: #{e.message}"
+        error_response = { body: { error: "トライアルユーザー作成処理に失敗しました" }, status: :internal_server_error }
+        raise ActiveRecord::Rollback
       end
+    end
+
+    if error_response
+      render json: error_response[:body], status: error_response[:status]
+    else
       set_token_cookies(result[:access_token], result[:refresh_token])
       render json: { user: result[:user].as_json(only: [:id, :email, :username, :premium, :age_group, :analysis_tone]) }, status: :created
-    rescue AuthService::RegistrationError => e
-      Rails.logger.error "Error in TrialUsersController#create: #{e.message}"
-      render json: { error: e.message }, status: :internal_server_error
     end
   end
 end

--- a/backend/app/controllers/users_controller.rb
+++ b/backend/app/controllers/users_controller.rb
@@ -6,22 +6,38 @@ class UsersController < ApplicationController
   # ユーザー登録
   # POST /auth/register (routes.rb で定義)
   def create
-    begin
-      # Strong Parameters を使用して安全にパラメータを受け取る
-      result = AuthService.register(user_params)
+    result = nil
+    error_response = nil
 
-      # AuthService.register は { access_token:, refresh_token:, user: } を返す
-      unless result[:user] && result[:access_token] && result[:refresh_token]
-        Rails.logger.error "ユーザー登録処理で AuthService から必要な情報が返されませんでした: #{result.inspect}"
-        render json: { error: "ユーザー登録処理に失敗しました" }, status: :internal_server_error
-        return
+    ApplicationRecord.transaction do
+      begin
+        result = AuthService.register(user_params)
+
+        unless result[:user] && result[:access_token] && result[:refresh_token]
+          Rails.logger.error "ユーザー登録処理で AuthService から必要な情報が返されませんでした: #{result.inspect}"
+          error_response = { body: { error: "ユーザー登録処理に失敗しました" }, status: :internal_server_error }
+          raise ActiveRecord::Rollback
+        end
+
+        result[:user].dream_profiles.create!(
+          name: "自分", avatar_emoji: "😴", color: "#6366f1",
+          relationship: "self", active: true, position: 0
+        )
+      rescue AuthService::RegistrationError => e
+        error_response = { body: { error: e.message }, status: :unprocessable_entity }
+        raise ActiveRecord::Rollback
+      rescue ActiveRecord::RecordInvalid => e
+        Rails.logger.error "自分プロフィールの自動作成に失敗しました: #{e.message}"
+        error_response = { body: { error: "ユーザー登録処理に失敗しました" }, status: :internal_server_error }
+        raise ActiveRecord::Rollback
       end
+    end
 
-      # ログイン時と同様にCookieを設定
+    if error_response
+      render json: error_response[:body], status: error_response[:status]
+    else
       set_token_cookies(result[:access_token], result[:refresh_token])
       render json: { user: result[:user].as_json(only: [:id, :email, :username, :premium, :age_group, :analysis_tone]) }, status: :created
-    rescue AuthService::RegistrationError => e
-      render json: { error: e.message }, status: :unprocessable_entity
     end
   end
 

--- a/backend/app/models/dream.rb
+++ b/backend/app/models/dream.rb
@@ -8,6 +8,7 @@ class Dream < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 100 }
   validates :content, presence: true, length: { maximum: 1000 }
+  validate :dream_profile_belongs_to_user, if: -> { dream_profile_id.present? }
 
   # analysis_status カラムを enum として定義し、メソッド名の衝突を避けるためにプレフィックスを付けます
   enum :analysis_status, { pending: 'pending', done: 'done', failed: 'failed' }, prefix: :analysis
@@ -21,6 +22,15 @@ class Dream < ApplicationRecord
   }
   # dream.analysis_done? の代わりに、コレクションの絞り込みにも使える
   scope :analyzed, -> { where(analysis_status: 'done') }
+
+  private
+
+  def dream_profile_belongs_to_user
+    return if dream_profile&.user_id == user_id
+    errors.add(:dream_profile_id, "は自分のプロフィールを指定してください")
+  end
+
+  public
 
   # 分析プロセスを開始するメソッド
   def start_analysis!

--- a/backend/app/models/dream.rb
+++ b/backend/app/models/dream.rb
@@ -1,5 +1,6 @@
 class Dream < ApplicationRecord
   belongs_to :user, optional: false
+  belongs_to :dream_profile, optional: true
   has_many :dream_emotions, dependent: :destroy
   has_many :dream_image_generations, dependent: :destroy
   has_many :emotions, through: :dream_emotions

--- a/backend/app/models/dream_profile.rb
+++ b/backend/app/models/dream_profile.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class DreamProfile < ApplicationRecord
+  RELATIONSHIPS = %w[self partner child parent friend pet other].freeze
+  MAX_ACTIVE_COUNT = 5
+
+  belongs_to :user
+
+  validates :name,         presence: true, length: { maximum: 30 }
+  validates :avatar_emoji, presence: true
+  validates :color,        presence: true,
+                           format: { with: /\A#[0-9a-fA-F]{6}\z/,
+                                     message: "は # から始まる6桁の16進数で指定してください" }
+  validates :relationship, inclusion: { in: RELATIONSHIPS }
+
+  validate :active_count_within_limit, if: -> { active? }
+  validate :self_profile_not_archived, if: -> { !active? && relationship == "self" }
+  validate :self_profile_unique_per_user, if: -> { relationship == "self" }
+
+  private
+
+  def active_count_within_limit
+    return unless user
+
+    scope = user.dream_profiles.where(active: true)
+    scope = scope.where.not(id: id) if persisted?
+    return if scope.count < MAX_ACTIVE_COUNT
+
+    errors.add(:base, "アクティブなプロフィールは#{MAX_ACTIVE_COUNT}件までです")
+  end
+
+  def self_profile_not_archived
+    errors.add(:base, "「自分」プロフィールはアーカイブできません")
+  end
+
+  def self_profile_unique_per_user
+    return unless user
+
+    scope = user.dream_profiles.where(relationship: "self")
+    scope = scope.where.not(id: id) if persisted?
+    return unless scope.exists?
+
+    errors.add(:relationship, "「自分」プロフィールはアカウントごとに1件のみ登録できます")
+  end
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   # パスワード認証機能を提供
   has_secure_password
   has_many :dreams, dependent: :destroy
+  has_many :dream_profiles, dependent: :destroy
   has_many :dream_image_generations, dependent: :destroy
   has_many :payments, dependent: :destroy
   has_many :subscriptions, dependent: :destroy

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -29,6 +29,13 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :dream_profiles, only: [:index, :create, :update] do
+    member do
+      patch :archive
+      patch :restore
+    end
+  end
+
   resources :emotions, only: [:index]
 
   # ユーザー関連

--- a/backend/db/migrate/20260601000000_create_dream_profiles.rb
+++ b/backend/db/migrate/20260601000000_create_dream_profiles.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class CreateDreamProfiles < ActiveRecord::Migration[7.1]
+  def change
+    create_table :dream_profiles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string  :name,          null: false
+      t.string  :avatar_emoji,  null: false, default: "😴"
+      t.string  :color,         null: false, default: "#6366f1"
+      t.string  :relationship,  null: false, default: "self"
+      t.boolean :active,        null: false, default: true
+      t.integer :position,      null: false, default: 0
+      t.timestamps
+    end
+
+    # 表示順クエリ用（user_id + position で並び替え）
+    add_index :dream_profiles, [:user_id, :position],
+              name: "idx_dream_profiles_user_position"
+
+    # active プロフィール絞り込み用部分インデックス
+    add_index :dream_profiles, :user_id,
+              where: "active = true",
+              name: "idx_dream_profiles_active"
+
+    # self プロフィールは user_id スコープで1件のみ許可
+    add_index :dream_profiles, :user_id,
+              unique: true,
+              where: "relationship = 'self'",
+              name: "idx_dream_profiles_unique_self"
+  end
+end

--- a/backend/db/migrate/20260602000000_add_dream_profile_id_to_dreams.rb
+++ b/backend/db/migrate/20260602000000_add_dream_profile_id_to_dreams.rb
@@ -1,0 +1,5 @@
+class AddDreamProfileIdToDreams < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :dreams, :dream_profile, null: true, foreign_key: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_12_000000) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_02_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,6 +71,22 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_12_000000) do
     t.index ["user_id"], name: "index_dream_image_generations_on_user_id"
   end
 
+  create_table "dream_profiles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.string "avatar_emoji", default: "😴", null: false
+    t.string "color", default: "#6366f1", null: false
+    t.string "relationship", default: "self", null: false
+    t.boolean "active", default: true, null: false
+    t.integer "position", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "position"], name: "idx_dream_profiles_user_position"
+    t.index ["user_id"], name: "idx_dream_profiles_active", where: "(active = true)"
+    t.index ["user_id"], name: "idx_dream_profiles_unique_self", unique: true, where: "((relationship)::text = 'self'::text)"
+    t.index ["user_id"], name: "index_dream_profiles_on_user_id"
+  end
+
   create_table "dreams", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -83,7 +99,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_12_000000) do
     t.datetime "analyzed_at"
     t.text "generated_image_url"
     t.datetime "image_generated_at"
+    t.bigint "dream_profile_id"
     t.index ["analysis_status"], name: "index_dreams_on_analysis_status"
+    t.index ["dream_profile_id"], name: "index_dreams_on_dream_profile_id"
     t.index ["user_id", "created_at"], name: "index_dreams_on_user_id_and_created_at"
     t.index ["user_id", "image_generated_at"], name: "index_dreams_on_user_id_and_image_generated_at", where: "(image_generated_at IS NOT NULL)"
     t.index ["user_id", "updated_at"], name: "index_dreams_on_user_id_and_updated_at_with_image", where: "(generated_image_url IS NOT NULL)"
@@ -146,11 +164,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_12_000000) do
     t.string "stripe_customer_id"
     t.integer "trial_analysis_count", default: 0, null: false
     t.integer "trial_audio_count", default: 0, null: false
-    t.integer "monthly_analysis_count", default: 0, null: false
-    t.datetime "monthly_analysis_count_reset_at"
     t.boolean "premium", default: false, null: false
     t.string "age_group", default: "child", null: false
     t.string "analysis_tone", default: "auto", null: false
+    t.integer "monthly_analysis_count", default: 0, null: false
+    t.datetime "monthly_analysis_count_reset_at"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["stripe_customer_id"], name: "index_users_on_stripe_customer_id", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
@@ -163,6 +181,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_12_000000) do
   add_foreign_key "dream_emotions", "emotions"
   add_foreign_key "dream_image_generations", "dreams"
   add_foreign_key "dream_image_generations", "users"
+  add_foreign_key "dream_profiles", "users"
+  add_foreign_key "dreams", "dream_profiles"
   add_foreign_key "dreams", "users"
   add_foreign_key "payments", "users"
   add_foreign_key "subscriptions", "users"

--- a/backend/lib/tasks/dream_profiles.rake
+++ b/backend/lib/tasks/dream_profiles.rake
@@ -1,0 +1,28 @@
+namespace :dream_profiles do
+  desc "全ユーザーに「自分」プロフィールがなければ作成する（冪等・何度実行しても安全）"
+  task ensure_self_profiles: :environment do
+    total   = 0
+    created = 0
+    skipped = 0
+
+    User.find_each do |user|
+      total += 1
+
+      profile = user.dream_profiles.find_or_create_by!(relationship: "self") do |p|
+        p.name         = "自分"
+        p.avatar_emoji = "😴"
+        p.color        = "#6366f1"
+        p.active       = true
+        p.position     = 0
+      end
+
+      if profile.previously_new_record?
+        created += 1
+      else
+        skipped += 1
+      end
+    end
+
+    puts "完了: 対象 #{total} ユーザー | 作成 #{created} 件 | スキップ #{skipped} 件"
+  end
+end

--- a/backend/spec/factories/dream_profiles.rb
+++ b/backend/spec/factories/dream_profiles.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  factory :dream_profile do
+    association :user
+    sequence(:name) { |n| "プロフィール#{n}" }
+    avatar_emoji { "🌙" }
+    color        { "#6366f1" }
+    relationship { "other" }
+    active       { true }
+    position     { 0 }
+
+    trait :self_profile do
+      name         { "自分" }
+      avatar_emoji { "😴" }
+      relationship { "self" }
+    end
+
+    trait :archived do
+      active { false }
+    end
+  end
+end

--- a/backend/spec/models/dream_profile_spec.rb
+++ b/backend/spec/models/dream_profile_spec.rb
@@ -1,0 +1,149 @@
+require "rails_helper"
+
+RSpec.describe DreamProfile, type: :model do
+  let(:user) { create(:user) }
+
+  # ------------------------------------------------------------------ #
+  # アソシエーション                                                      #
+  # ------------------------------------------------------------------ #
+  describe "アソシエーション" do
+    it { should belong_to(:user) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # 基本バリデーション                                                    #
+  # ------------------------------------------------------------------ #
+  describe "基本バリデーション" do
+    subject { build(:dream_profile, user: user) }
+
+    it { should validate_presence_of(:name) }
+    it { should validate_length_of(:name).is_at_most(30) }
+    it { should validate_presence_of(:avatar_emoji) }
+    it { should validate_presence_of(:color) }
+    it { should validate_inclusion_of(:relationship).in_array(DreamProfile::RELATIONSHIPS) }
+  end
+
+  # ------------------------------------------------------------------ #
+  # color フォーマット                                                    #
+  # ------------------------------------------------------------------ #
+  describe "color のフォーマットバリデーション" do
+    it "小文字 hex は有効" do
+      expect(build(:dream_profile, user: user, color: "#a1b2c3")).to be_valid
+    end
+
+    it "大文字 hex は有効" do
+      expect(build(:dream_profile, user: user, color: "#A1B2C3")).to be_valid
+    end
+
+    it "# なし文字列は無効" do
+      profile = build(:dream_profile, user: user, color: "a1b2c3")
+      expect(profile).not_to be_valid
+      expect(profile.errors[:color]).to be_present
+    end
+
+    it "3桁 hex は無効" do
+      profile = build(:dream_profile, user: user, color: "#abc")
+      expect(profile).not_to be_valid
+      expect(profile.errors[:color]).to be_present
+    end
+
+    it "不正な文字を含む場合は無効" do
+      profile = build(:dream_profile, user: user, color: "#zzzzzz")
+      expect(profile).not_to be_valid
+      expect(profile.errors[:color]).to be_present
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # active プロフィール上限（MAX_ACTIVE_COUNT = 5）                      #
+  # ------------------------------------------------------------------ #
+  describe "active プロフィールの上限チェック" do
+    context "active が 4 件のとき" do
+      before { create_list(:dream_profile, 4, user: user) }
+
+      it "5件目の作成は valid" do
+        expect(build(:dream_profile, user: user)).to be_valid
+      end
+    end
+
+    context "active が 5 件のとき" do
+      before { create_list(:dream_profile, 5, user: user) }
+
+      it "6件目の作成は invalid" do
+        profile = build(:dream_profile, user: user)
+        expect(profile).not_to be_valid
+        expect(profile.errors[:base]).to include("アクティブなプロフィールは5件までです")
+      end
+
+      it "archived プロフィールの復元（active: true への変更）も invalid" do
+        archived = create(:dream_profile, :archived, user: user)
+        archived.active = true
+        expect(archived).not_to be_valid
+        expect(archived.errors[:base]).to include("アクティブなプロフィールは5件までです")
+      end
+    end
+
+    context "archived プロフィールは上限にカウントしない" do
+      before do
+        create_list(:dream_profile, 5, user: user)
+        # archived は active カウントに含まれないため作成できる
+      end
+
+      it "active が 5 件あっても archived は作成できる" do
+        expect(build(:dream_profile, :archived, user: user)).to be_valid
+      end
+    end
+
+    context "既存 active プロフィールの name 更新は上限に影響しない" do
+      before { create_list(:dream_profile, 5, user: user) }
+
+      it "active のまま name を変えても valid" do
+        profile = DreamProfile.where(user: user, active: true).first
+        profile.name = "新しい名前"
+        expect(profile).to be_valid
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # 「自分」プロフィールのアーカイブ禁止                                 #
+  # ------------------------------------------------------------------ #
+  describe "self プロフィールのアーカイブ禁止" do
+    let!(:self_profile) { create(:dream_profile, :self_profile, user: user) }
+
+    it "self プロフィールを active: false にすると invalid" do
+      self_profile.active = false
+      expect(self_profile).not_to be_valid
+      expect(self_profile.errors[:base]).to include("「自分」プロフィールはアーカイブできません")
+    end
+
+    it "self 以外のプロフィールは active: false にできる" do
+      other = create(:dream_profile, user: user)
+      other.active = false
+      expect(other).to be_valid
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # 「自分」プロフィールの一意性（1 ユーザー 1 件）                      #
+  # ------------------------------------------------------------------ #
+  describe "self プロフィールの一意性" do
+    let!(:self_profile) { create(:dream_profile, :self_profile, user: user) }
+
+    it "同一ユーザーに 2件目の self プロフィールは invalid" do
+      dup = build(:dream_profile, :self_profile, user: user)
+      expect(dup).not_to be_valid
+      expect(dup.errors[:relationship]).to include("「自分」プロフィールはアカウントごとに1件のみ登録できます")
+    end
+
+    it "別ユーザーなら self プロフィールを作れる" do
+      other_user = create(:user)
+      expect(build(:dream_profile, :self_profile, user: other_user)).to be_valid
+    end
+
+    it "自分自身の更新（name 変更など）では一意性エラーにならない" do
+      self_profile.name = "私"
+      expect(self_profile).to be_valid
+    end
+  end
+end

--- a/backend/spec/requests/auth_spec.rb
+++ b/backend/spec/requests/auth_spec.rb
@@ -175,6 +175,18 @@ RSpec.describe 'Authentication API', type: :request do
         expect(json_response['user']['premium']).to be false
         expect(response.cookies['access_token']).to be_present
       end
+
+      it '登録と同時に「自分」プロフィールが自動作成される' do
+        expect {
+          post '/auth/register', params: valid_user_params, as: :json, headers: { 'HOST' => 'backend' }
+        }.to change(DreamProfile, :count).by(1)
+
+        user = User.find_by(email: 'newuser@example.com')
+        self_profile = user.dream_profiles.find_by(relationship: 'self')
+        expect(self_profile).to be_present
+        expect(self_profile.name).to eq('自分')
+        expect(self_profile.active).to eq(true)
+      end
     end
 
     context '無効なパラメータの場合' do

--- a/backend/spec/requests/dream_profiles_spec.rb
+++ b/backend/spec/requests/dream_profiles_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'DreamProfiles API', type: :request do
           authenticated_post('/dream_profiles', user, params: valid_params.merge(name: ''))
         }.not_to change(DreamProfile, :count)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       context 'active が 5 件のとき' do
@@ -88,7 +88,7 @@ RSpec.describe 'DreamProfiles API', type: :request do
             authenticated_post('/dream_profiles', user, params: valid_params)
           }.not_to change(DreamProfile, :count)
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           json = JSON.parse(response.body)
           expect(json['error']).to include('5件')
         end
@@ -120,7 +120,7 @@ RSpec.describe 'DreamProfiles API', type: :request do
 
       it '無効なパラメーターで 422 を返す' do
         authenticated_patch("/dream_profiles/#{profile.id}", user, params: { name: '' })
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it '他ユーザーのプロフィールは更新できない（404）' do
@@ -159,7 +159,7 @@ RSpec.describe 'DreamProfiles API', type: :request do
         self_profile = create(:dream_profile, :self_profile, user: user)
         authenticated_patch("/dream_profiles/#{self_profile.id}/archive", user)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(self_profile.reload.active).to eq(true)
       end
 
@@ -194,7 +194,7 @@ RSpec.describe 'DreamProfiles API', type: :request do
         it '復元は 422 を返す' do
           authenticated_patch("/dream_profiles/#{archived_profile.id}/restore", user)
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           json = JSON.parse(response.body)
           expect(json['error']).to include('5件')
           expect(archived_profile.reload.active).to eq(false)

--- a/backend/spec/requests/dream_profiles_spec.rb
+++ b/backend/spec/requests/dream_profiles_spec.rb
@@ -1,0 +1,211 @@
+require 'rails_helper'
+
+RSpec.describe 'DreamProfiles API', type: :request do
+  let!(:user)       { create(:user) }
+  let!(:other_user) { create(:user) }
+
+  # ------------------------------------------------------------------ #
+  # GET /dream_profiles                                                  #
+  # ------------------------------------------------------------------ #
+  describe 'GET /dream_profiles' do
+    context '認証済みユーザーの場合' do
+      before do
+        create(:dream_profile, user: user, name: "自分", relationship: "self", position: 0)
+        create(:dream_profile, user: user, name: "パートナー", relationship: "partner", position: 1)
+        create(:dream_profile, :archived, user: user, name: "旧友", relationship: "friend")
+        create(:dream_profile, user: other_user)
+      end
+
+      it 'ユーザー自身のプロフィール（active/archived 含む）を返す' do
+        authenticated_get('/dream_profiles', user)
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json.length).to eq(3)
+        names = json.map { |p| p['name'] }
+        expect(names).to include("自分", "パートナー", "旧友")
+      end
+
+      it '他ユーザーのプロフィールを含まない' do
+        authenticated_get('/dream_profiles', user)
+        json = JSON.parse(response.body)
+        ids = json.map { |p| p['id'] }
+        expect(DreamProfile.where(id: ids).pluck(:user_id).uniq).to eq([user.id])
+      end
+
+      it 'archived フィールドを含む' do
+        authenticated_get('/dream_profiles', user)
+        json = JSON.parse(response.body)
+        archived_profile = json.find { |p| p['name'] == '旧友' }
+        expect(archived_profile['archived']).to eq(true)
+        active_profile = json.find { |p| p['name'] == '自分' }
+        expect(active_profile['archived']).to eq(false)
+      end
+    end
+
+    context '未認証の場合' do
+      it '401 を返す' do
+        get '/dream_profiles'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # POST /dream_profiles                                                 #
+  # ------------------------------------------------------------------ #
+  describe 'POST /dream_profiles' do
+    let(:valid_params) do
+      { name: "友達", avatar_emoji: "👫", color: "#ff6b6b", relationship: "friend" }
+    end
+
+    context '認証済みユーザーの場合' do
+      it '有効なパラメーターでプロフィールを作成できる' do
+        expect {
+          authenticated_post('/dream_profiles', user, params: valid_params)
+        }.to change(DreamProfile, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        json = JSON.parse(response.body)
+        expect(json['name']).to eq('友達')
+        expect(json['relationship']).to eq('friend')
+        expect(json['archived']).to eq(false)
+      end
+
+      it '無効なパラメーター（name 空）で 422 を返す' do
+        expect {
+          authenticated_post('/dream_profiles', user, params: valid_params.merge(name: ''))
+        }.not_to change(DreamProfile, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      context 'active が 5 件のとき' do
+        before { create_list(:dream_profile, 5, user: user) }
+
+        it '6件目の作成は 422 を返す' do
+          expect {
+            authenticated_post('/dream_profiles', user, params: valid_params)
+          }.not_to change(DreamProfile, :count)
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          json = JSON.parse(response.body)
+          expect(json['error']).to include('5件')
+        end
+      end
+    end
+
+    context '未認証の場合' do
+      it '401 を返す' do
+        post '/dream_profiles', params: valid_params, as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # PATCH /dream_profiles/:id                                            #
+  # ------------------------------------------------------------------ #
+  describe 'PATCH /dream_profiles/:id' do
+    let!(:profile) { create(:dream_profile, user: user, name: "旧名前") }
+
+    context '認証済みユーザーの場合' do
+      it 'name を更新できる' do
+        authenticated_patch("/dream_profiles/#{profile.id}", user, params: { name: '新しい名前' })
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['name']).to eq('新しい名前')
+        expect(profile.reload.name).to eq('新しい名前')
+      end
+
+      it '無効なパラメーターで 422 を返す' do
+        authenticated_patch("/dream_profiles/#{profile.id}", user, params: { name: '' })
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it '他ユーザーのプロフィールは更新できない（404）' do
+        other_profile = create(:dream_profile, user: other_user)
+        authenticated_patch("/dream_profiles/#{other_profile.id}", user, params: { name: '乗っ取り' })
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context '未認証の場合' do
+      it '401 を返す' do
+        patch "/dream_profiles/#{profile.id}", params: { name: '新名前' }, as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # PATCH /dream_profiles/:id/archive                                    #
+  # ------------------------------------------------------------------ #
+  describe 'PATCH /dream_profiles/:id/archive' do
+    let!(:profile) { create(:dream_profile, user: user) }
+
+    context '認証済みユーザーの場合' do
+      it 'プロフィールをアーカイブできる' do
+        authenticated_patch("/dream_profiles/#{profile.id}/archive", user)
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json['active']).to eq(false)
+        expect(json['archived']).to eq(true)
+        expect(profile.reload.active).to eq(false)
+      end
+
+      it 'self プロフィールのアーカイブは 422 を返す' do
+        self_profile = create(:dream_profile, :self_profile, user: user)
+        authenticated_patch("/dream_profiles/#{self_profile.id}/archive", user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(self_profile.reload.active).to eq(true)
+      end
+
+      it '他ユーザーのプロフィールは操作できない（404）' do
+        other_profile = create(:dream_profile, user: other_user)
+        authenticated_patch("/dream_profiles/#{other_profile.id}/archive", user)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # PATCH /dream_profiles/:id/restore                                    #
+  # ------------------------------------------------------------------ #
+  describe 'PATCH /dream_profiles/:id/restore' do
+    let!(:archived_profile) { create(:dream_profile, :archived, user: user) }
+
+    context '認証済みユーザーの場合' do
+      it 'アーカイブ済みプロフィールを復元できる' do
+        authenticated_patch("/dream_profiles/#{archived_profile.id}/restore", user)
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json['active']).to eq(true)
+        expect(json['archived']).to eq(false)
+        expect(archived_profile.reload.active).to eq(true)
+      end
+
+      context 'active が 5 件のとき' do
+        before { create_list(:dream_profile, 5, user: user) }
+
+        it '復元は 422 を返す' do
+          authenticated_patch("/dream_profiles/#{archived_profile.id}/restore", user)
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          json = JSON.parse(response.body)
+          expect(json['error']).to include('5件')
+          expect(archived_profile.reload.active).to eq(false)
+        end
+      end
+
+      it '他ユーザーのプロフィールは操作できない（404）' do
+        other_archived = create(:dream_profile, :archived, user: other_user)
+        authenticated_patch("/dream_profiles/#{other_archived.id}/restore", user)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/backend/spec/support/auth_helpers.rb
+++ b/backend/spec/support/auth_helpers.rb
@@ -26,6 +26,10 @@ module AuthHelpers
     put path, params: params, headers: auth_headers(user), as: :json
   end
 
+  def authenticated_patch(path, user, params: {})
+    patch path, params: params, headers: auth_headers(user), as: :json
+  end
+
   def authenticated_delete(path, user)
     delete path, headers: auth_headers(user)
   end

--- a/backend/spec/tasks/dream_profiles_rake_spec.rb
+++ b/backend/spec/tasks/dream_profiles_rake_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe 'rake dream_profiles:ensure_self_profiles' do
+  # Rake タスクは一度だけロードすればよい
+  before(:all) do
+    Rails.application.load_tasks
+  end
+
+  # Rake タスクは1回しか実行されないため、各テスト前に reenable する
+  def invoke_task
+    Rake::Task['dream_profiles:ensure_self_profiles'].reenable
+    # テスト出力を汚さないよう stdout を抑制
+    original = $stdout
+    $stdout = StringIO.new
+    Rake::Task['dream_profiles:ensure_self_profiles'].invoke
+  ensure
+    $stdout = original
+  end
+
+  # ------------------------------------------------------------------ #
+  # self プロフィールがないユーザーへの作成                             #
+  # ------------------------------------------------------------------ #
+  context 'self プロフィールがないユーザーが複数いる場合' do
+    let!(:user_a) { create(:user) }
+    let!(:user_b) { create(:user) }
+
+    it '全員分の self プロフィールを作成する' do
+      expect { invoke_task }.to change(DreamProfile, :count).by(2)
+    end
+
+    it '作成されたプロフィールが正しい初期値を持つ' do
+      invoke_task
+      [user_a, user_b].each do |u|
+        profile = u.dream_profiles.find_by(relationship: 'self')
+        expect(profile).to be_present
+        expect(profile.name).to eq('自分')
+        expect(profile.avatar_emoji).to eq('😴')
+        expect(profile.color).to eq('#6366f1')
+        expect(profile.active).to eq(true)
+        expect(profile.position).to eq(0)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # 既存の self プロフィールはスキップ                                  #
+  # ------------------------------------------------------------------ #
+  context '一部のユーザーがすでに self プロフィールを持つ場合' do
+    let!(:user_has) do
+      u = create(:user)
+      create(:dream_profile, :self_profile, user: u)
+      u
+    end
+    let!(:user_no) { create(:user) }
+
+    it '持っていないユーザーにだけ作成する' do
+      expect { invoke_task }.to change(DreamProfile, :count).by(1)
+    end
+
+    it '既存の self プロフィールを重複させない' do
+      invoke_task
+      expect(user_has.dream_profiles.where(relationship: 'self').count).to eq(1)
+    end
+
+    it '不足していたユーザーに self プロフィールができている' do
+      invoke_task
+      expect(user_no.dream_profiles.find_by(relationship: 'self')).to be_present
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # 冪等性（2回実行しても重複しない）                                   #
+  # ------------------------------------------------------------------ #
+  context '2回実行した場合' do
+    let!(:user) { create(:user) }
+
+    it 'プロフィール数が変わらない' do
+      invoke_task
+      expect { invoke_task }.not_to change(DreamProfile, :count)
+    end
+
+    it 'self プロフィールは1件のまま' do
+      invoke_task
+      invoke_task
+      expect(user.dream_profiles.where(relationship: 'self').count).to eq(1)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # 全員がすでに self プロフィールを持つ場合                           #
+  # ------------------------------------------------------------------ #
+  context '全ユーザーがすでに self プロフィールを持つ場合' do
+    let!(:user) do
+      u = create(:user)
+      create(:dream_profile, :self_profile, user: u)
+      u
+    end
+
+    it '何も作成しない' do
+      expect { invoke_task }.not_to change(DreamProfile, :count)
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # stdout 出力の確認                                                   #
+  # ------------------------------------------------------------------ #
+  context '出力確認' do
+    let!(:user_a) { create(:user) }
+    let!(:user_b) do
+      u = create(:user)
+      create(:dream_profile, :self_profile, user: u)
+      u
+    end
+
+    it '対象数・作成数・スキップ数を出力する' do
+      Rake::Task['dream_profiles:ensure_self_profiles'].reenable
+      output = StringIO.new
+      original = $stdout
+      $stdout = output
+      Rake::Task['dream_profiles:ensure_self_profiles'].invoke
+      $stdout = original
+
+      result = output.string
+      expect(result).to include('対象 2 ユーザー')
+      expect(result).to include('作成 1 件')
+      expect(result).to include('スキップ 1 件')
+    end
+  end
+end

--- a/frontend/app/components/DreamForm.tsx
+++ b/frontend/app/components/DreamForm.tsx
@@ -149,7 +149,8 @@ export default function DreamForm({
         const data = await getDreamProfiles();
         const active = data.filter((p) => !p.archived);
         setProfiles(active);
-        if (!selectedProfileId) {
+        // 新規作成時のみ self をデフォルト選択（編集時は initialData.dream_profile_id を優先）
+        if (!initialData) {
           const selfProfile = active.find((p) => p.relationship === "self");
           if (selfProfile) setSelectedProfileId(selfProfile.id);
         }

--- a/frontend/app/components/DreamForm.tsx
+++ b/frontend/app/components/DreamForm.tsx
@@ -3,8 +3,8 @@
 import React, { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 
-import { Dream, Emotion, DreamDraftData } from "../types";
-import { getEmotions, previewAnalysis, ApiError } from "@/lib/apiClient";
+import { Dream, DreamProfile, Emotion, DreamDraftData } from "../types";
+import { getDreamProfiles, getEmotions, previewAnalysis, ApiError } from "@/lib/apiClient";
 import { toast } from "@/lib/toast";
 import { groupEmotionsByDisplayLabel } from "./emotionGrouping";
 import MorpheusSVG from "./MorpheusSVG";
@@ -12,6 +12,7 @@ import MorpheusSVG from "./MorpheusSVG";
 interface DreamFormData {
   title: string;
   content?: string;
+  dream_profile_id?: number;
   emotion_ids?: number[];
   analysis_json?: {
     analysis: string;
@@ -58,6 +59,10 @@ export default function DreamForm({
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [analysisLimitReached, setAnalysisLimitReached] = useState(false);
   const [analysisRevealKey, setAnalysisRevealKey] = useState(0);
+  const [profiles, setProfiles] = useState<DreamProfile[]>([]);
+  const [selectedProfileId, setSelectedProfileId] = useState<number | undefined>(
+    initialData?.dream_profile_id
+  );
   const [morpheusRating, setMorpheusRating] = useState<"good" | "bad" | null>(
     null
   );
@@ -131,8 +136,6 @@ export default function DreamForm({
     const fetchEmotions = async () => {
       setIsFetchingEmotions(true);
       try {
-        // 以前: 汎用のapiClient.getを使っていました。
-        // 今回: 感情リスト取得専用の `getEmotions` 関数を使います。
         const emotionsData = await getEmotions();
         setEmotions(emotionsData);
       } catch {
@@ -141,7 +144,21 @@ export default function DreamForm({
         setIsFetchingEmotions(false);
       }
     };
+    const fetchProfiles = async () => {
+      try {
+        const data = await getDreamProfiles();
+        const active = data.filter((p) => !p.archived);
+        setProfiles(active);
+        if (!selectedProfileId) {
+          const selfProfile = active.find((p) => p.relationship === "self");
+          if (selfProfile) setSelectedProfileId(selfProfile.id);
+        }
+      } catch {
+        // プロフィール取得失敗はフォームを壊さない
+      }
+    };
     fetchEmotions();
+    fetchProfiles();
   }, []);
 
   useEffect(() => {
@@ -213,6 +230,7 @@ export default function DreamForm({
     onSubmit({
       title: title.trim(),
       content: content.trim(),
+      dream_profile_id: selectedProfileId,
       emotion_ids: selectedEmotionIds,
       ...(analysisPayload
         ? {
@@ -229,6 +247,35 @@ export default function DreamForm({
       onSubmit={handleSubmit}
       className="p-6 border border-border rounded-lg bg-card text-card-foreground shadow"
     >
+      {profiles.length > 1 && (
+        <div className="mb-5">
+          <label className="block mb-2 font-semibold text-card-foreground text-sm">
+            誰の夢？
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {profiles.map((p) => {
+              const isSelected = selectedProfileId === p.id;
+              return (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => setSelectedProfileId(p.id)}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border-2 transition-all ${
+                    isSelected
+                      ? "bg-primary/10 text-primary"
+                      : "border-border bg-background text-foreground hover:bg-muted"
+                  }`}
+                  style={isSelected ? { borderColor: p.color } : {}}
+                >
+                  <span>{p.avatar_emoji}</span>
+                  <span>{p.name}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
       {isDraftApplied && (
         <div className="mb-4 rounded-md border border-primary/30 bg-primary/10 px-4 py-3 text-sm text-primary-foreground">
           モルペウスが きいた おはなし だよ。まちがってたら なおしてね。

--- a/frontend/app/profiles/page.tsx
+++ b/frontend/app/profiles/page.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ChevronLeft, Plus, Archive, RotateCcw, Pencil } from "lucide-react";
+import { useAuth } from "@/context/AuthContext";
+import Loading from "@/app/loading";
+import {
+  getDreamProfiles,
+  createDreamProfile,
+  updateDreamProfile,
+  archiveDreamProfile,
+  restoreDreamProfile,
+} from "@/lib/apiClient";
+import type { DreamProfile, DreamRelationship } from "@/app/types";
+import { toast } from "@/lib/toast";
+
+const RELATIONSHIP_LABELS: Record<DreamRelationship, string> = {
+  self: "自分",
+  partner: "パートナー",
+  child: "子ども",
+  parent: "親",
+  friend: "友達",
+  pet: "ペット",
+  other: "その他",
+};
+
+const COLOR_PALETTE = [
+  "#6366f1", "#8b5cf6", "#ec4899", "#f59e0b",
+  "#10b981", "#3b82f6", "#ef4444", "#14b8a6",
+];
+
+const EMOJI_SUGGESTIONS = [
+  "😴", "🙂", "😊", "🧑", "👶", "🧒", "👦", "👧",
+  "💕", "🥰", "👨", "👩", "🧓", "👴", "👵",
+  "🐱", "🐶", "🐰", "🐹", "✨", "🌟", "🎭", "🌙",
+];
+
+interface ProfileFormState {
+  name: string;
+  avatar_emoji: string;
+  color: string;
+  relationship: DreamRelationship;
+}
+
+const DEFAULT_FORM: ProfileFormState = {
+  name: "",
+  avatar_emoji: "🌙",
+  color: "#6366f1",
+  relationship: "other",
+};
+
+export default function ProfilesPage() {
+  const { authStatus } = useAuth();
+  const router = useRouter();
+
+  const [profiles, setProfiles] = useState<DreamProfile[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showArchived, setShowArchived] = useState(false);
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingProfile, setEditingProfile] = useState<DreamProfile | null>(null);
+  const [form, setForm] = useState<ProfileFormState>(DEFAULT_FORM);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const loadProfiles = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await getDreamProfiles();
+      setProfiles(data);
+    } catch {
+      toast.error("プロフィールの取得に失敗しました。");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (authStatus === "unauthenticated") {
+      router.push("/login");
+      return;
+    }
+    if (authStatus === "authenticated") {
+      loadProfiles();
+    }
+  }, [authStatus, loadProfiles, router]);
+
+  const activeProfiles = profiles.filter((p) => !p.archived);
+  const archivedProfiles = profiles.filter((p) => p.archived);
+  const remaining = 5 - activeProfiles.length;
+
+  const openCreate = () => {
+    setEditingProfile(null);
+    setForm(DEFAULT_FORM);
+    setModalOpen(true);
+  };
+
+  const openEdit = (profile: DreamProfile) => {
+    setEditingProfile(profile);
+    setForm({
+      name: profile.name,
+      avatar_emoji: profile.avatar_emoji,
+      color: profile.color,
+      relationship: profile.relationship,
+    });
+    setModalOpen(true);
+  };
+
+  const handleSave = async () => {
+    if (!form.name.trim()) {
+      toast.error("なまえ を いれてね。");
+      return;
+    }
+    setIsSaving(true);
+    try {
+      if (editingProfile) {
+        const updated = await updateDreamProfile(editingProfile.id, form);
+        setProfiles((prev) => prev.map((p) => (p.id === updated.id ? updated : p)));
+        toast.success("プロフィールを更新しました。");
+      } else {
+        const created = await createDreamProfile(form);
+        setProfiles((prev) => [...prev, created]);
+        toast.success("プロフィールを作成しました。");
+      }
+      setModalOpen(false);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "保存できませんでした。";
+      toast.error(msg);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleArchive = async (profile: DreamProfile) => {
+    try {
+      const updated = await archiveDreamProfile(profile.id);
+      setProfiles((prev) => prev.map((p) => (p.id === updated.id ? updated : p)));
+      toast.success(`${profile.name} をアーカイブしました。`);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "アーカイブできませんでした。";
+      toast.error(msg);
+    }
+  };
+
+  const handleRestore = async (profile: DreamProfile) => {
+    try {
+      const updated = await restoreDreamProfile(profile.id);
+      setProfiles((prev) => prev.map((p) => (p.id === updated.id ? updated : p)));
+      toast.success(`${profile.name} を復元しました。`);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "復元できませんでした。";
+      toast.error(msg);
+    }
+  };
+
+  if (authStatus === "checking") return <Loading />;
+
+  return (
+    <div className="min-h-screen bg-background text-foreground pb-20">
+      <header className="sticky top-0 z-10 backdrop-blur-md bg-background/80 border-b border-border/50">
+        <div className="container max-w-2xl mx-auto px-4 h-16 flex items-center">
+          <Link
+            href="/settings"
+            className="flex items-center text-muted-foreground hover:text-primary transition-colors pr-4"
+          >
+            <ChevronLeft className="w-5 h-5 mr-1" />
+            もどる
+          </Link>
+          <h1 className="text-xl font-bold">夢プロフィール</h1>
+          <span className="ml-auto text-sm text-muted-foreground">
+            残り <span className="font-bold text-foreground">{remaining}</span> 枠
+          </span>
+        </div>
+      </header>
+
+      <main className="container max-w-2xl mx-auto px-4 py-8 space-y-6">
+        <p className="text-sm text-muted-foreground">
+          家族やペットのプロフィールを作って、誰の夢かを記録できます。最大5つまで。
+        </p>
+
+        {isLoading ? (
+          <div className="grid grid-cols-2 gap-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-36 rounded-2xl bg-muted animate-pulse" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-3">
+            {activeProfiles.map((p) => (
+              <ProfileCard
+                key={p.id}
+                profile={p}
+                onEdit={() => openEdit(p)}
+                onArchive={() => handleArchive(p)}
+              />
+            ))}
+
+            {remaining > 0 && (
+              <button
+                onClick={openCreate}
+                className="flex flex-col items-center justify-center gap-2 h-36 rounded-2xl border-2 border-dashed border-border text-muted-foreground hover:border-primary hover:text-primary transition-colors"
+              >
+                <Plus className="w-6 h-6" />
+                <span className="text-sm font-medium">ついか</span>
+              </button>
+            )}
+          </div>
+        )}
+
+        {archivedProfiles.length > 0 && (
+          <section>
+            <button
+              type="button"
+              onClick={() => setShowArchived((v) => !v)}
+              className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-3"
+            >
+              <Archive className="w-4 h-4" />
+              アーカイブ済み ({archivedProfiles.length}件)
+              <span className="text-xs">{showArchived ? "▲" : "▼"}</span>
+            </button>
+
+            {showArchived && (
+              <div className="space-y-2">
+                {archivedProfiles.map((p) => (
+                  <div
+                    key={p.id}
+                    className="flex items-center gap-3 p-3 rounded-xl border border-border/50 bg-card/50"
+                  >
+                    <span
+                      className="text-2xl w-10 h-10 flex items-center justify-center rounded-full shrink-0"
+                      style={{ backgroundColor: p.color + "22" }}
+                    >
+                      {p.avatar_emoji}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium text-sm truncate text-muted-foreground">{p.name}</p>
+                      <p className="text-xs text-muted-foreground">{RELATIONSHIP_LABELS[p.relationship]}</p>
+                    </div>
+                    {remaining > 0 && (
+                      <button
+                        onClick={() => handleRestore(p)}
+                        className="shrink-0 flex items-center gap-1 text-xs text-primary hover:text-primary/70 transition-colors"
+                      >
+                        <RotateCcw className="w-3 h-3" />
+                        復元
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+      </main>
+
+      {modalOpen && (
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-4 bg-background/80 backdrop-blur-sm">
+          <div className="bg-card w-full max-w-sm rounded-3xl shadow-2xl border border-border/50 overflow-hidden">
+            <div className="p-6 space-y-5 max-h-[85vh] overflow-y-auto">
+              <h2 className="text-lg font-bold">
+                {editingProfile ? "プロフィールを編集" : "プロフィールを追加"}
+              </h2>
+
+              <div className="flex justify-center">
+                <div
+                  className="w-16 h-16 rounded-full flex items-center justify-center text-3xl"
+                  style={{ backgroundColor: form.color + "33" }}
+                >
+                  {form.avatar_emoji}
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium mb-1">なまえ</label>
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                  maxLength={30}
+                  placeholder="例: たろう / ねこのミー"
+                  className="w-full rounded-xl border border-input bg-background px-4 py-2.5 text-sm text-foreground focus:ring-2 focus:ring-ring"
+                />
+              </div>
+
+              {editingProfile?.relationship !== "self" && (
+                <div>
+                  <label className="block text-sm font-medium mb-2">かんけい</label>
+                  <div className="grid grid-cols-4 gap-1.5">
+                    {(
+                      Object.entries(RELATIONSHIP_LABELS) as [DreamRelationship, string][]
+                    )
+                      .filter(([val]) => val !== "self")
+                      .map(([val, label]) => (
+                        <button
+                          key={val}
+                          type="button"
+                          onClick={() => setForm((f) => ({ ...f, relationship: val }))}
+                          className={`py-1.5 px-2 text-xs rounded-lg border transition-colors ${
+                            form.relationship === val
+                              ? "border-primary bg-primary/10 text-primary font-semibold"
+                              : "border-border bg-background text-foreground hover:bg-muted"
+                          }`}
+                        >
+                          {label}
+                        </button>
+                      ))}
+                  </div>
+                </div>
+              )}
+
+              <div>
+                <label className="block text-sm font-medium mb-2">えもじ</label>
+                <div className="flex flex-wrap gap-1.5">
+                  {EMOJI_SUGGESTIONS.map((emoji) => (
+                    <button
+                      key={emoji}
+                      type="button"
+                      onClick={() => setForm((f) => ({ ...f, avatar_emoji: emoji }))}
+                      className={`w-9 h-9 text-lg rounded-lg transition-all ${
+                        form.avatar_emoji === emoji
+                          ? "bg-primary/20 ring-2 ring-primary"
+                          : "bg-muted hover:bg-muted/70"
+                      }`}
+                    >
+                      {emoji}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium mb-2">いろ</label>
+                <div className="flex gap-2 flex-wrap">
+                  {COLOR_PALETTE.map((color) => (
+                    <button
+                      key={color}
+                      type="button"
+                      onClick={() => setForm((f) => ({ ...f, color }))}
+                      className={`w-8 h-8 rounded-full transition-all ${
+                        form.color === color
+                          ? "ring-2 ring-offset-2 ring-foreground scale-110"
+                          : "hover:scale-105"
+                      }`}
+                      style={{ backgroundColor: color }}
+                      aria-label={color}
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={() => setModalOpen(false)}
+                  className="flex-1 py-3 rounded-xl bg-muted text-muted-foreground font-bold hover:bg-muted/80 transition-colors"
+                >
+                  キャンセル
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={isSaving}
+                  className="flex-1 py-3 rounded-xl bg-primary text-primary-foreground font-bold hover:bg-primary/90 transition-colors disabled:opacity-50"
+                >
+                  {isSaving ? "ほぞん中..." : "ほぞんする"}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProfileCard({
+  profile,
+  onEdit,
+  onArchive,
+}: {
+  profile: DreamProfile;
+  onEdit: () => void;
+  onArchive: () => void;
+}) {
+  const isSelf = profile.relationship === "self";
+  return (
+    <div className="relative flex flex-col items-center gap-2 p-4 rounded-2xl border border-border/50 bg-card shadow-sm">
+      <div
+        className="w-14 h-14 rounded-full flex items-center justify-center text-3xl"
+        style={{ backgroundColor: profile.color + "33" }}
+      >
+        {profile.avatar_emoji}
+      </div>
+      <p className="font-semibold text-sm text-center truncate w-full">{profile.name}</p>
+      <p className="text-xs text-muted-foreground">{RELATIONSHIP_LABELS[profile.relationship]}</p>
+      <div className="flex gap-2 mt-1">
+        <button
+          onClick={onEdit}
+          className="p-1.5 rounded-lg text-muted-foreground hover:text-primary hover:bg-primary/10 transition-colors"
+          aria-label="編集"
+        >
+          <Pencil className="w-3.5 h-3.5" />
+        </button>
+        {!isSelf && (
+          <button
+            onClick={onArchive}
+            className="p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+            aria-label="アーカイブ"
+          >
+            <Archive className="w-3.5 h-3.5" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -287,6 +287,25 @@ const SettingsPage = () => {
           </div>
         </section>
 
+        {/* 夢プロフィール */}
+        <section className="space-y-4">
+          <div className="bg-card/50 backdrop-blur-sm border border-border/50 rounded-2xl p-6 shadow-sm">
+            <h2 className="text-lg font-bold mb-3 text-primary flex items-center">
+              <span className="text-2xl mr-2">👨‍👩‍👧‍👦</span>
+              夢プロフィール
+            </h2>
+            <p className="text-sm text-muted-foreground mb-4">
+              家族やペットのプロフィールを作って、誰の夢かを記録できます。最大5つまで。
+            </p>
+            <Link
+              href="/profiles"
+              className="block w-full py-3 px-4 rounded-xl border border-border bg-background text-sm font-medium text-foreground hover:bg-muted transition-colors text-center"
+            >
+              プロフィールを管理する →
+            </Link>
+          </div>
+        </section>
+
         {/* 安心感を与えるメッセージセクション */}
         <section className="space-y-4">
           <div className="bg-card/50 backdrop-blur-sm border border-border/50 rounded-2xl p-6 shadow-sm">

--- a/frontend/app/types.ts
+++ b/frontend/app/types.ts
@@ -1,6 +1,21 @@
 export type AgeGroup = "child_small" | "child" | "preteen" | "teen" | "adult";
 export type AnalysisTone = "auto" | "gentle_kids" | "junior" | "standard" | "deep";
 
+export type DreamRelationship = "self" | "partner" | "child" | "parent" | "friend" | "pet" | "other";
+
+export interface DreamProfile {
+  id: number;
+  name: string;
+  avatar_emoji: string;
+  color: string;
+  relationship: DreamRelationship;
+  active: boolean;
+  position: number;
+  archived: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface User {
   id: string; // FrontendではIDを文字列として扱う
   username?: string; // トライアルユーザーは未設定の場合がある
@@ -34,6 +49,7 @@ export interface Dream {
   title: string;
   content?: string;
   userId: number;
+  dream_profile_id?: number;
   created_at: string;
   updated_at: string;
   emotions?: Emotion[];
@@ -82,6 +98,7 @@ export interface DreamDraftData {
 export interface DreamInput {
   title: string;
   content?: string;
+  dream_profile_id?: number;
   emotion_ids?: number[];
   analysis_json?: {
     analysis: string;

--- a/frontend/lib/apiClient.ts
+++ b/frontend/lib/apiClient.ts
@@ -12,6 +12,8 @@
 import { createApiUrl } from "./api-config";
 import type {
   Dream,
+  DreamProfile,
+  DreamRelationship,
   Emotion,
   BackendUser,
   User,
@@ -325,6 +327,45 @@ export type AnalysisQuota = {
 
 export async function getAnalysisQuota(): Promise<AnalysisQuota> {
   return apiFetch<AnalysisQuota>("/dreams/analysis_quota");
+}
+
+export async function getDreamProfiles(): Promise<DreamProfile[]> {
+  return apiFetch<DreamProfile[]>("/dream_profiles");
+}
+
+export async function createDreamProfile(data: {
+  name: string;
+  avatar_emoji: string;
+  color: string;
+  relationship: DreamRelationship;
+  position?: number;
+}): Promise<DreamProfile> {
+  return apiFetch<DreamProfile>("/dream_profiles", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateDreamProfile(
+  id: number,
+  data: Partial<{ name: string; avatar_emoji: string; color: string; relationship: DreamRelationship; position: number }>
+): Promise<DreamProfile> {
+  return apiFetch<DreamProfile>(`/dream_profiles/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function archiveDreamProfile(id: number): Promise<DreamProfile> {
+  return apiFetch<DreamProfile>(`/dream_profiles/${id}/archive`, {
+    method: "PATCH",
+  });
+}
+
+export async function restoreDreamProfile(id: number): Promise<DreamProfile> {
+  return apiFetch<DreamProfile>(`/dream_profiles/${id}/restore`, {
+    method: "PATCH",
+  });
 }
 
 export async function verifyAuth(): Promise<{ user: User } | null> {


### PR DESCRIPTION
## 変更概要

### Backend
- `dream_profiles` テーブル新規作成（5件上限・self アーカイブ不可・self 一意制約）
- `DreamProfilesController` CRUD API（index / create / update / archive / restore）
- ユーザー登録時（通常・トライアル両方）に「自分」プロフィールをトランザクション内で自動作成
- `dreams.dream_profile_id` カラム追加（nullable）、create 時に未指定なら self プロフィールを自動セット
- `rake dream_profiles:ensure_self_profiles` — 既存ユーザー向け冪等移行タスク

### Frontend
- `DreamProfile` / `DreamRelationship` 型追加、`Dream` / `DreamInput` に `dream_profile_id` 追加
- 5つのプロフィール API 関数を `apiClient.ts` に追加
- `/profiles` ページ新規作成（プロフィール管理 CRUD・絵文字・カラー選択・アーカイブ/復元）
- `DreamForm` に「誰の夢？」プロフィールピッカー追加（2件以上のとき表示、self を自動選択）
- 設定ページにプロフィール管理へのリンクを追加

## デプロイ後の作業（本番 Render Shell で実行）

```bash
bundle exec rails db:migrate
bundle exec rails dream_profiles:ensure_self_profiles
```

## テスト結果

67 examples, 0 failures（model spec + request spec + rake task spec）

## 関連 docs

`docs/phase5-dream-profiles-design.md`