### PR TITLE
feat: 夢一覧にプロフィールバッジを表示

### DIFF
--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -17,13 +17,16 @@ class DreamsController < ApplicationController
     # generated_image_url は base64 で最大 1MB になるため一覧では SELECT 時点で除外する。
     # as_json(only:) だけでは ActiveRecord が SELECT * でロードするためメモリに乗る。
     # 詳細画面（show）でのみ返す。
-    index_columns = %i[id title content created_at analysis_json analysis_status analyzed_at user_id]
+    index_columns = %i[id title content created_at analysis_json analysis_status analyzed_at user_id dream_profile_id]
     initial_scope = current_user.dreams.select(index_columns).order(created_at: :desc)
     filter_params = params.permit(:query, :start_date, :end_date, emotion_ids: [])
-    @dreams = DreamFilterQuery.new(initial_scope, filter_params).call.includes(:emotions)
+    @dreams = DreamFilterQuery.new(initial_scope, filter_params).call.includes(:emotions, :dream_profile)
     render json: @dreams.as_json(
       only: index_columns - [:user_id],
-      include: :emotions
+      include: {
+        emotions: {},
+        dream_profile: { only: [:id, :name, :avatar_emoji, :color, :active] }
+      }
     )
   end
 

--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -21,13 +21,7 @@ class DreamsController < ApplicationController
     initial_scope = current_user.dreams.select(index_columns).order(created_at: :desc)
     filter_params = params.permit(:query, :start_date, :end_date, emotion_ids: [])
     @dreams = DreamFilterQuery.new(initial_scope, filter_params).call.includes(:emotions, :dream_profile)
-    render json: @dreams.as_json(
-      only: index_columns - [:user_id],
-      include: {
-        emotions: {},
-        dream_profile: { only: [:id, :name, :avatar_emoji, :color, :active] }
-      }
-    )
+    render json: @dreams.as_json(dream_list_json_options(only: index_columns - [:user_id]))
   end
 
   # GET /dreams/statuses?ids=1,2,3
@@ -151,11 +145,12 @@ class DreamsController < ApplicationController
       end_date = Date.new(year, month, 1).end_of_month
       @dreams = current_user.dreams
                            .where(created_at: start_date..end_date)
-                           .includes(:emotions)
+                           .includes(:emotions, :dream_profile)
                            .order(created_at: :desc)
       render json: @dreams.as_json(
-        only: [:id, :title, :content, :created_at, :analysis_json, :analysis_status, :analyzed_at],
-        include: :emotions
+        dream_list_json_options(
+          only: [:id, :title, :content, :created_at, :analysis_json, :analysis_status, :analyzed_at, :dream_profile_id]
+        )
       )
     rescue ArgumentError, TypeError
       render json: { error: "無効な日付フォーマットです。YYYY-MM 形式で指定してください。" }, status: :bad_request
@@ -306,6 +301,20 @@ class DreamsController < ApplicationController
         emotion_ids: [],
         analysis_json: [:analysis, :text, { emotion_tags: [] }]
       )
+    end
+
+    def dream_list_json_options(only:)
+      {
+        only: only,
+        include: {
+          emotions: {},
+          dream_profile: dream_profile_json_options
+        }
+      }
+    end
+
+    def dream_profile_json_options
+      { only: [:id, :name, :avatar_emoji, :color, :active] }
     end
 
     def check_analysis_limit

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -346,12 +346,23 @@ RSpec.describe 'Dreams API', type: :request do
   end
 
   describe 'GET /dreams/month/:year_month' do
+    let!(:may_profile) do
+      create(
+        :dream_profile,
+        user: user,
+        name: '長男',
+        avatar_emoji: '👦',
+        color: '#10b981',
+        active: true
+      )
+    end
     let!(:may_dream) do
       create(
         :dream,
         user: user,
         title: '5月の夢',
         content: '空の上を歩く夢',
+        dream_profile: may_profile,
         created_at: Time.zone.parse('2025-05-10 12:00:00'),
         analysis_status: 'done',
         analysis_json: { analysis: '明るい気持ち', emotion_tags: ['嬉しい', '安心'] }
@@ -391,6 +402,21 @@ RSpec.describe 'Dreams API', type: :request do
         expect(json_response.first['analysis_json']['analysis']).to eq('明るい気持ち')
         expect(json_response.first['emotions'].map { |emotion| emotion['id'] }).to match_array(
           [emotions.first.id, emotions.third.id]
+        )
+      end
+
+      it '指定月の夢に夢プロフィールの軽量情報を含める' do
+        authenticated_get('/dreams/month/2025-05', user)
+
+        expect(response).to have_http_status(:ok)
+        json_response = JSON.parse(response.body)
+        expect(json_response.first['dream_profile_id']).to eq(may_profile.id)
+        expect(json_response.first['dream_profile']).to eq(
+          'id' => may_profile.id,
+          'name' => '長男',
+          'avatar_emoji' => '👦',
+          'color' => '#10b981',
+          'active' => true
         )
       end
 

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -271,6 +271,32 @@ RSpec.describe 'Dreams API', type: :request do
         expect(json_response.length).to eq(3)
       end
 
+      it '夢プロフィールの軽量情報を含める' do
+        profile = create(
+          :dream_profile,
+          user: user,
+          name: '長男',
+          avatar_emoji: '👦',
+          color: '#10b981',
+          active: true
+        )
+        dream = create(:dream, user: user, dream_profile: profile)
+
+        authenticated_get('/dreams', user)
+
+        expect(response).to have_http_status(:ok)
+
+        json_response = JSON.parse(response.body)
+        returned_dream = json_response.find { |item| item['id'] == dream.id }
+        expect(returned_dream['dream_profile']).to eq(
+          'id' => profile.id,
+          'name' => '長男',
+          'avatar_emoji' => '👦',
+          'color' => '#10b981',
+          'active' => true
+        )
+      end
+
       context 'フィルタリング' do
         it 'emotion_idsパラメーターでフィルタリングできる' do
           dream_with_emotion = create(:dream, user: user)

--- a/frontend/__tests__/components/DreamCard.test.js
+++ b/frontend/__tests__/components/DreamCard.test.js
@@ -77,6 +77,27 @@ describe("DreamCard", () => {
     expect(screen.getByText("😢 かなしい")).toBeInTheDocument();
   });
 
+  test("AAA: 夢プロフィールが渡されたらバッジを表示する（props）", () => {
+    // Arrange
+    const dream = {
+      ...baseDream,
+      dream_profile: {
+        id: 2,
+        name: "長男",
+        avatar_emoji: "👦",
+        color: "#10b981",
+        active: true,
+      },
+    };
+
+    // Act
+    render(<DreamCard dream={dream} />);
+
+    // Assert
+    expect(screen.getByText("👦")).toBeInTheDocument();
+    expect(screen.getByText("長男")).toBeInTheDocument();
+  });
+
   test("AAA: 詳細ページへのリンクがあり、href に id が入っている（リンク/イベント）", async () => {
     // Arrange
     const user = userEvent.setup();

--- a/frontend/app/components/DreamCard.tsx
+++ b/frontend/app/components/DreamCard.tsx
@@ -49,6 +49,13 @@ const DreamCard = ({ dream }: DreamCardProps) => {
     emotionLabels[0] != null
       ? getEmotionTone(emotionLabels[0]).accentClassName
       : "from-sky-300 via-blue-200 to-indigo-400";
+  const profile = dream.dream_profile;
+  const profileBadgeStyle = profile?.color
+    ? {
+        borderColor: `${profile.color}66`,
+        backgroundColor: `${profile.color}1A`,
+      }
+    : undefined;
 
   return (
     <Link
@@ -77,12 +84,23 @@ const DreamCard = ({ dream }: DreamCardProps) => {
           {/* Header: Date & Title */}
           <div className="mb-3">
             <div className="flex justify-between items-start">
-              <p
-                className="text-xs text-muted-foreground mb-1 font-medium"
-                suppressHydrationWarning
-              >
-                {formatDate(dream.created_at)}
-              </p>
+              <div className="flex flex-wrap items-center gap-2 mb-1">
+                <p
+                  className="text-xs text-muted-foreground font-medium"
+                  suppressHydrationWarning
+                >
+                  {formatDate(dream.created_at)}
+                </p>
+                {profile ? (
+                  <span
+                    className="inline-flex max-w-[9rem] items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold text-foreground/80"
+                    style={profileBadgeStyle}
+                  >
+                    <span aria-hidden="true">{profile.avatar_emoji}</span>
+                    <span className="truncate">{profile.name}</span>
+                  </span>
+                ) : null}
+              </div>
               {dream.analysis_status === "pending" && (
                 <div className="flex flex-col gap-1 w-24">
                   <span className="flex items-center gap-1.5 text-[10px] font-bold text-amber-600 bg-amber-100/80 px-2 py-0.5 rounded-full border border-amber-200/50">

--- a/frontend/app/profiles/page.tsx
+++ b/frontend/app/profiles/page.tsx
@@ -175,8 +175,9 @@ export default function ProfilesPage() {
       </header>
 
       <main className="container max-w-2xl mx-auto px-4 py-8 space-y-6">
-        <p className="text-sm text-muted-foreground">
-          家族やペットのプロフィールを作って、誰の夢かを記録できます。最大5つまで。
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          夢プロフィールを作ると、自分・家族・ペットなど、誰の夢かを分けて記録できます。
+          夢を書くときに選ぶと、あとから人ごとに見返しやすくなります。最大5つまで。
         </p>
 
         {isLoading ? (

--- a/frontend/app/types.ts
+++ b/frontend/app/types.ts
@@ -50,6 +50,10 @@ export interface Dream {
   content?: string;
   userId: number;
   dream_profile_id?: number;
+  dream_profile?: Pick<
+    DreamProfile,
+    "id" | "name" | "avatar_emoji" | "color" | "active"
+  > | null;
   created_at: string;
   updated_at: string;
   emotions?: Emotion[];


### PR DESCRIPTION
## 概要
夢一覧カードに dream_profiles のプロフィールバッジを表示します。

## 背景
Phase 5で夢作成・編集時にプロフィールを選択できるようになりましたが、ホーム画面の夢一覧では「誰の夢か」が分かりづらい状態でした。

このPRでは、`/dreams` 一覧APIに軽量な `dream_profile` 情報を追加し、DreamCard上で絵文字・名前・プロフィールカラーを使ったバッジを表示します。

## 変更内容
- `/dreams` 一覧APIに軽量な `dream_profile` 情報を追加
  - id
  - name
  - avatar_emoji
  - color
  - active
- frontend の `Dream` 型に `dream_profile` を追加
- `DreamCard` にプロフィールバッジを表示
- プロフィール管理画面の説明文を具体化
- backend / frontend のテストを更新

## 今回やらないこと
- プロフィール別フィルター
- プロフィール別AI分析カスタマイズ
- モルペウス画像変更
- ログイン維持改善
- DB migration

## 確認
- `docker compose exec backend-test env RUBYOPT= RUBY_DEBUG_OPEN=false bundle exec rspec spec/requests/dreams_spec.rb`
  - 74 examples, 0 failures
- `cd frontend && npm test -- DreamCard`
  - 1 passed, 6 tests passed
- `cd frontend && npm test`
  - 16 passed, 132 tests passed
- `docker compose exec backend-test env RUBYOPT= RUBY_DEBUG_OPEN=false bundle exec rspec`
  - 254 examples, 0 failures
- `cd frontend && npm run build`
  - Compiled successfully
  - TypeScript OK

## 補足
- 古い夢などで `dream_profile` が null の場合はバッジを表示しません
- プロフィール名が長い場合は省略表示します
- `docs/code-reading/` は既存の未追跡ファイルのため含めていません