### PR TITLE
fix: アカウント削除フローの安全性改善（未認証ガード・失敗時挙動・二重logout解消）

### DIFF
--- a/frontend/__tests__/app/settings/page.test.tsx
+++ b/frontend/__tests__/app/settings/page.test.tsx
@@ -1,0 +1,171 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import SettingsPage from "@/app/settings/page";
+import { useAuth } from "@/context/AuthContext";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: jest.fn() }),
+}));
+
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@/lib/apiClient", () => ({
+  __esModule: true,
+  updateProfile: jest.fn(),
+  default: {},
+}));
+
+jest.mock("@/lib/toast", () => ({
+  __esModule: true,
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("@/app/components/MorpheusImage", () => ({
+  __esModule: true,
+  default: () => <div data-testid="morpheus-image" />,
+}));
+
+jest.mock("@/app/components/MorpheusLoginRequired", () => ({
+  __esModule: true,
+  default: () => <div data-testid="morpheus-login-required" />,
+}));
+
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+type AuthValue = ReturnType<typeof useAuth>;
+
+function makeAuthValue(overrides: Partial<AuthValue> = {}): AuthValue {
+  return {
+    authStatus: "authenticated",
+    isLoggedIn: true,
+    user: {
+      id: "1",
+      email: "a@b.com",
+      username: "tester",
+      age_group: "adult",
+      analysis_tone: "auto",
+    },
+    userId: "1",
+    login: jest.fn(),
+    logout: jest.fn(),
+    deleteUser: jest.fn(),
+    error: null,
+    ...overrides,
+  } as AuthValue;
+}
+
+/** 削除モーダルを開き、ジュニアロックを解いて最終確認まで進める */
+function proceedToFinalConfirm() {
+  fireEvent.click(screen.getByRole("button", { name: "さくじょ" }));
+  const question = screen.getByText(/\d+ \+ \d+ = \?/).textContent ?? "";
+  const [a, b] = (question.match(/\d+/g) ?? []).map(Number);
+  fireEvent.change(screen.getByPlaceholderText("?に入る数字"), {
+    target: { value: String(a + b) },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "すすむ" }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// 1. 未認証ガード
+// ---------------------------------------------------------------------------
+
+describe("未認証ガード", () => {
+  it("unauthenticated のときはログイン導線を表示し、設定画面を出さない", () => {
+    mockedUseAuth.mockReturnValue(
+      makeAuthValue({
+        authStatus: "unauthenticated",
+        isLoggedIn: false,
+        user: null,
+        userId: null,
+      })
+    );
+
+    render(<SettingsPage />);
+
+    expect(screen.getByTestId("morpheus-login-required")).toBeInTheDocument();
+    expect(
+      screen.queryByText("アカウントをさくじょする")
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. userId が無い状態での削除
+// ---------------------------------------------------------------------------
+
+describe("userId が無い状態での削除", () => {
+  it("画面内にエラーを表示し、無反応にならない", async () => {
+    mockedUseAuth.mockReturnValue(makeAuthValue({ userId: null }));
+
+    render(<SettingsPage />);
+    proceedToFinalConfirm();
+    fireEvent.click(
+      screen.getByRole("button", { name: "はい、すべて さくじょします" })
+    );
+
+    expect(
+      await screen.findByText(/ログイン情報を確認できませんでした/)
+    ).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. 削除APIが失敗した場合
+// ---------------------------------------------------------------------------
+
+describe("削除APIが失敗した場合", () => {
+  it("エラーを表示し、logout / redirect に進まない", async () => {
+    const authValue = makeAuthValue();
+    (authValue.deleteUser as jest.Mock).mockRejectedValue(new Error("boom"));
+    mockedUseAuth.mockReturnValue(authValue);
+
+    render(<SettingsPage />);
+    proceedToFinalConfirm();
+    fireEvent.click(
+      screen.getByRole("button", { name: "はい、すべて さくじょします" })
+    );
+
+    expect(
+      await screen.findByText(/さくじょに しっぱいしました/)
+    ).toBeInTheDocument();
+    expect(authValue.logout).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. 削除成功時
+// ---------------------------------------------------------------------------
+
+describe("削除成功時", () => {
+  it("完了メッセージを表示し、logout API 経由の二重ログアウトをしない", async () => {
+    const authValue = makeAuthValue();
+    (authValue.deleteUser as jest.Mock).mockResolvedValue(undefined);
+    mockedUseAuth.mockReturnValue(authValue);
+
+    render(<SettingsPage />);
+    proceedToFinalConfirm();
+    fireEvent.click(
+      screen.getByRole("button", { name: "はい、すべて さくじょします" })
+    );
+
+    expect(
+      await screen.findByText("アカウントを さくじょしました")
+    ).toBeInTheDocument();
+    // ローカル状態のクリアは deleteUser() 側の責務。settings からは logout を呼ばない
+    expect(authValue.logout).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/context/AuthContext.test.tsx
+++ b/frontend/__tests__/context/AuthContext.test.tsx
@@ -46,7 +46,12 @@ jest.mock("@/lib/apiClient", () => {
 const AUTH_HINT_KEY = "dreamjournal_auth_hint";
 const mockedGet = apiClient.get as jest.MockedFunction<typeof apiClient.get>;
 const mockedPost = apiClient.post as jest.MockedFunction<typeof apiClient.post>;
-const mockedUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
+const mockedDelete = apiClient.delete as jest.MockedFunction<
+  typeof apiClient.delete
+>;
+const mockedUsePathname = usePathname as jest.MockedFunction<
+  typeof usePathname
+>;
 const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
 
 function makeApiError(status: number): ApiError {
@@ -66,6 +71,7 @@ type CapturedContext = {
   userId: string | null;
   error: string | null;
   logout: () => Promise<void>;
+  deleteUser: () => Promise<void>;
 };
 const captured: CapturedContext = {
   authStatus: "",
@@ -73,6 +79,7 @@ const captured: CapturedContext = {
   userId: null,
   error: null,
   logout: async () => {},
+  deleteUser: async () => {},
 };
 
 function ContextReader() {
@@ -82,6 +89,7 @@ function ContextReader() {
   captured.userId = ctx.userId;
   captured.error = ctx.error;
   captured.logout = ctx.logout;
+  captured.deleteUser = ctx.deleteUser;
   return null;
 }
 
@@ -166,20 +174,17 @@ describe("403 / 404 / 500 (恒久的エラー)", () => {
     }
   );
 
-  it.each([403, 404, 500])(
-    "%i の場合は authHint が消える",
-    async (status) => {
-      localStorage.setItem(AUTH_HINT_KEY, "1");
-      mockedGet.mockRejectedValue(makeApiError(status));
+  it.each([403, 404, 500])("%i の場合は authHint が消える", async (status) => {
+    localStorage.setItem(AUTH_HINT_KEY, "1");
+    mockedGet.mockRejectedValue(makeApiError(status));
 
-      renderWithProvider();
+    renderWithProvider();
 
-      await waitFor(() => {
-        expect(captured.authStatus).toBe("unauthenticated");
-      });
-      expect(localStorage.getItem(AUTH_HINT_KEY)).toBeNull();
-    }
-  );
+    await waitFor(() => {
+      expect(captured.authStatus).toBe("unauthenticated");
+    });
+    expect(localStorage.getItem(AUTH_HINT_KEY)).toBeNull();
+  });
 
   it("500 の場合はリトライしない（get が1回だけ呼ばれる）", async () => {
     jest.useFakeTimers();
@@ -192,11 +197,15 @@ describe("403 / 404 / 500 (恒久的エラー)", () => {
     expect(mockedGet).toHaveBeenCalledTimes(1);
 
     // タイマーを進めても再呼び出しされない
-    await act(async () => { jest.advanceTimersByTime(7000); });
+    await act(async () => {
+      jest.advanceTimersByTime(7000);
+    });
     await act(async () => {});
     expect(mockedGet).toHaveBeenCalledTimes(1);
 
-    act(() => { jest.runAllTimers(); });
+    act(() => {
+      jest.runAllTimers();
+    });
     jest.useRealTimers();
   });
 });
@@ -209,7 +218,9 @@ describe("一時障害 (502/503/504/network error)", () => {
   beforeEach(() => jest.useFakeTimers());
   afterEach(() => {
     // 残っているタイマーをすべて消化してから実タイマーに戻す
-    act(() => { jest.runAllTimers(); });
+    act(() => {
+      jest.runAllTimers();
+    });
     jest.useRealTimers();
   });
 
@@ -224,7 +235,9 @@ describe("一時障害 (502/503/504/network error)", () => {
 
     expect(captured.authStatus).not.toBe("unauthenticated");
     expect(localStorage.getItem(AUTH_HINT_KEY)).toBe("1");
-    expect(captured.error).toBe("サーバーを起動しています。しばらくお待ちください。");
+    expect(captured.error).toBe(
+      "サーバーを起動しています。しばらくお待ちください。"
+    );
   }
 
   it("502: authStatus が unauthenticated にならない", async () => {
@@ -276,7 +289,9 @@ describe("一時障害 (502/503/504/network error)", () => {
     expect(mockedGet).toHaveBeenCalledTimes(1);
 
     // 6秒進める → retry タイマー発火
-    await act(async () => { jest.advanceTimersByTime(6100); });
+    await act(async () => {
+      jest.advanceTimersByTime(6100);
+    });
     // 2回目のリトライ非同期を消化
     await act(async () => {});
 
@@ -292,19 +307,27 @@ describe("一時障害 (502/503/504/network error)", () => {
     // 1回目
     await act(async () => {});
     // 2回目
-    await act(async () => { jest.advanceTimersByTime(6100); });
+    await act(async () => {
+      jest.advanceTimersByTime(6100);
+    });
     await act(async () => {});
     // 3回目
-    await act(async () => { jest.advanceTimersByTime(6100); });
+    await act(async () => {
+      jest.advanceTimersByTime(6100);
+    });
     await act(async () => {});
     // 4回目（上限超え → タイマーは設定されない）
-    await act(async () => { jest.advanceTimersByTime(6100); });
+    await act(async () => {
+      jest.advanceTimersByTime(6100);
+    });
     await act(async () => {});
 
     // 初回 + リトライ3回 = 4回まで
     expect(mockedGet).toHaveBeenCalledTimes(4);
     // 5回目以上のタイマーは存在しないので、さらに進めても get は増えない
-    await act(async () => { jest.advanceTimersByTime(6100); });
+    await act(async () => {
+      jest.advanceTimersByTime(6100);
+    });
     await act(async () => {});
     expect(mockedGet).toHaveBeenCalledTimes(4);
   });
@@ -317,7 +340,9 @@ describe("一時障害 (502/503/504/network error)", () => {
 describe("リトライ上限 (3回) 到達後", () => {
   beforeEach(() => jest.useFakeTimers());
   afterEach(() => {
-    act(() => { jest.runAllTimers(); });
+    act(() => {
+      jest.runAllTimers();
+    });
     jest.useRealTimers();
   });
 
@@ -329,7 +354,9 @@ describe("リトライ上限 (3回) 到達後", () => {
     // 初回 + 3回リトライ = 4回分の失敗を消化
     await act(async () => {});
     for (let i = 0; i < 3; i++) {
-      await act(async () => { jest.advanceTimersByTime(6100); });
+      await act(async () => {
+        jest.advanceTimersByTime(6100);
+      });
       await act(async () => {});
     }
   }
@@ -410,5 +437,75 @@ describe("logout()", () => {
 
     expect(captured.user).toBeNull();
     expect(captured.userId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. deleteUser() — アカウント削除
+// ---------------------------------------------------------------------------
+
+describe("deleteUser()", () => {
+  async function renderAuthenticated() {
+    localStorage.setItem(AUTH_HINT_KEY, "1");
+    mockedGet.mockResolvedValue({ user: { id: 1, email: "a@b.com" } } as never);
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(captured.authStatus).toBe("authenticated");
+    });
+  }
+
+  it("API削除が失敗したら例外を再throwする", async () => {
+    await renderAuthenticated();
+    mockedDelete.mockRejectedValue(makeApiError(500));
+
+    await act(async () => {
+      await expect(captured.deleteUser()).rejects.toThrow();
+    });
+  });
+
+  it("API削除が失敗したら認証状態を維持し logout API を呼ばない", async () => {
+    await renderAuthenticated();
+    mockedDelete.mockRejectedValue(makeApiError(500));
+
+    await act(async () => {
+      await captured.deleteUser().catch(() => {});
+    });
+
+    expect(captured.authStatus).toBe("authenticated");
+    expect(localStorage.getItem(AUTH_HINT_KEY)).toBe("1");
+    expect(mockedPost).not.toHaveBeenCalledWith("/auth/logout");
+  });
+
+  it("削除成功時は logout API を呼ばずローカル認証状態をクリアする", async () => {
+    await renderAuthenticated();
+    mockedDelete.mockResolvedValue(null as never);
+
+    await act(async () => {
+      await captured.deleteUser();
+    });
+
+    // バックエンドの destroy が Cookie を破棄済みのため /auth/logout は呼ばない
+    expect(mockedPost).not.toHaveBeenCalledWith("/auth/logout");
+    expect(captured.authStatus).toBe("unauthenticated");
+    expect(captured.user).toBeNull();
+    expect(captured.userId).toBeNull();
+    expect(localStorage.getItem(AUTH_HINT_KEY)).toBeNull();
+  });
+
+  it("userId が無い場合は例外を投げ、削除APIを呼ばない", async () => {
+    mockedGet.mockRejectedValue(makeApiError(401));
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(captured.authStatus).toBe("unauthenticated");
+    });
+
+    await act(async () => {
+      await expect(captured.deleteUser()).rejects.toThrow();
+    });
+    expect(mockedDelete).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { useAuth } from "../../context/AuthContext";
 import Loading from "../loading";
 import Link from "next/link";
@@ -10,6 +9,7 @@ import { updateProfile } from "@/lib/apiClient";
 import { toast } from "@/lib/toast";
 import type { AgeGroup, AnalysisTone } from "@/app/types";
 import MorpheusImage from "@/app/components/MorpheusImage";
+import MorpheusLoginRequired from "@/app/components/MorpheusLoginRequired";
 
 const AGE_GROUP_OPTIONS: { value: AgeGroup; label: string }[] = [
   { value: "child_small", label: "6さい いか" },
@@ -38,8 +38,7 @@ const generateMathProblem = () => {
 };
 
 const SettingsPage = () => {
-  const { authStatus, userId, user, logout, deleteUser } = useAuth();
-  const router = useRouter();
+  const { authStatus, userId, user, deleteUser } = useAuth();
 
   // プロフィール編集フォーム用 state
   const [profileUsername, setProfileUsername] = useState(user?.username ?? "");
@@ -110,12 +109,15 @@ const SettingsPage = () => {
   const [errorMsg, setErrorMsg] = useState("");
 
   const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState("");
+  const [isDeleted, setIsDeleted] = useState(false);
 
   // モーダルを開くたびに問題を再生成
   const openDeleteModal = () => {
     setMathProblem(generateMathProblem());
     setUserAnswer("");
     setErrorMsg("");
+    setDeleteError("");
     setStep("lock");
     setIsDeleteModalOpen(true);
   };
@@ -131,28 +133,66 @@ const SettingsPage = () => {
   };
 
   const handleDelete = async () => {
+    if (!userId) {
+      setDeleteError(
+        "ログイン情報を確認できませんでした。もう一度ログインしてください。"
+      );
+      return;
+    }
     setIsDeleting(true);
+    setDeleteError("");
     try {
-      if (userId) {
-        await deleteUser();
-        logout();
-        router.push("/");
-      } else {
-        console.error("ユーザーIDが見つかりません。");
-      }
-    } catch (error) {
-      console.error("ユーザー削除に失敗しました。", error);
-      alert(
-        "アカウントの削除に失敗しました。 しばらくしてから実行してください。"
+      // 削除成功時のローカル認証状態クリアは deleteUser() が行う
+      await deleteUser();
+      setIsDeleteModalOpen(false);
+      setIsDeleted(true);
+    } catch {
+      // 失敗時はモーダルを開いたままエラーを表示し、ログアウト・遷移しない
+      setDeleteError(
+        "さくじょに しっぱいしました。しばらくしてから もういちど ためしてね。"
       );
     } finally {
       setIsDeleting(false);
-      setIsDeleteModalOpen(false);
     }
   };
 
+  // 削除完了画面（認証状態クリア後も「おかえり！」等を出さずに完了を伝える）
+  if (isDeleted) {
+    return (
+      <div className="min-h-screen bg-background text-foreground flex items-center justify-center px-4">
+        <div className="w-full max-w-md text-center space-y-4 bg-card border border-border/50 rounded-2xl p-8 shadow-sm">
+          <div className="text-4xl" aria-hidden="true">
+            🌙
+          </div>
+          <h1 className="text-xl font-bold">アカウントを さくじょしました</h1>
+          <p className="text-sm text-muted-foreground">
+            これまで つかってくれて ありがとう。
+            <br />
+            また あそびに きてね。
+          </p>
+          <Link
+            href="/"
+            className="inline-flex min-h-11 items-center justify-center rounded-xl bg-primary px-5 py-3 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            トップページへ
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
   if (authStatus === "checking") {
     return <Loading />;
+  }
+
+  // 未認証ガード: 設定画面（削除導線を含む）を表示しない
+  if (authStatus === "unauthenticated") {
+    return (
+      <MorpheusLoginRequired
+        title="設定を開くにはログインが必要だよ"
+        message="保護者メニューは、アカウントの大切な設定を行う場所です。ログインすると、プロフィールやアカウントの設定ができます。"
+      />
+    );
   }
 
   return (
@@ -483,6 +523,15 @@ const SettingsPage = () => {
                     ※このそうさは とりけせません。
                   </p>
                 </div>
+
+                {deleteError && (
+                  <p
+                    role="alert"
+                    className="text-destructive text-sm font-bold"
+                  >
+                    {deleteError}
+                  </p>
+                )}
 
                 <div className="flex flex-col gap-3 pt-4">
                   <button

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -188,15 +188,22 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const deleteUser = useCallback(async () => {
     if (!userId) {
       setError("ユーザーIDが存在しません");
-      return;
+      throw new Error("ユーザーIDが存在しません");
     }
     try {
       await apiClient.delete(`/users/${userId}`);
-      await logout();
     } catch (err) {
       setError("アカウント削除に失敗しました");
+      throw err;
     }
-  }, [userId, logout]);
+    // バックエンドの destroy が認証Cookieを破棄済みのため、
+    // /auth/logout は呼ばずローカルの認証状態だけをクリアする
+    setAuthHint(false);
+    setAuthStatus("unauthenticated");
+    setUser(null);
+    setUserId(null);
+    setError(null);
+  }, [userId]);
 
   return (
     <AuthContext.Provider


### PR DESCRIPTION
## 背景

本番実機確認で見つかったアカウント削除フローの問題（フロントエンドのみ）を最小スコープで修正します。

- 未認証でも /settings が表示され、削除モーダルを最後まで操作できた
- 未認証で削除実行しても console.error のみで画面は無反応だった
- deleteUser() がAPI失敗を握りつぶし、削除失敗でも logout / redirect に進み得た
- deleteUser() 内と settings 側で logout が二重に呼ばれ、削除後に logout API が400になっていた
- 削除成功後に /login の「おかえり！」が表示され、完了が分かりにくかった

## 変更内容

### context/AuthContext.tsx
- `deleteUser()`: userId 不在・API失敗時に例外を throw（呼び出し元で検知可能に）
- 削除成功時は `/auth/logout` を呼ばずローカル認証状態のみクリア（バックエンドの destroy がCookie破棄済みのため。二重logout・400を解消）

### app/settings/page.tsx
- 未認証ガード追加: `authStatus === "unauthenticated"` で `MorpheusLoginRequired` を表示（home / subscription と同じパターン）
- `handleDelete`: userId 不在時はモーダル内にエラー表示。API失敗時はモーダルを開いたままエラー表示し、ログアウト・遷移しない
- 削除成功時のみモーダルを閉じ、「アカウントを さくじょしました」完了画面を表示（`alert()` / `console.error` のみの分岐を撤去）

## テスト

- `__tests__/context/AuthContext.test.tsx`: deleteUser の再throw / 失敗時の認証状態維持 / 成功時のlogout API不使用とローカル状態クリア / userId不在時のthrow（4件追加）
- `__tests__/app/settings/page.test.tsx`（新規）: 未認証ガード / userId不在エラー表示 / API失敗時に遷移しない / 成功時の完了表示（4件）
- `npx jest`: **180 passed / 180** （リグレッションなし）
- ブラウザ確認: 未認証で /settings → ログイン導線画面が表示され、削除UIは出ない

## スコープ外（次PR候補）

- Stripe サブスク解約処理（削除前の cancel 必須化）
- `DELETE /users/:id` → `DELETE /account` 化
- モーダルの a11y（role="dialog" / フォーカストラップ）