### PR TITLE
fix: 夢の森のP3フォロー（お祝いボタン文言・proxyの/forest登録）

### DIFF
--- a/frontend/app/components/forest/HarvestCelebration.tsx
+++ b/frontend/app/components/forest/HarvestCelebration.tsx
@@ -63,7 +63,7 @@ export default function HarvestCelebration({
                 onClick={onClose}
                 className="flex-1 rounded-xl bg-muted px-4 py-2 text-sm font-bold text-muted-foreground"
               >
-                とじる
+                ホームへ
               </button>
               <Link
                 href="/forest"

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -47,6 +47,7 @@ export async function proxy(request: NextRequest) {
   const isProtectedPage =
     pathname.startsWith("/home") ||
     pathname.startsWith("/dream") ||
+    pathname.startsWith("/forest") ||
     pathname.startsWith("/settings");
 
   // Only these pages render MorpheusLoginRequired for unauthenticated users.
@@ -91,6 +92,7 @@ export const config = {
   matcher: [
     "/home/:path*",
     "/dream/:path*",
+    "/forest/:path*",
     "/settings/:path*",
     "/login",
     "/register",


### PR DESCRIPTION
## 概要
PR #352（夢の森）レビューで P3 として見送った2点のフォローです。6/13 家族ユーザーテスト前のリスク最小化のため最小修正に絞っています。

## 変更
- **HarvestCelebration**: 「とじる」ボタンは実際には `/home` へ遷移するため、文言を「ホームへ」に変更（挙動と一致させる）
- **proxy.ts**: `isProtectedPage` と `matcher` に `/forest` を追加し、AuthContext の保護パス（#352 で追加済み）とサーバー側を整合

## テスト
- [x] Jest: 180 passed
- [x] E2E（forest-flow）: passed
- [x] 「とじる」を参照するテストが無いことを確認（コピー変更の影響なし）
