### PR TITLE
feat: アーカイブ済みプロフィールの夢に状態バッジを表示

### DIFF
--- a/frontend/__tests__/components/DreamCard.test.js
+++ b/frontend/__tests__/components/DreamCard.test.js
@@ -98,6 +98,46 @@ describe("DreamCard", () => {
     expect(screen.getByText("長男")).toBeInTheDocument();
   });
 
+  test("AAA: active: false のプロフィールでは「アーカイブ済み」バッジが表示される", () => {
+    // Arrange
+    const dream = {
+      ...baseDream,
+      dream_profile: {
+        id: 3,
+        name: "旧プロフィール",
+        avatar_emoji: "👤",
+        color: "#94a3b8",
+        active: false,
+      },
+    };
+
+    // Act
+    render(<DreamCard dream={dream} />);
+
+    // Assert
+    expect(screen.getByText("アーカイブ済み")).toBeInTheDocument();
+  });
+
+  test("AAA: active: true のプロフィールでは「アーカイブ済み」バッジが表示されない", () => {
+    // Arrange
+    const dream = {
+      ...baseDream,
+      dream_profile: {
+        id: 2,
+        name: "長男",
+        avatar_emoji: "👦",
+        color: "#10b981",
+        active: true,
+      },
+    };
+
+    // Act
+    render(<DreamCard dream={dream} />);
+
+    // Assert
+    expect(screen.queryByText("アーカイブ済み")).not.toBeInTheDocument();
+  });
+
   test("AAA: 詳細ページへのリンクがあり、href に id が入っている（リンク/イベント）", async () => {
     // Arrange
     const user = userEvent.setup();

--- a/frontend/app/components/DreamCard.tsx
+++ b/frontend/app/components/DreamCard.tsx
@@ -100,6 +100,11 @@ const DreamCard = ({ dream }: DreamCardProps) => {
                     <span className="truncate">{profile.name}</span>
                   </span>
                 ) : null}
+                {profile && !profile.active ? (
+                  <span className="inline-flex shrink-0 items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                    アーカイブ済み
+                  </span>
+                ) : null}
               </div>
               {dream.analysis_status === "pending" && (
                 <div className="flex flex-col gap-1 w-24">


### PR DESCRIPTION
## 概要

DreamCard のプロフィールバッジ隣に、`dream_profile.active === false` のときだけ「アーカイブ済み」補助バッジを表示します。

```
通常:         🐱 モカ
アーカイブ済み: 🐱 モカ  [アーカイブ済み]
```

## 背景

PR #333 でプロフィールバッジ表示、PR #334 でプロフィール別フィルターを実装しました。これにより「誰の夢か分かる」「絞り込める」ができるようになりました。

次の改善として、アーカイブ済みプロフィールに紐づく過去の夢を見返したとき、そのプロフィールが現在は使われていないことをユーザーに伝えます。

## 変更内容

- `frontend/app/components/DreamCard.tsx` — `profile && !profile.active` を条件とする補助バッジを追加
- `frontend/__tests__/components/DreamCard.test.js` — 2テスト追加

## backend / types.ts は変更不要

`dreams_controller.rb` の `dream_profile_json_options` はすでに `active` を返しており（`:id, :name, :avatar_emoji, :color, :active`）、`Dream.dream_profile` 型も `Pick<DreamProfile, "id" | "name" | "avatar_emoji" | "color" | "active">` で `active` を含んでいます。表示ロジックの追加だけで完結しました。

## 表示ルール

| 状態 | 表示 |
|---|---|
| `dream_profile.active === false` | プロフィールバッジ + 「アーカイブ済み」バッジを表示 |
| `dream_profile.active === true` | プロフィールバッジのみ表示（アーカイブバッジなし） |
| `dream_profile === null / undefined` | バッジなし（何も表示しない） |

## UX 補足

- 「アーカイブ済み」バッジは操作要素ではなく補助表示。クリックハンドラー・role は持たない
- `shrink-0` でスマホ幅の折り返し時も押しつぶされない
- `bg-muted / text-muted-foreground / border-border` のシステムカラーでダーク・ライト両対応
- `text-[10px]` でプロフィールバッジより一段小さく補助的な位置づけ

## テスト結果

- `cd frontend && npm test`
  - 17 suites, 147 tests passed
- `cd frontend && npm run build`
  - 成功

追加したテスト:
- `active: false` のプロフィールでは「アーカイブ済み」バッジが表示される ✅
- `active: true` のプロフィールでは「アーカイブ済み」バッジが表示されない ✅

## リスク

- **低**: スマホ幅でバッジが2行になる可能性あるが、`flex-wrap` で自然に折り返す想定（崩れではない）
- **低**: アーカイブ済みプロフィールを持つ夢がない場合はバッジが表示されないためリグレッションなし
- **なし**: backend・types.ts・認証まわりの変更なし

## 今回やらないこと

- アーカイブ済みプロフィールのフィルターチップ表示
- アーカイブ済みプロフィールの復元 UI
- プロフィール管理画面の変更
- DB migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)