### PR TITLE
fix: 本番で[すべて]チップがdream_profile_idを解除しない問題を修正

### DIFF
--- a/frontend/__tests__/components/SearchBar.test.js
+++ b/frontend/__tests__/components/SearchBar.test.js
@@ -2,6 +2,21 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import SearchBar from "@/app/components/SearchBar";
 
+// SearchBar 内部の useRouter をモックする
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+  }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/home",
+}));
+
 const mockEmotions = [
   { id: 1, name: "嬉しい" },
   { id: 2, name: "楽しい" },
@@ -29,13 +44,14 @@ describe("SearchBar", () => {
       expect(screen.queryByText("😊 うれしい")).not.toBeInTheDocument();
     });
 
-    it("プロフィール絞り込みをhidden inputで保持する", () => {
-      const { container } = render(
-        <SearchBar emotions={mockEmotions} dreamProfileId="2" />
-      );
+    it("dream_profile_id の hidden input はレンダリングされない（router.push 経由で管理）", () => {
+      // SearchBar は dreamProfileId prop を持たない。
+      // dream_profile_id は submit 時に window.location.search から読む設計のため、
+      // hidden input が DOM に存在しないことを確認する。
+      const { container } = render(<SearchBar emotions={mockEmotions} />);
 
       const input = container.querySelector('input[name="dream_profile_id"]');
-      expect(input).toHaveValue("2");
+      expect(input).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/app/components/SearchBar.tsx
+++ b/frontend/app/components/SearchBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { Emotion } from "@/app/types";
 import { getJSTDateStr } from "@/lib/date";
 import { Button } from "./ui/button";
@@ -10,7 +11,8 @@ type SearchBarProps = {
   query?: string | string[] | undefined;
   startDate?: string | string[] | undefined;
   endDate?: string | string[] | undefined;
-  dreamProfileId?: string | string[] | undefined;
+  // dreamProfileId は prop で受け取らず、submit 時に window.location.search から読む
+  // （ProfileFilterChips の router.push 後も含め、常に現在の URL の値を使うため）
   emotions?: Emotion[];
   selectedEmotionIds?: string[];
 };
@@ -26,12 +28,11 @@ export default function SearchBar({
   query,
   startDate,
   endDate,
-  dreamProfileId,
   emotions = [],
   selectedEmotionIds = [],
 }: SearchBarProps) {
+  const router = useRouter();
   const normalizedSelectedEmotionIds = selectedEmotionIds.map((id) => Number(id));
-  const normalizedDreamProfileId = normalizeParam(dreamProfileId);
   const selectedIdsKey = normalizedSelectedEmotionIds.join(",");
   const [queryValue, setQueryValue] = useState(normalizeParam(query));
   const [dateFrom, setDateFrom] = useState(normalizeParam(startDate));
@@ -72,6 +73,43 @@ export default function SearchBar({
     }
   }, [hasAdvancedFilters]);
 
+  /**
+   * フォーム送信を router.push に委譲する。
+   *
+   * - ネイティブ form 送信（action="/home" GET）を preventDefault で止める
+   * - dream_profile_id は window.location.search から読む
+   *   → [すべて]チップが router.push で URL を変更した後でも正しい値を取得できる
+   * - これにより「[すべて]クリック後にフォームが再送信して dream_profile_id を復元する」
+   *   バグを防ぐ
+   */
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    // 現在の URL から dream_profile_id を取得する
+    const currentParams = new URLSearchParams(window.location.search);
+    const nextParams = new URLSearchParams();
+
+    if (queryValue) {
+      nextParams.set("query", queryValue);
+    }
+    if (dateFrom) {
+      nextParams.set("startDate", dateFrom);
+    }
+    if (dateTo) {
+      nextParams.set("endDate", dateTo);
+    }
+    selectedIds.forEach((id) => nextParams.append("emotion_ids[]", String(id)));
+
+    // dream_profile_id は現在の URL から引き継ぐ（prop や hidden input は使わない）
+    const dreamProfileId = currentParams.get("dream_profile_id");
+    if (dreamProfileId) {
+      nextParams.set("dream_profile_id", dreamProfileId);
+    }
+
+    const queryString = nextParams.toString();
+    router.push(queryString ? `/home?${queryString}` : "/home");
+  };
+
   const applyPreset = (from: Date, to: Date) => {
     setDateFrom(getJSTDateStr(from));
     setDateTo(getJSTDateStr(to));
@@ -106,20 +144,13 @@ export default function SearchBar({
 
   return (
     <form
-      action="/home"
-      method="get"
+      onSubmit={handleSubmit}
       className="mb-6 w-full rounded-2xl border border-border bg-card p-4 shadow-sm"
     >
+      {/* dream_profile_id の hidden input は削除 — handleSubmit で window.location.search から読む */}
       {selectedIds.map((id) => (
         <input key={id} type="hidden" name="emotion_ids[]" value={id} />
       ))}
-      {normalizedDreamProfileId && (
-        <input
-          type="hidden"
-          name="dream_profile_id"
-          value={normalizedDreamProfileId}
-        />
-      )}
       {/* 折りたたみ時も日付フィルターを保持する */}
       {!isExpanded && dateFrom && (
         <input type="hidden" name="startDate" value={dateFrom} />

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -348,7 +348,6 @@ export default function HomePage() {
             query={searchParams.get("query") || undefined}
             startDate={searchParams.get("startDate") || undefined}
             endDate={searchParams.get("endDate") || undefined}
-            dreamProfileId={selectedDreamProfileId || undefined}
             emotions={emotions}
             selectedEmotionIds={searchParams.getAll("emotion_ids[]")}
           />

--- a/frontend/e2e/home-flow.spec.ts
+++ b/frontend/e2e/home-flow.spec.ts
@@ -236,13 +236,56 @@ test.describe("ホームページ：認証済みユーザーの夢一覧表示",
 
     const searchInput = page.locator("#search-query");
     await searchInput.fill("空");
-    await Promise.all([
-      page.waitForNavigation({ waitUntil: "domcontentloaded" }),
-      page.getByRole("button", { name: "さがす", exact: true }).click(),
-    ]);
+
+    // SearchBar が router.push を使うようになったため soft navigation になる
+    // waitForNavigation の代わりに toHaveURL で完了を待つ
+    await page.getByRole("button", { name: "さがす", exact: true }).click();
 
     await expect(page).toHaveURL(/dream_profile_id=2/);
     await expect(page).toHaveURL(/query=%E7%A9%BA/);
+  });
+
+  test("[すべて]チップで dream_profile_id を解除し query を保持する", async ({
+    page,
+  }) => {
+    await page.goto("/home?dream_profile_id=2&query=%E7%A9%BA");
+
+    await page.getByRole("button", { name: "すべて" }).click();
+
+    await expect(page).toHaveURL(/\/home\?query=%E7%A9%BA/);
+    await expect(page).not.toHaveURL(/dream_profile_id/);
+  });
+
+  test("[すべて]チップで dream_profile_id だけある場合は /home になる", async ({
+    page,
+  }) => {
+    await page.goto("/home?dream_profile_id=2");
+
+    await page.getByRole("button", { name: "すべて" }).click();
+
+    await expect(page).toHaveURL(/^.*\/home$/);
+    await expect(page).not.toHaveURL(/dream_profile_id/);
+  });
+
+  test("[すべて]後に検索フォームを送信しても dream_profile_id が戻らない", async ({
+    page,
+  }) => {
+    // dream_profile_id=2&query=空 の状態で開始
+    await page.goto("/home?dream_profile_id=2&query=%E7%A9%BA");
+
+    // [すべて] をクリックして dream_profile_id を削除
+    await page.getByRole("button", { name: "すべて" }).click();
+    await expect(page).toHaveURL(/\/home\?query=%E7%A9%BA/);
+    await expect(page).not.toHaveURL(/dream_profile_id/);
+
+    // [すべて] 後に検索フォームを送信する
+    const searchInput = page.locator("#search-query");
+    await searchInput.fill("海");
+    await page.getByRole("button", { name: "さがす", exact: true }).click();
+
+    // dream_profile_id が戻っていないことを確認（SearchBar の hidden input 再送信バグの回帰テスト）
+    await expect(page).not.toHaveURL(/dream_profile_id/);
+    await expect(page).toHaveURL(/query=%E6%B5%B7/);
   });
 
   test("夢が0件のとき空状態メッセージが表示される", async ({ page }) => {


### PR DESCRIPTION
## 問題

PR #338 で `window.location.search` による修正を加えたが、本番環境（Vercel）では依然として [すべて]チップが動作しなかった。

**再現手順:** `/home?dream_profile_id=6&query=魚` → [すべて]クリック  
**期待:** `/home?query=魚`  
**実際:** `/home?dream_profile_id=6&query=魚`（URL不変）

## 根本原因

`SearchBar` が `<form method="get" action="/home">` のネイティブ HTML フォームで、`dream_profile_id` を `<input type="hidden">` として保持していた。

[すべて]クリック後、`router.push("/home?query=魚")` でURLが変わっても、ブラウザの blur/focus 挙動などでフォームが再送信されると hidden input の `dream_profile_id=6` がURLに復元されていた。

証拠: ユーザーが報告した URL の並び順（`dream_profile_id=6&query=魚`）が SearchBar の DOM 順（hidden input → text input）と完全に一致していた。

## 修正内容

| ファイル | 変更 |
|---|---|
| `SearchBar.tsx` | `dreamProfileId` prop と hidden input を削除。`onSubmit` ハンドラを追加し `router.push` に委譲。submit 時は `window.location.search` から `dream_profile_id` を読む |
| `home/page.tsx` | `SearchBar` への `dreamProfileId` prop を削除 |
| `SearchBar.test.js` | `next/navigation` モックを追加。dream_profile_id hidden input が存在しないことを確認するテストに更新 |
| `home-flow.spec.ts` | `waitForNavigation` → soft navigation 対応。`[すべて]` テスト追加・「[すべて]後のフォーム送信でdream_profile_idが戻らない」回帰テスト追加 |

## なぜこの修正が正しいか

- SearchBar の submit ハンドラで `window.location.search` を読むため、[すべて]後（dream_profile_id削除後）に検索しても dream_profile_id は含まれない
- プロフィールチップ選択中に検索した場合、URL の dream_profile_id が引き継がれるため既存ユースケースも維持される

## テスト結果

- Jest: 17 suites, 145 tests ✅
- Next.js build ✅
- Playwright: 8 tests（新規3件含む）✅

## チェックリスト

- [x] [すべて]で dream_profile_id が消える
- [x] query は保持される
- [x] dream_profile_id のみの場合は /home になる
- [x] [すべて]後に検索しても dream_profile_id が戻らない（新規回帰テスト）
- [x] プロフィールチップ選択 + 検索で dream_profile_id が保持される

🤖 Generated with [Claude Code](https://claude.com/claude-code)