### PR TITLE
feat: アカウント削除前にStripeサブスクを即時解約する

### DIFF
--- a/backend/app/controllers/users_controller.rb
+++ b/backend/app/controllers/users_controller.rb
@@ -43,6 +43,15 @@ class UsersController < ApplicationController
 
   # ユーザー削除
   def destroy
+    # 削除前に Stripe 側のサブスクを即時解約する。失敗したら削除を中断。
+    begin
+      SubscriptionCanceler.new(current_user).call
+    rescue SubscriptionCanceler::CancellationError => e
+      Rails.logger.error("[AccountDeletion] Stripe解約失敗 user_id=#{current_user.id}: #{e.message}")
+      return render json: { error: "サブスクリプションの解約に失敗しました。時間をおいて再度お試しください。" },
+                    status: :unprocessable_content
+    end
+
     # 削除対象は常に現在のユーザーに限定する
     if current_user.destroy
       # ログアウト処理も忘れずに行う

--- a/backend/app/services/subscription_canceler.rb
+++ b/backend/app/services/subscription_canceler.rb
@@ -1,0 +1,34 @@
+# アカウント削除前に、ユーザーの active な Stripe サブスクを即時解約するサービス。
+# DB更新は行わない（Subscription を query するのみ）。
+# 解約に失敗した場合は CancellationError を raise し、呼び出し元が削除を中断できるようにする。
+class SubscriptionCanceler
+  class CancellationError < StandardError; end
+
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    @user.subscriptions.where(status: Subscription::ACTIVE_STATUSES).find_each do |sub|
+      cancel_one(sub)
+    end
+  end
+
+  private
+
+  def cancel_one(sub)
+    Stripe::Subscription.cancel(sub.stripe_subscription_id)
+  rescue Stripe::InvalidRequestError => e
+    # 「対象が既に存在しない」= 課金停止済みとみなして冪等に成功扱い。
+    # それ以外（IDが不正・想定外のリクエストエラー等）は失敗扱い。
+    if e.respond_to?(:code) && e.code == 'resource_missing'
+      Rails.logger.info("[AccountDeletion] 解約スキップ（既に不在）sub=#{sub.stripe_subscription_id}: #{e.message}")
+      return
+    end
+
+    raise CancellationError, e.message
+  rescue Stripe::StripeError => e
+    # ネットワーク障害・認証エラー・レート制限など → 中断
+    raise CancellationError, e.message
+  end
+end

--- a/backend/spec/requests/users_spec.rb
+++ b/backend/spec/requests/users_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe 'Users API', type: :request do
+  describe 'DELETE /users/:id' do
+    it_behaves_like 'unauthorized request', :delete, '/users/0'
+
+    context 'active サブスクがあり、Stripe 解約に成功する場合' do
+      it 'ユーザーを削除し 200 を返す' do
+        user = create(:user)
+        create(:subscription, user: user, stripe_subscription_id: 'sub_ok_1', status: 'active')
+
+        expect(Stripe::Subscription).to receive(:cancel).with('sub_ok_1')
+
+        authenticated_delete("/users/#{user.id}", user)
+
+        expect(response).to have_http_status(:ok)
+        expect(User.exists?(user.id)).to be false
+      end
+    end
+
+    context 'Stripe 解約に失敗する場合' do
+      it 'ユーザーを削除せず 422 を返す' do
+        user = create(:user)
+        create(:subscription, user: user, stripe_subscription_id: 'sub_ng_1', status: 'active')
+
+        allow(Stripe::Subscription).to receive(:cancel).and_raise(
+          Stripe::APIConnectionError.new('connection failed')
+        )
+
+        authenticated_delete("/users/#{user.id}", user)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(JSON.parse(response.body)['error']).to include('解約に失敗')
+        expect(User.exists?(user.id)).to be true
+      end
+    end
+
+    context '解約成功後に destroy が失敗する場合' do
+      it '既存の false 分岐に入り、ユーザーは残り 401 を返す' do
+        user = create(:user)
+        create(:subscription, user: user, stripe_subscription_id: 'sub_dfail_1', status: 'active')
+
+        allow(Stripe::Subscription).to receive(:cancel).with('sub_dfail_1')
+        allow_any_instance_of(User).to receive(:destroy).and_return(false)
+
+        authenticated_delete("/users/#{user.id}", user)
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(User.exists?(user.id)).to be true
+      end
+    end
+
+    context 'サブスクが無い場合' do
+      it 'Stripe を呼ばずにユーザーを削除し 200 を返す' do
+        user = create(:user)
+
+        expect(Stripe::Subscription).not_to receive(:cancel)
+
+        authenticated_delete("/users/#{user.id}", user)
+
+        expect(response).to have_http_status(:ok)
+        expect(User.exists?(user.id)).to be false
+      end
+    end
+  end
+end

--- a/backend/spec/services/subscription_canceler_spec.rb
+++ b/backend/spec/services/subscription_canceler_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe SubscriptionCanceler do
+  let(:user) { create(:user) }
+
+  describe '#call' do
+    context 'active なサブスクがある場合' do
+      it '正しい stripe_subscription_id で Stripe::Subscription.cancel を呼ぶ' do
+        create(:subscription, user: user, stripe_subscription_id: 'sub_active_1', status: 'active')
+
+        expect(Stripe::Subscription).to receive(:cancel).with('sub_active_1')
+
+        described_class.new(user).call
+      end
+    end
+
+    context 'past_due なサブスクがある場合' do
+      it '解約する' do
+        create(:subscription, user: user, stripe_subscription_id: 'sub_pastdue_1', status: 'past_due')
+
+        expect(Stripe::Subscription).to receive(:cancel).with('sub_pastdue_1')
+
+        described_class.new(user).call
+      end
+    end
+
+    context 'canceled なサブスクのみの場合' do
+      it 'Stripe を呼ばない（スキップ）' do
+        create(:subscription, user: user, stripe_subscription_id: 'sub_canceled_1', status: 'canceled')
+
+        expect(Stripe::Subscription).not_to receive(:cancel)
+
+        described_class.new(user).call
+      end
+    end
+
+    context '複数の active サブスクがある場合' do
+      it '全件解約する' do
+        create(:subscription, user: user, stripe_subscription_id: 'sub_multi_1', status: 'active')
+        create(:subscription, user: user, stripe_subscription_id: 'sub_multi_2', status: 'past_due')
+
+        expect(Stripe::Subscription).to receive(:cancel).with('sub_multi_1')
+        expect(Stripe::Subscription).to receive(:cancel).with('sub_multi_2')
+
+        described_class.new(user).call
+      end
+    end
+
+    context 'Stripe 側に既に存在しない場合（resource_missing）' do
+      it '成功扱いし、CancellationError を raise しない' do
+        create(:subscription, user: user, stripe_subscription_id: 'sub_gone_1', status: 'active')
+
+        allow(Stripe::Subscription).to receive(:cancel).and_raise(
+          Stripe::InvalidRequestError.new('No such subscription: sub_gone_1', 'subscription', code: 'resource_missing')
+        )
+
+        expect { described_class.new(user).call }.not_to raise_error
+      end
+    end
+
+    context 'resource_missing 以外の InvalidRequestError の場合' do
+      it 'CancellationError を raise する' do
+        create(:subscription, user: user, stripe_subscription_id: 'sub_bad_1', status: 'active')
+
+        allow(Stripe::Subscription).to receive(:cancel).and_raise(
+          Stripe::InvalidRequestError.new('Invalid parameter', 'subscription', code: 'parameter_invalid')
+        )
+
+        expect { described_class.new(user).call }.to raise_error(SubscriptionCanceler::CancellationError)
+      end
+    end
+
+    context 'ネットワーク障害（APIConnectionError）の場合' do
+      it 'CancellationError を raise する' do
+        create(:subscription, user: user, stripe_subscription_id: 'sub_net_1', status: 'active')
+
+        allow(Stripe::Subscription).to receive(:cancel).and_raise(
+          Stripe::APIConnectionError.new('connection failed')
+        )
+
+        expect { described_class.new(user).call }.to raise_error(SubscriptionCanceler::CancellationError)
+      end
+    end
+
+    context 'サブスクが無い場合' do
+      it 'Stripe を呼ばず正常に return する' do
+        expect(Stripe::Subscription).not_to receive(:cancel)
+
+        expect { described_class.new(user).call }.not_to raise_error
+      end
+    end
+  end
+end

--- a/docs/superpowers/plans/2026-06-13-stripe-cancellation-on-account-deletion.md
+++ b/docs/superpowers/plans/2026-06-13-stripe-cancellation-on-account-deletion.md
@@ -1,0 +1,353 @@
+# Stripeサブスク即時解約（アカウント削除前）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** アカウント削除（`UsersController#destroy`）の前に、Stripe 側の active なサブスクを即時解約し、解約に失敗したら削除を中断する。
+
+**Architecture:** `SubscriptionCanceler` サービスが Stripe 側の解約だけを担当（DB更新はしない）。コントローラが「解約 → 成功なら destroy」をオーケストレーションし、解約失敗時は 422 を返す。フロントは PR #353 の既存エラー表示で受けるため変更なし。
+
+**Tech Stack:** Rails 7（APIモード）, Stripe gem 19.1.0, RSpec, FactoryBot
+
+**設計ドキュメント:** [docs/superpowers/specs/2026-06-13-stripe-cancellation-on-account-deletion-design.md](../specs/2026-06-13-stripe-cancellation-on-account-deletion-design.md)
+
+---
+
+## 前提・実行環境
+
+- **バックエンドのテストは Docker 内でのみ実行する。** 全 `rspec` コマンドは以下の前置きを付ける:
+  ```
+  docker-compose -f docker-compose.yml -f docker-compose.dev.yml exec backend bundle exec rspec <path>
+  ```
+  以降の手順では `<RSPEC>` をこの前置きの短縮表記として使う。コンテナ未起動なら先に `make dev-up`。
+- ルート: `DELETE /users/:id`（`config/routes.rb:43` `resources :users, only: [:destroy]`）
+- 認証ヘルパー（`spec/support/auth_helpers.rb`）: `authenticated_delete(path, user)`
+- 共有例（`spec/support/shared_examples/unauthorized_request.rb`）: `it_behaves_like 'unauthorized request', :delete, '/users/0'`
+- factory: `:user`（`spec/factories/users.rb`）, `:subscription`（`spec/factories/subscriptions.rb`、デフォルト `status: "active"`）
+
+## File Structure
+
+| ファイル | 種別 | 責務 |
+|---|---|---|
+| `backend/app/services/subscription_canceler.rb` | 新規 | User の active な Stripe サブスクを即時解約する。DB更新はしない。失敗時 `CancellationError` を raise |
+| `backend/app/controllers/users_controller.rb` | 修正（`destroy`） | 解約 → 成功なら `current_user.destroy`、失敗なら 422 |
+| `backend/spec/services/subscription_canceler_spec.rb` | 新規 | `SubscriptionCanceler` の単体テスト |
+| `backend/spec/requests/users_spec.rb` | 新規 | `DELETE /users/:id` の結合テスト |
+
+---
+
+## Task 1: SubscriptionCanceler サービス
+
+**Files:**
+- Create: `backend/app/services/subscription_canceler.rb`
+- Test: `backend/spec/services/subscription_canceler_spec.rb`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`backend/spec/services/subscription_canceler_spec.rb` を新規作成:
+
+```ruby
+require 'rails_helper'
+
+RSpec.describe SubscriptionCanceler do
+  let(:user) { create(:user) }
+
+  describe '#call' do
+    context 'active なサブスクがある場合' do
+      it '正しい stripe_subscription_id で Stripe::Subscription.cancel を呼ぶ' do
+        create(:subscription, user: user, stripe_subscription_id: 'sub_active_1', status: 'active')
+
+        expect(Stripe::Subscription).to receive(:cancel).with('sub_active_1')
+
+        described_class.new(user).call
+      end
+    end
+
+    context 'past_due なサブスクがある場合' do
+      it '解約する' do
+        create(:subscription, user: user, stripe_subscription_id: 'sub_pastdue_1', status: 'past_due')
+
+        expect(Stripe::Subscription).to receive(:cancel).with('sub_pastdue_1')
+
+        described_class.new(user).call
+      end
+    end
+
+    context 'canceled なサブスクのみの場合' do
+      it 'Stripe を呼ばない（スキップ）' do
+        create(:subscription, user: user, stripe_subscription_id: 'sub_canceled_1', status: 'canceled')
+
+        expect(Stripe::Subscription).not_to receive(:cancel)
+
+        described_class.new(user).call
+      end
+    end
+
+    context '複数の active サブスクがある場合' do
+      it '全件解約する' do
+        create(:subscription, user: user, stripe_subscription_id: 'sub_multi_1', status: 'active')
+        create(:subscription, user: user, stripe_subscription_id: 'sub_multi_2', status: 'past_due')
+
+        expect(Stripe::Subscription).to receive(:cancel).with('sub_multi_1')
+        expect(Stripe::Subscription).to receive(:cancel).with('sub_multi_2')
+
+        described_class.new(user).call
+      end
+    end
+
+    context 'Stripe 側に既に存在しない場合（resource_missing）' do
+      it '成功扱いし、CancellationError を raise しない' do
+        create(:subscription, user: user, stripe_subscription_id: 'sub_gone_1', status: 'active')
+
+        allow(Stripe::Subscription).to receive(:cancel).and_raise(
+          Stripe::InvalidRequestError.new('No such subscription: sub_gone_1', 'subscription', code: 'resource_missing')
+        )
+
+        expect { described_class.new(user).call }.not_to raise_error
+      end
+    end
+
+    context 'resource_missing 以外の InvalidRequestError の場合' do
+      it 'CancellationError を raise する' do
+        create(:subscription, user: user, stripe_subscription_id: 'sub_bad_1', status: 'active')
+
+        allow(Stripe::Subscription).to receive(:cancel).and_raise(
+          Stripe::InvalidRequestError.new('Invalid parameter', 'subscription', code: 'parameter_invalid')
+        )
+
+        expect { described_class.new(user).call }.to raise_error(SubscriptionCanceler::CancellationError)
+      end
+    end
+
+    context 'ネットワーク障害（APIConnectionError）の場合' do
+      it 'CancellationError を raise する' do
+        create(:subscription, user: user, stripe_subscription_id: 'sub_net_1', status: 'active')
+
+        allow(Stripe::Subscription).to receive(:cancel).and_raise(
+          Stripe::APIConnectionError.new('connection failed')
+        )
+
+        expect { described_class.new(user).call }.to raise_error(SubscriptionCanceler::CancellationError)
+      end
+    end
+
+    context 'サブスクが無い場合' do
+      it 'Stripe を呼ばず正常に return する' do
+        expect(Stripe::Subscription).not_to receive(:cancel)
+
+        expect { described_class.new(user).call }.not_to raise_error
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `<RSPEC> spec/services/subscription_canceler_spec.rb`
+Expected: FAIL（`uninitialized constant SubscriptionCanceler`）
+
+- [ ] **Step 3: 最小実装を書く**
+
+`backend/app/services/subscription_canceler.rb` を新規作成:
+
+```ruby
+# アカウント削除前に、ユーザーの active な Stripe サブスクを即時解約するサービス。
+# DB更新は行わない（Subscription を query するのみ）。
+# 解約に失敗した場合は CancellationError を raise し、呼び出し元が削除を中断できるようにする。
+class SubscriptionCanceler
+  class CancellationError < StandardError; end
+
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    @user.subscriptions.where(status: Subscription::ACTIVE_STATUSES).find_each do |sub|
+      cancel_one(sub)
+    end
+  end
+
+  private
+
+  def cancel_one(sub)
+    Stripe::Subscription.cancel(sub.stripe_subscription_id)
+  rescue Stripe::InvalidRequestError => e
+    # 「対象が既に存在しない」= 課金停止済みとみなして冪等に成功扱い。
+    # それ以外（IDが不正・想定外のリクエストエラー等）は失敗扱い。
+    if e.respond_to?(:code) && e.code == 'resource_missing'
+      Rails.logger.info("[AccountDeletion] 解約スキップ（既に不在）sub=#{sub.stripe_subscription_id}: #{e.message}")
+      return
+    end
+    raise CancellationError, e.message
+  rescue Stripe::StripeError => e
+    # ネットワーク障害・認証エラー・レート制限など → 中断
+    raise CancellationError, e.message
+  end
+end
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `<RSPEC> spec/services/subscription_canceler_spec.rb`
+Expected: PASS（9 examples, 0 failures）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add backend/app/services/subscription_canceler.rb backend/spec/services/subscription_canceler_spec.rb
+git commit -m "feat: Stripeサブスク即時解約サービス SubscriptionCanceler を追加
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: UsersController#destroy に解約処理を統合
+
+**Files:**
+- Modify: `backend/app/controllers/users_controller.rb`（`destroy` アクション、現状 44-55 行）
+- Test: `backend/spec/requests/users_spec.rb`（新規）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`backend/spec/requests/users_spec.rb` を新規作成:
+
+```ruby
+require 'rails_helper'
+
+RSpec.describe 'Users API', type: :request do
+  describe 'DELETE /users/:id' do
+    it_behaves_like 'unauthorized request', :delete, '/users/0'
+
+    context 'active サブスクがあり、Stripe 解約に成功する場合' do
+      it 'ユーザーを削除し 200 を返す' do
+        user = create(:user)
+        create(:subscription, user: user, stripe_subscription_id: 'sub_ok_1', status: 'active')
+
+        expect(Stripe::Subscription).to receive(:cancel).with('sub_ok_1')
+
+        authenticated_delete("/users/#{user.id}", user)
+
+        expect(response).to have_http_status(:ok)
+        expect(User.exists?(user.id)).to be false
+      end
+    end
+
+    context 'Stripe 解約に失敗する場合' do
+      it 'ユーザーを削除せず 422 を返す' do
+        user = create(:user)
+        create(:subscription, user: user, stripe_subscription_id: 'sub_ng_1', status: 'active')
+
+        allow(Stripe::Subscription).to receive(:cancel).and_raise(
+          Stripe::APIConnectionError.new('connection failed')
+        )
+
+        authenticated_delete("/users/#{user.id}", user)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)['error']).to include('解約に失敗')
+        expect(User.exists?(user.id)).to be true
+      end
+    end
+
+    context '解約成功後に destroy が失敗する場合' do
+      it '既存の false 分岐に入り、ユーザーは残り 401 を返す' do
+        user = create(:user)
+        create(:subscription, user: user, stripe_subscription_id: 'sub_dfail_1', status: 'active')
+
+        allow(Stripe::Subscription).to receive(:cancel).with('sub_dfail_1')
+        allow_any_instance_of(User).to receive(:destroy).and_return(false)
+
+        authenticated_delete("/users/#{user.id}", user)
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(User.exists?(user.id)).to be true
+      end
+    end
+
+    context 'サブスクが無い場合' do
+      it 'Stripe を呼ばずにユーザーを削除し 200 を返す' do
+        user = create(:user)
+
+        expect(Stripe::Subscription).not_to receive(:cancel)
+
+        authenticated_delete("/users/#{user.id}", user)
+
+        expect(response).to have_http_status(:ok)
+        expect(User.exists?(user.id)).to be false
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `<RSPEC> spec/requests/users_spec.rb`
+Expected: FAIL（解約失敗ケースで、現状は `cancel` を呼ばず 200 になる／422 にならない）
+
+- [ ] **Step 3: destroy アクションを修正**
+
+`backend/app/controllers/users_controller.rb` の `destroy` アクション（現状 44-55 行）を以下に置き換える:
+
+```ruby
+  # ユーザー削除
+  def destroy
+    # 削除前に Stripe 側のサブスクを即時解約する。失敗したら削除を中断。
+    begin
+      SubscriptionCanceler.new(current_user).call
+    rescue SubscriptionCanceler::CancellationError => e
+      Rails.logger.error("[AccountDeletion] Stripe解約失敗 user_id=#{current_user.id}: #{e.message}")
+      return render json: { error: "サブスクリプションの解約に失敗しました。時間をおいて再度お試しください。" },
+                    status: :unprocessable_entity
+    end
+
+    # 削除対象は常に現在のユーザーに限定する
+    if current_user.destroy
+      # ログアウト処理も忘れずに行う
+      cookies.delete(:access_token)
+      cookies.delete(:refresh_token, path: '/')
+      render json: { message: "ユーザーアカウントが正常に削除されました" }, status: :ok
+    else
+      render json: { error: "許可されていない操作です。" }, status: :unauthorized
+    end
+  end
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `<RSPEC> spec/requests/users_spec.rb`
+Expected: PASS（5 examples 程度, 0 failures）
+
+- [ ] **Step 5: 関連 spec の回帰確認**
+
+Run: `<RSPEC> spec/services/subscription_canceler_spec.rb spec/requests/users_spec.rb`
+Expected: 全 PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add backend/app/controllers/users_controller.rb backend/spec/requests/users_spec.rb
+git commit -m "feat: アカウント削除前にStripeサブスクを即時解約し、失敗時は削除を中断
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: 全バックエンド spec の回帰確認
+
+- [ ] **Step 1: バックエンド全 spec を実行**
+
+Run: `<RSPEC> spec/`
+Expected: 全 PASS（既存 spec を含めリグレッションなし）
+
+- [ ] **Step 2: 失敗があれば修正、なければ完了**
+
+---
+
+## Self-Review チェック結果
+
+- **Spec coverage:** 解約対象 status（Task1 active/past_due/canceled ケース）、失敗時中断（Task2 422 ケース）、即時解約（`Stripe::Subscription.cancel`）、resource_missing 冪等（Task1）、destroy 失敗ケース（Task2 401）、フロント変更なし（このプランにフロントタスクなし）、保持設計不変更（subscriptions/payments を触るタスクなし）— 全て対応タスクあり。
+- **Placeholder scan:** TBD/TODO なし。全テスト・実装コードを記載済み。
+- **Type consistency:** `SubscriptionCanceler.new(user).call` / `SubscriptionCanceler::CancellationError` を Task1 定義・Task2 使用で一致。`Stripe::Subscription.cancel(id)`、status は `Subscription::ACTIVE_STATUSES` で一貫。

--- a/docs/superpowers/specs/2026-06-13-stripe-cancellation-on-account-deletion-design.md
+++ b/docs/superpowers/specs/2026-06-13-stripe-cancellation-on-account-deletion-design.md
@@ -73,7 +73,7 @@ DELETE /users/:id  (UsersController#destroy)
 
 `backend/app/services/subscription_canceler.rb`
 
-- 責務: 渡された User の active な Stripe サブスクを全て即時解約する。**DBには触れない**。
+- 責務: 渡された User の active な Stripe サブスクを全て即時解約する。**DB更新はしない**（`Subscription` を query するが、行の更新・削除は行わない）。
 - 依存: `Stripe::Subscription`, `Subscription::ACTIVE_STATUSES`
 - インターフェース: `SubscriptionCanceler.new(user).call` → 成功時は正常 return、失敗時は `CancellationError` を raise
 
@@ -182,6 +182,8 @@ Stripe のスタブは既存の `spec/requests/billing_portal_spec.rb` の作法
 
 - active サブスクあり + 解約成功 → user が削除される・200・Cookie 削除
 - 解約失敗（`CancellationError`） → **user は DB に残る**・422・エラーJSON・`current_user.destroy` 未到達
+- 解約成功 + `current_user.destroy` が false → 既存の destroy false 分岐に入る・**user は残る**・Cookie は削除しない・401（[users_controller.rb:45](../../../backend/app/controllers/users_controller.rb#L45) の既存挙動を維持）
+  - 課金安全上は許容（Stripe 停止は完了済み）。再試行時は `resource_missing` で冪等にスキップされる
 - サブスクなし → user 削除・200（Stripe 未呼出）
 - 未認証 → 401（既存挙動を維持）
 

--- a/docs/superpowers/specs/2026-06-13-stripe-cancellation-on-account-deletion-design.md
+++ b/docs/superpowers/specs/2026-06-13-stripe-cancellation-on-account-deletion-design.md
@@ -1,0 +1,192 @@
+# 設計: アカウント削除前のStripeサブスク即時解約
+
+- 日付: 2026-06-13
+- ブランチ（予定）: `feat/cancel-stripe-subscription-on-account-deletion`
+- 関連: PR #353（アカウント削除フローのフロントエンド安全性改善・マージ済み）
+
+## 背景 / 解決する問題
+
+本番実機検証で確認した最優先の安全性課題:
+
+> `User#destroy` 時に Stripe 解約処理が一切ない（`before_destroy` コールバックなし）。
+> 課金中ユーザーがアカウント削除すると、Stripe 側のサブスクは生き続けてカードへの請求が継続する。
+
+現状の `UsersController#destroy` は `current_user.destroy` を呼ぶだけ。
+`User has_many :subscriptions, dependent: :destroy` によって**ローカルDBの subscription 行は消える**が、
+**Stripe 側のサブスクリプションは解約されない**ため、アプリ上はアカウントが存在しないのに課金だけが続く「幽霊サブスク」が発生しうる。
+
+このPRは「**退会する前に、課金の蛇口を必ず閉める**」守りの強化である。
+
+## スコープ
+
+### このPRでやること（バックエンドのみ）
+
+- `User#destroy` の前に、Stripe 側の active なサブスクを**即時解約**するサービスクラスを追加
+- 解約に失敗したらアカウント削除を**中断**し、422 を返す
+- service spec / request spec を追加
+
+### このPRでやらないこと（別PR）
+
+- `subscriptions` / `payments` の保持・匿名化設計の変更
+- `DELETE /users/:id` → `DELETE /account` リファクタ（`set_user` / `params[:id]` の撤去）
+- フロントエンドの変更（**不要** — 後述）
+
+> **保持設計に関する明記:**
+> このPRでは local subscriptions / payments の保持設計は変更しない。
+> `User.destroy` によって local subscription 行が削除される可能性があるため、削除後の webhook 更新には依存しない。
+> このPRの責務は、`User.destroy` 前に Stripe 側の課金を即時停止することに限定する。
+
+## 設計判断（確定事項）
+
+| 論点 | 決定 |
+|---|---|
+| 配置 | **サービスクラス** `SubscriptionCanceler`（モデルにもコントローラにも Stripe ロジックを置かない） |
+| 解約失敗時 | **アカウント削除を中断**（422 を返す。`current_user.destroy` に到達させない） |
+| 解約タイミング | **即時解約**（`Stripe::Subscription.cancel`。日割り返金なし） |
+| 解約対象 status | 既存の `Subscription::ACTIVE_STATUSES`（`active`, `past_due`） |
+| 冪等性 | `resource_missing`（対象が既に存在しない）のみ成功扱い。その他の `InvalidRequestError` は失敗扱い |
+
+### 配置をサービスクラスにする理由
+
+既存コードは副作用をサービス層（`AuthService` / `PaymentsObservability` など）に寄せる規約がある。
+Stripe 呼び出しという「失敗しうるネットワーク処理」をモデル（`before_destroy`）やコントローラ直書きから隔離することで、
+モデルを薄く保ち、単体テストを容易にする。
+
+```
+DELETE /users/:id  (UsersController#destroy)
+        │
+        ├─ 1. SubscriptionCanceler.new(current_user).call
+        │      └─ active/past_due のサブスクを Stripe::Subscription.cancel で即時解約
+        │           ├─ 成功 / resource_missing → OK（冪等）
+        │           └─ その他 Stripe エラー → CancellationError を raise
+        │
+        ├─ 2a. 解約成功 → current_user.destroy（dependent: :destroy でローカルDBも削除）→ 200
+        └─ 2b. 解約失敗 → destroy せず 422 + エラーJSON
+```
+
+**順序が肝**: 解約（ネットワーク）が先、`destroy`（DB）が後。
+解約が失敗したら `destroy` に到達しないため、「削除したのに課金が残る」が構造的に起きない。
+
+## コンポーネント
+
+### `SubscriptionCanceler`（新規）
+
+`backend/app/services/subscription_canceler.rb`
+
+- 責務: 渡された User の active な Stripe サブスクを全て即時解約する。**DBには触れない**。
+- 依存: `Stripe::Subscription`, `Subscription::ACTIVE_STATUSES`
+- インターフェース: `SubscriptionCanceler.new(user).call` → 成功時は正常 return、失敗時は `CancellationError` を raise
+
+```ruby
+class SubscriptionCanceler
+  class CancellationError < StandardError; end
+
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    @user.subscriptions.where(status: Subscription::ACTIVE_STATUSES).find_each do |sub|
+      cancel_one(sub)
+    end
+  end
+
+  private
+
+  def cancel_one(sub)
+    Stripe::Subscription.cancel(sub.stripe_subscription_id)
+  rescue Stripe::InvalidRequestError => e
+    # 「対象が既に存在しない」= 課金停止済みとみなして冪等に成功扱い。
+    # それ以外（IDが不正・想定外のリクエストエラー等）は失敗扱い。
+    if e.respond_to?(:code) && e.code == "resource_missing"
+      Rails.logger.info("[AccountDeletion] 解約スキップ（既に不在）sub=#{sub.stripe_subscription_id}: #{e.message}")
+      return
+    end
+    raise CancellationError, e.message
+  rescue Stripe::StripeError => e
+    # ネットワーク障害・認証エラー・レート制限など → 中断
+    raise CancellationError, e.message
+  end
+end
+```
+
+> 冪等性の方針: `InvalidRequestError` は原則 `CancellationError` として扱う。
+> ただし Stripe 側で subscription が既に存在しないことを示す `resource_missing` のケースのみ、課金停止済みとみなして成功扱いする。
+> （「もう退会済みです」はOK、「会員番号が変です」はNG）
+
+### `UsersController#destroy`（修正）
+
+`backend/app/controllers/users_controller.rb`
+
+```ruby
+def destroy
+  begin
+    SubscriptionCanceler.new(current_user).call
+  rescue SubscriptionCanceler::CancellationError => e
+    Rails.logger.error("[AccountDeletion] Stripe解約失敗 user_id=#{current_user.id}: #{e.message}")
+    return render json: { error: "サブスクリプションの解約に失敗しました。時間をおいて再度お試しください。" },
+                  status: :unprocessable_entity
+  end
+
+  if current_user.destroy
+    cookies.delete(:access_token)
+    cookies.delete(:refresh_token, path: '/')
+    render json: { message: "ユーザーアカウントが正常に削除されました" }, status: :ok
+  else
+    render json: { error: "許可されていない操作です。" }, status: :unauthorized
+  end
+end
+```
+
+`set_user` / `params[:id]` は今回は触らない（別PR）。
+
+## エラーハンドリングと再試行
+
+`SubscriptionCanceler` は active なサブスクを順に解約する。途中で1件失敗すると `CancellationError` を raise し、
+コントローラが 422 を返してアカウント削除を中断する。
+
+- 例: sub A 解約成功 → sub B でネットワーク失敗 → 422 で中断
+- ユーザーが再試行 → sub A は `resource_missing` で冪等にスキップ → sub B を再解約 → 全成功 → `destroy`
+
+これにより「部分的に解約された状態」からも安全に再試行できる。
+
+## フロントエンドとの接続（変更なし）
+
+PR #353 で以下が実装済みのため、**このPRはバックエンドのみ**で完結する:
+
+- `deleteUser()` は API 失敗時に例外を再 throw する
+- `handleDelete` は catch して「さくじょに しっぱいしました。しばらくしてから もういちど ためしてね。」をモーダル内に表示する
+
+422 → `apiClient.delete` が reject → `deleteUser` 再throw → `handleDelete` catch → 既存のエラー表示。
+PR #353 の投資がそのまま効く。
+
+## テスト戦略
+
+Stripe のスタブは既存の `spec/requests/billing_portal_spec.rb` の作法に合わせる:
+- 成功: `expect(Stripe::Subscription).to receive(:cancel).with(stripe_subscription_id).and_return(...)`
+- 失敗: `allow(Stripe::Subscription).to receive(:cancel).and_raise(Stripe::StripeError.new('...'))`
+- ヘルパー: `authenticated_post` 相当の認証付きリクエスト（`type: :request`）、factory `:user` / `:subscription`、共有例 `'unauthorized request'`
+
+### service spec — `spec/services/subscription_canceler_spec.rb`
+
+- active なサブスク → 正しい `stripe_subscription_id` で `Stripe::Subscription.cancel` を呼ぶ
+- past_due なサブスク → 解約する
+- canceled なサブスク → Stripe を呼ばない（スキップ）
+- 複数 active サブスク → 全件解約する
+- `Stripe::InvalidRequestError(code: "resource_missing")` → 成功扱い（raise しない）
+- `Stripe::InvalidRequestError`（resource_missing 以外） → `CancellationError` を raise
+- `Stripe::APIConnectionError`（StripeError サブクラス） → `CancellationError` を raise
+- サブスクなし → no-op で正常 return（Stripe を呼ばない）
+
+### request spec — `spec/requests/users_spec.rb`（destroy）
+
+- active サブスクあり + 解約成功 → user が削除される・200・Cookie 削除
+- 解約失敗（`CancellationError`） → **user は DB に残る**・422・エラーJSON・`current_user.destroy` 未到達
+- サブスクなし → user 削除・200（Stripe 未呼出）
+- 未認証 → 401（既存挙動を維持）
+
+## 実装順序（TDD）
+
+1. service spec を書く（RED）→ `SubscriptionCanceler` 実装（GREEN）
+2. request spec を書く（RED）→ `UsersController#destroy` 修正（GREEN）
+3. 全 spec green を確認


### PR DESCRIPTION
## 概要

アカウント削除時にStripe側のサブスクリプションが残り、退会後も請求が継続するリスクを防ぐため、User.destroy の前に active/past_due の Stripe subscription を即時解約する処理を追加しました。

設計ドキュメントと実装プランも同じPRに含めています。

## 変更内容

- SubscriptionCanceler を追加
- Subscription::ACTIVE_STATUSES のサブスクを Stripe::Subscription.cancel で即時解約
- resource_missing は既に解約済み/不在として冪等成功扱い
- その他の Stripe エラー時は CancellationError を raise
- UsersController#destroy で destroy 前に SubscriptionCanceler を呼び出し
- 解約失敗時は user を削除せず 422 を返す
- service spec / request spec を追加

## テスト

- docker compose ... bundle exec rspec spec/services/subscription_canceler_spec.rb spec/requests/users_spec.rb
  - 13 examples, 0 failures

- docker compose ... bundle exec rspec spec/
  - 272 examples, 0 failures

## スコープ外

- subscriptions / payments の保持・匿名化設計
- DELETE /users/:id → DELETE /account 化
- フロントエンド変更
- 既存 spec の :unprocessable_entity deprecation warning 修正