### PR TITLE
chore: dream_profilesのRLSを有効化

### DIFF
--- a/backend/db/migrate/20260603000000_enable_rls_on_dream_profiles.rb
+++ b/backend/db/migrate/20260603000000_enable_rls_on_dream_profiles.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Supabase セキュリティアドバイザーの RLS 警告を解消するマイグレーション
+#
+# 【背景】
+# public.dream_profiles テーブルに RLS が有効化されておらず、
+# Supabase Security Advisor に警告が出ていた。
+#
+# 【設計方針】
+# このアプリは Rails API のみが DB に接続する設計のため、
+# PostgREST（Supabase の直接接続口）からのアクセスは全遮断が正しい。
+# RLS を有効化し、ポリシーを追加しないことで「デフォルト拒否（Default Deny）」を実現。
+#
+# 【影響範囲】
+# Rails は postgres ロール（スーパーユーザー / BYPASSRLS 権限あり）で接続するため
+# RLS 有効化後も既存処理（プロフィール一覧・作成・編集・アーカイブ）に影響なし。
+# フロントエンドから Supabase への直接アクセスはないため anon / authenticated ロール用
+# ポリシーの追加は不要。
+#
+# 【注意】
+# schema.rb（Ruby形式）は RLS 設定を記録しない。
+# このmigrationでバージョン管理する。
+class EnableRlsOnDreamProfiles < ActiveRecord::Migration[7.1]
+  def up
+    # RLS を有効化（ポリシーなし = 全行を拒否 = Default Deny）
+    execute "ALTER TABLE public.dream_profiles ENABLE ROW LEVEL SECURITY;"
+
+    # Rails サービスアカウントは BYPASSRLS 権限を持つため引き続き全アクセス可能
+    # Supabase PostgREST / anon ロールからのアクセスは遮断される
+  end
+
+  def down
+    execute "ALTER TABLE public.dream_profiles DISABLE ROW LEVEL SECURITY;"
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_02_000000) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_03_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
## 概要
Supabase Security Advisor の `rls_disabled_in_public` 警告に対応するため、`public.dream_profiles` の Row Level Security を有効化します。

## 背景
YumeTree は frontend から Supabase client / PostgREST / Realtime / GraphQL に直接アクセスせず、Rails API 経由で PostgreSQL に接続しています。

既存の `payments` / `dream_image_generations` / `ai_usage_logs` と同様に、RLSを有効化し、policyを追加しないことで Supabase 直接アクセス口を Default Deny にします。

## 変更内容
- `public.dream_profiles` に RLS を有効化する migration を追加
- RLS policy は追加しない
- `schema.rb` は migration version のみ更新

## 確認
- `rails db:migrate`
- `rails db:test:prepare`
- `rspec spec/models/dream_profile_spec.rb spec/requests/dream_profiles_spec.rb spec/requests/dreams_spec.rb`
  - 112 examples, 0 failures
- `rspec`
  - 253 examples, 0 failures

## 補足
`backend` コンテナでの migration は debug port 12345 の衝突により失敗したため、`backend-test` コンテナから development DB を指定して検証しました。