### PR TITLE
fix: すべてチップでプロフィール絞り込みを解除する

### DIFF
--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -247,7 +247,7 @@ export default function HomePage() {
 
   const handleProfileFilterChange = useCallback(
     (profileId: string | null) => {
-      const nextParams = new URLSearchParams(searchParams.toString());
+      const nextParams = new URLSearchParams(window.location.search);
 
       if (profileId) {
         nextParams.set("dream_profile_id", profileId);
@@ -258,7 +258,7 @@ export default function HomePage() {
       const queryString = nextParams.toString();
       router.push(queryString ? `/home?${queryString}` : "/home");
     },
-    [router, searchParams]
+    [router]
   );
 
   // 検索がアクティブになったらパネルを開く（条件分岐より前に置く必要あり）

--- a/frontend/e2e/home-flow.spec.ts
+++ b/frontend/e2e/home-flow.spec.ts
@@ -267,4 +267,26 @@ test.describe("ホームページ：認証済みユーザーの夢一覧表示",
       page.getByRole("heading", { name: "夢はまだありません" })
     ).toBeVisible();
   });
+
+  test("[すべて]チップで dream_profile_id を解除し query を保持する", async ({
+    page,
+  }) => {
+    await page.goto("/home?dream_profile_id=2&query=%E7%A9%BA");
+
+    await page.getByRole("button", { name: "すべて" }).click();
+
+    await expect(page).toHaveURL(/\/home\?query=%E7%A9%BA/);
+    await expect(page).not.toHaveURL(/dream_profile_id/);
+  });
+
+  test("[すべて]チップで dream_profile_id だけある場合は /home になる", async ({
+    page,
+  }) => {
+    await page.goto("/home?dream_profile_id=2");
+
+    await page.getByRole("button", { name: "すべて" }).click();
+
+    await expect(page).toHaveURL(/^.*\/home$/);
+    await expect(page).not.toHaveURL(/dream_profile_id/);
+  });
 });


### PR DESCRIPTION
## 概要

`/home` の [すべて] チップを押しても `dream_profile_id` が URL から消えない不具合を修正します。

## 背景

PR #334 でプロフィール別フィルターを実装しました。本番確認で以下の不具合を確認しました。

**再現手順:**
1. `/home?dream_profile_id=10&query=魚` のように、プロフィール絞り込みと検索が両方ある状態で [すべて] チップを押す
2. 期待: `/home?query=魚`（dream_profile_id だけ消える）
3. 実際: URL が変わらない（dream_profile_id が消えない）

## 本番で見つかった不具合

`handleProfileFilterChange` で `new URLSearchParams(searchParams.toString())` を使っていました。React の `useSearchParams()` は concurrent rendering 環境でキャッシュされた値を返すことがあり、チップクリック時に `searchParams` が stale（古い状態）になるケースがありました。その結果、URL の更新が正しく反映されませんでした。

## 修正内容

**変更ファイル:**
- `frontend/app/home/page.tsx`（1行変更 + 依存配列から `searchParams` を削除）
- `frontend/e2e/home-flow.spec.ts`（E2Eテスト2件追加）

**Before:**
```tsx
const nextParams = new URLSearchParams(searchParams.toString());
// ...
}, [router, searchParams]);
```

**After:**
```tsx
const nextParams = new URLSearchParams(window.location.search);
// ...
}, [router]);
```

## searchParams.toString() ではなく window.location.search を使う理由

| 方式 | 問題点 |
|---|---|
| `searchParams.toString()` | React のレンダリングサイクル内でキャッシュされた値を参照するため、concurrent mode で stale になることがある |
| `window.location.search` | 常に現在のブラウザ URL を参照するため、stale にならない |

`window.location.search` はクライアントサイドのみで動作するが、`handleProfileFilterChange` はボタンクリックハンドラーであり SSR では実行されないため、安全に使用できます。

また、`searchParams` を依存配列から除外することで、`searchParams` の変化ごとに `useCallback` が再生成されるコストも削減されます。

## 追加したE2Eテスト

```ts
test("[すべて]チップで dream_profile_id を解除し query を保持する", async ({ page }) => {
  await page.goto("/home?dream_profile_id=2&query=%E7%A9%BA");
  await page.getByRole("button", { name: "すべて" }).click();
  await expect(page).toHaveURL(/\/home\?query=%E7%A9%BA/);
  await expect(page).not.toHaveURL(/dream_profile_id/);
});

test("[すべて]チップで dream_profile_id だけある場合は /home になる", async ({ page }) => {
  await page.goto("/home?dream_profile_id=2");
  await page.getByRole("button", { name: "すべて" }).click();
  await expect(page).toHaveURL(/^.*\/home$/);
  await expect(page).not.toHaveURL(/dream_profile_id/);
});
```

## テスト結果

- `cd frontend && npm test`
  - 17 suites, 145 tests passed
- `cd frontend && npm run build`
  - 成功
- `cd frontend && npx playwright test e2e/home-flow.spec.ts`
  - 7 passed（新規2件含む）

## リスク

- **低**: `window.location.search` はクライアントサイドのみ。SSR では `handleProfileFilterChange` は実行されないため影響なし
- **低**: 依存配列から `searchParams` を外したことで、React の exhaustive-deps lint warning が出る可能性があるが、`window.location.search` を使う設計上意図的な除外
- **なし**: backend・types.ts・認証まわりの変更なし

## 関連PR

- PR #334: feat: ホーム画面にプロフィール別フィルターを追加（本不具合の発生源）
- PR #337: feat: アーカイブ済みプロフィールの夢に状態バッジを表示（並行開発）

🤖 Generated with [Claude Code](https://claude.com/claude-code)