### PR TITLE
chore: Render Free向けにdream_profiles補完処理を一時追加

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -130,6 +130,19 @@ else
             echo "❌ [本番環境] マイグレーション失敗"
             exit 1
         fi
+
+        # 一時対応: Render Free で Shell が使えないため、Phase 5 の self プロフィール補完を起動時に実行する
+        if [ "$RUN_DREAM_PROFILES_BACKFILL" = "true" ]; then
+            echo "🔄 [本番環境] RUN_DREAM_PROFILES_BACKFILL=true を検出 - self プロフィール補完を実行します..."
+            if bundle exec rails dream_profiles:ensure_self_profiles; then
+                echo "✅ [本番環境] self プロフィール補完完了"
+            else
+                echo "❌ [本番環境] self プロフィール補完失敗"
+                exit 1
+            fi
+        else
+            echo "ℹ️  [本番環境] self プロフィール補完をスキップします (RUN_DREAM_PROFILES_BACKFILL != true)"
+        fi
     else
         echo "ℹ️  [本番環境] 自動マイグレーションをスキップします (RUN_MIGRATIONS != true)"
     fi


### PR DESCRIPTION
## 概要
Render Free インスタンスでは Shell が使えないため、Phase 5 dream_profiles の既存ユーザー向け self プロフィール補完を、環境変数で制御できる一時処理として `entrypoint.sh` に追加しました。

## 変更内容
- `RUN_DREAM_PROFILES_BACKFILL=true` のときだけ `bundle exec rails dream_profiles:ensure_self_profiles` を実行
- 既存の `RUN_MIGRATIONS=true` による `db:migrate` 成功後にのみ実行
- 未設定時はスキップ
- backfill 失敗時は `exit 1` で起動停止

## Render で一時的に設定する環境変数
```env
RUN_MIGRATIONS=true
RUN_DREAM_PROFILES_BACKFILL=true
```

## 本番反映後に戻すこと
本番デプロイ成功・動作確認後、以下を削除または false に戻します。

```env
RUN_MIGRATIONS=false
RUN_DREAM_PROFILES_BACKFILL=false
```

注意: `RUN_DREAM_PROFILES_BACKFILL=true` だけでは実行されません。migrate 成功後にだけ backfill するため、Render 側では `RUN_MIGRATIONS=true` も同時に設定してください。

## テスト
- `bash -n backend/entrypoint.sh`
- `docker compose exec backend-test env RUBYOPT= RUBY_DEBUG_OPEN=false bundle exec rspec spec/models/dream_profile_spec.rb spec/requests/dream_profiles_spec.rb spec/requests/auth_spec.rb spec/tasks/dream_profiles_rake_spec.rb`

結果: 67 examples, 0 failures