### PR TITLE
chore: Phase 5本番補完用の一時処理を削除

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -131,18 +131,6 @@ else
             exit 1
         fi
 
-        # 一時対応: Render Free で Shell が使えないため、Phase 5 の self プロフィール補完を起動時に実行する
-        if [ "$RUN_DREAM_PROFILES_BACKFILL" = "true" ]; then
-            echo "🔄 [本番環境] RUN_DREAM_PROFILES_BACKFILL=true を検出 - self プロフィール補完を実行します..."
-            if bundle exec rails dream_profiles:ensure_self_profiles; then
-                echo "✅ [本番環境] self プロフィール補完完了"
-            else
-                echo "❌ [本番環境] self プロフィール補完失敗"
-                exit 1
-            fi
-        else
-            echo "ℹ️  [本番環境] self プロフィール補完をスキップします (RUN_DREAM_PROFILES_BACKFILL != true)"
-        fi
     else
         echo "ℹ️  [本番環境] 自動マイグレーションをスキップします (RUN_MIGRATIONS != true)"
     fi

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe User, type: :model do
       user = create(
         :user,
         monthly_analysis_count: 7,
-        monthly_analysis_count_reset_at: 2.months.ago
+        monthly_analysis_count_reset_at: Time.zone.parse('2026-02-01 00:00:00')
       )
 
       user.reset_monthly_analysis_count_if_needed!(Time.zone.parse('2026-04-15 10:00:00'))
@@ -56,7 +56,7 @@ RSpec.describe User, type: :model do
       user = create(
         :user,
         monthly_analysis_count: 5,
-        monthly_analysis_count_reset_at: 2.months.ago
+        monthly_analysis_count_reset_at: Time.zone.parse('2026-02-01 00:00:00')
       )
 
       user.increment_monthly_analysis_count!(Time.zone.parse('2026-04-15 10:00:00'))
@@ -88,7 +88,7 @@ RSpec.describe User, type: :model do
 
     it 'resets stale count then reserves the slot' do
       user = create(:user, monthly_analysis_count: 8,
-                           monthly_analysis_count_reset_at: 2.months.ago)
+                           monthly_analysis_count_reset_at: Time.zone.parse('2026-02-01 00:00:00'))
 
       result = user.reserve_monthly_analysis_slot!(Time.zone.parse('2026-04-15 10:00:00'))
 


### PR DESCRIPTION
## 概要
Phase 5 dream_profiles の本番DB反映と既存ユーザー向け self プロフィール補完が完了したため、一時対応として追加していた `RUN_DREAM_PROFILES_BACKFILL` 分岐を削除します。

## 背景
Render Free インスタンスでは Shell が使えないため、PR #321 で一時的に `entrypoint.sh` から `dream_profiles:ensure_self_profiles` を実行できるようにしていました。

本番で以下を確認済みです。

- `db:migrate` 成功
- `dream_profiles:ensure_self_profiles` 成功
- Render 環境変数を false に戻して再デプロイ済み
- 本番ブラウザで dream_profiles の主要フロー確認済み

## 変更内容
- `backend/entrypoint.sh` から `RUN_DREAM_PROFILES_BACKFILL` 関連の一時処理を削除
- 既存の `RUN_MIGRATIONS` 処理は維持

## 確認
- `bash -n backend/entrypoint.sh`
- `docker compose exec backend-test env RUBYOPT= RUBY_DEBUG_OPEN=false bundle exec rails db:test:prepare`
- Phase 5 関連 spec: `140 examples, 0 failures`