### PR TITLE
feat: 森の雰囲気強化・空状態改善・ホームプレビューウィジェット

### DIFF
--- a/frontend/app/components/DreamForm.tsx
+++ b/frontend/app/components/DreamForm.tsx
@@ -25,12 +25,14 @@ interface DreamFormData {
 
 interface DreamFormProps {
   initialData?: Dream;
+  defaultProfileId?: number;
   onSubmit: (data: DreamFormData) => void;
   isLoading?: boolean;
 }
 
 export default function DreamForm({
   initialData,
+  defaultProfileId,
   onSubmit,
   isLoading = false,
 }: DreamFormProps) {
@@ -61,7 +63,7 @@ export default function DreamForm({
   const [analysisRevealKey, setAnalysisRevealKey] = useState(0);
   const [profiles, setProfiles] = useState<DreamProfile[]>([]);
   const [selectedProfileId, setSelectedProfileId] = useState<number | undefined>(
-    initialData?.dream_profile_id
+    defaultProfileId ?? initialData?.dream_profile_id
   );
   const [morpheusRating, setMorpheusRating] = useState<"good" | "bad" | null>(
     null
@@ -149,8 +151,8 @@ export default function DreamForm({
         const data = await getDreamProfiles();
         const active = data.filter((p) => !p.archived);
         setProfiles(active);
-        // 新規作成時のみ self をデフォルト選択（編集時は initialData.dream_profile_id を優先）
-        if (!initialData) {
+        // 新規作成時のみ self をデフォルト選択（編集時 or defaultProfileId 指定時はスキップ）
+        if (!initialData && !defaultProfileId) {
           const selfProfile = active.find((p) => p.relationship === "self");
           if (selfProfile) setSelectedProfileId(selfProfile.id);
         }

--- a/frontend/app/components/forest/ForestPreviewWidget.tsx
+++ b/frontend/app/components/forest/ForestPreviewWidget.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Link from "next/link";
+import { Trees } from "lucide-react";
+import type { DreamProfile } from "@/app/types";
+import { getGrowthLevel, getCanopyScale } from "@/lib/forest";
+
+export default function ForestPreviewWidget({ profiles }: { profiles: DreamProfile[] }) {
+  const active = profiles.filter((p) => !p.archived);
+  if (active.length === 0) return null;
+
+  return (
+    <div className="bg-card border border-border rounded-xl p-4 w-full mb-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="font-bold text-card-foreground flex items-center gap-2 text-sm">
+          <Trees className="h-4 w-4 text-primary" aria-hidden="true" />
+          ゆめの もり
+        </h3>
+        <Link
+          href="/forest"
+          className="text-xs text-primary font-semibold hover:underline"
+        >
+          もりを みる →
+        </Link>
+      </div>
+      <div className="flex items-end justify-center gap-4 py-1">
+        {active.slice(0, 4).map((p) => {
+          const count = p.dreams_count ?? 0;
+          const { level } = getGrowthLevel(count);
+          const scale = getCanopyScale(level);
+          const canopySize = Math.round(44 * scale);
+          return (
+            <Link
+              key={p.id}
+              href={`/forest/${p.id}`}
+              className="flex flex-col items-center group"
+              aria-label={`${p.name}の木（夢${count}件）`}
+            >
+              <div
+                className="rounded-full flex items-center justify-center transition-transform group-hover:scale-110"
+                style={{
+                  width: canopySize,
+                  height: canopySize,
+                  background: `radial-gradient(circle at 40% 35%, ${p.color}cc, ${p.color}55 70%, transparent)`,
+                  boxShadow: `0 0 14px ${p.color}44`,
+                }}
+              >
+                <span className="text-sm" aria-hidden="true">{p.avatar_emoji}</span>
+              </div>
+              <div
+                className="bg-[#6b4a2b]"
+                style={{ width: 4, height: Math.round(10 + level * 2), borderRadius: "0 0 2px 2px" }}
+              />
+              <span className="text-[10px] text-muted-foreground mt-0.5 max-w-[48px] truncate text-center block">
+                {p.name}
+              </span>
+            </Link>
+          );
+        })}
+        {active.length > 4 && (
+          <span className="text-xs text-muted-foreground self-center">
+            +{active.length - 4}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/forest/ForestScene.tsx
+++ b/frontend/app/components/forest/ForestScene.tsx
@@ -1,16 +1,34 @@
 "use client";
 
 import { motion, useReducedMotion } from "framer-motion";
+import Link from "next/link";
 import type { DreamProfile } from "@/app/types";
 import MiniTree from "./MiniTree";
 
-/** 星をランダムだが固定の位置でちりばめる（再描画で動かないよう定数化） */
 const STARS = Array.from({ length: 40 }, (_, i) => ({
   left: (i * 53) % 100,
   top: (i * 37) % 70,
   delay: (i % 7) * 0.4,
   size: (i % 3) + 1,
 }));
+
+const FIREFLIES = Array.from({ length: 8 }, (_, i) => ({
+  left: (i * 13 + 8) % 85 + 7,
+  top: 55 + (i * 7) % 28,
+  delay: (i * 0.7) % 2.8,
+  dx: ((i % 3) - 1) * 18,
+  dy: -(8 + (i % 5) * 4),
+}));
+
+const GROUND_DECO = [
+  { left: 4, emoji: "🍄" },
+  { left: 16, emoji: "🌿" },
+  { left: 29, emoji: "🌸" },
+  { left: 57, emoji: "🌿" },
+  { left: 70, emoji: "🍄" },
+  { left: 82, emoji: "🌱" },
+  { left: 91, emoji: "🌿" },
+];
 
 export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) {
   const reduceMotion = useReducedMotion();
@@ -25,19 +43,81 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
           style={{ left: `${s.left}%`, top: `${s.top}%`, width: s.size, height: s.size }}
           animate={reduceMotion ? undefined : { opacity: [0.2, 1, 0.2] }}
           transition={{ duration: 3, repeat: Infinity, delay: s.delay }}
+          aria-hidden="true"
         />
       ))}
+
       {/* 月 */}
-      <div className="absolute right-8 top-8 h-16 w-16 rounded-full bg-[#fef3c7] shadow-[0_0_50px_20px_rgba(254,243,199,0.35)]" />
+      <div
+        className="absolute right-8 top-8 h-16 w-16 rounded-full bg-[#fef3c7] shadow-[0_0_50px_20px_rgba(254,243,199,0.35)]"
+        aria-hidden="true"
+      />
+
+      {/* ほたる（reduced-motion 時は静止した光点として表示） */}
+      {FIREFLIES.map((f, i) => (
+        <motion.span
+          key={i}
+          className="absolute h-1.5 w-1.5 rounded-full bg-amber-200"
+          style={{ left: `${f.left}%`, top: `${f.top}%`, opacity: 0.5 }}
+          animate={
+            reduceMotion
+              ? undefined
+              : { x: [0, f.dx, 0], y: [0, f.dy, 0], opacity: [0.15, 0.9, 0.15] }
+          }
+          transition={{ duration: 2.5 + f.delay, repeat: Infinity, ease: "easeInOut", delay: f.delay }}
+          aria-hidden="true"
+        />
+      ))}
 
       {/* 地面 */}
-      <div className="absolute bottom-0 h-28 w-full bg-gradient-to-t from-[#2a2150] to-transparent" />
+      <div
+        className="absolute bottom-0 h-28 w-full bg-gradient-to-t from-[#2a2150] to-transparent"
+        aria-hidden="true"
+      />
 
-      {/* 木を並べる */}
-      <div className="relative z-10 flex flex-wrap items-end justify-center gap-6 px-6 pb-16 pt-24">
-        {profiles.map((p) => (
-          <MiniTree key={p.id} profile={p} />
+      {/* 霧 */}
+      <div
+        className="pointer-events-none absolute bottom-0 h-20 w-full"
+        style={{ background: "linear-gradient(to top, rgba(70,45,150,0.40), rgba(50,30,110,0.12) 55%, transparent)" }}
+        aria-hidden="true"
+      />
+
+      {/* 地面の草花 */}
+      <div className="absolute bottom-5 left-0 right-0 z-[5]" aria-hidden="true">
+        {GROUND_DECO.map((d, i) => (
+          <span key={i} className="absolute text-xs" style={{ left: `${d.left}%`, bottom: 0 }}>
+            {d.emoji}
+          </span>
         ))}
+      </div>
+
+      {/* 木を並べる / プロフィール0件の空状態 */}
+      <div className="relative z-10 flex flex-wrap items-end justify-center gap-6 px-6 pb-16 pt-24">
+        {profiles.length === 0 ? (
+          <div className="flex flex-col items-center gap-4 py-10 text-center">
+            <motion.span
+              className="text-5xl"
+              animate={reduceMotion ? undefined : { y: [-4, 4, -4], scale: [1, 1.05, 1] }}
+              transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
+              aria-hidden="true"
+            >
+              🌱
+            </motion.span>
+            <p className="text-base font-bold text-white/90">まだ きが ないよ</p>
+            <p className="text-sm leading-relaxed text-white/60">
+              プロフィールを つくると、<br />
+              ゆめの きが ここに そだつよ。
+            </p>
+            <Link
+              href="/profiles"
+              className="mt-2 rounded-full bg-primary px-5 py-2 text-sm font-bold text-primary-foreground shadow-lg shadow-primary/20"
+            >
+              プロフィールを つくる
+            </Link>
+          </div>
+        ) : (
+          profiles.map((p) => <MiniTree key={p.id} profile={p} />)
+        )}
       </div>
     </div>
   );

--- a/frontend/app/components/forest/MiniTree.tsx
+++ b/frontend/app/components/forest/MiniTree.tsx
@@ -28,7 +28,7 @@ export default function MiniTree({ profile }: { profile: DreamProfile }) {
           width: 96 * scale,
           height: 96 * scale,
           background: `radial-gradient(circle at 40% 35%, ${profile.color}cc, ${profile.color}55 70%, transparent)`,
-          boxShadow: `0 0 28px ${profile.color}55`,
+          boxShadow: `0 0 32px ${profile.color}66, 0 0 12px ${profile.color}33`,
         }}
         animate={reduceMotion ? undefined : { scale: [1, 1.04, 1] }}
         transition={{ duration: 5, repeat: Infinity, ease: "easeInOut" }}
@@ -44,6 +44,17 @@ export default function MiniTree({ profile }: { profile: DreamProfile }) {
       <div
         className="w-2.5 rounded-b-sm bg-[#6b4a2b]"
         style={{ height: 18 + level * 4 }}
+      />
+      {/* 根元の光輪 */}
+      <div
+        className="rounded-full"
+        style={{
+          width: Math.round(40 * scale),
+          height: 5,
+          background: `radial-gradient(ellipse, ${profile.color}55, transparent 70%)`,
+          marginBottom: 3,
+        }}
+        aria-hidden="true"
       />
       {/* 名前と件数 */}
       <span className="mt-1 text-xs font-semibold text-foreground/90">

--- a/frontend/app/dream/new/page.tsx
+++ b/frontend/app/dream/new/page.tsx
@@ -3,7 +3,7 @@
 import DreamForm from "../../components/DreamForm";
 import MorpheusSmall from "../../components/MorpheusSmall";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import React, { useLayoutEffect, useState } from "react";
 import { useAuth } from "../../../context/AuthContext";
 import Loading from "../../loading";
@@ -48,7 +48,11 @@ function getNewDreamCopy(ageGroup: AgeGroup | undefined) {
 
 export default function NewDreamPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { authStatus, user } = useAuth();
+  const preselectedProfileId = searchParams.get("dream_profile_id")
+    ? Number(searchParams.get("dream_profile_id"))
+    : undefined;
   const [isSaving, setIsSaving] = useState(false);
   const [hasDraft, setHasDraft] = useState(false);
   const [isDraftChecked, setIsDraftChecked] = useState(false);
@@ -143,7 +147,11 @@ export default function NewDreamPage() {
         </div>
       ) : null}
 
-      <DreamForm onSubmit={handleCreateSubmit} isLoading={isSaving} />
+      <DreamForm
+        onSubmit={handleCreateSubmit}
+        isLoading={isSaving}
+        initialData={preselectedProfileId ? { dream_profile_id: preselectedProfileId } : undefined}
+      />
 
       <HarvestCelebration
         open={showHarvest}

--- a/frontend/app/dream/new/page.tsx
+++ b/frontend/app/dream/new/page.tsx
@@ -150,7 +150,7 @@ export default function NewDreamPage() {
       <DreamForm
         onSubmit={handleCreateSubmit}
         isLoading={isSaving}
-        initialData={preselectedProfileId ? { dream_profile_id: preselectedProfileId } : undefined}
+        defaultProfileId={preselectedProfileId}
       />
 
       <HarvestCelebration

--- a/frontend/app/forest/[profileId]/page.tsx
+++ b/frontend/app/forest/[profileId]/page.tsx
@@ -91,7 +91,7 @@ export default function ForestProfilePage() {
               ゆめを かいて、さいしょの みを ならせよう。
             </p>
             <Link
-              href="/dream/new"
+              href={`/dream/new?dream_profile_id=${profile.id}`}
               className="mt-2 rounded-full bg-primary px-5 py-2 text-sm font-bold text-primary-foreground shadow-lg shadow-primary/20"
             >
               ゆめを かく

--- a/frontend/app/forest/[profileId]/page.tsx
+++ b/frontend/app/forest/[profileId]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { ChevronLeft } from "lucide-react";
+import { motion, useReducedMotion } from "framer-motion";
 import { useAuth } from "@/context/AuthContext";
 import Loading from "@/app/loading";
 import { getDreamProfiles, getDreamsForProfile } from "@/lib/apiClient";
@@ -20,6 +21,7 @@ export default function ForestProfilePage() {
   const params = useParams();
   const profileId = Number(params.profileId);
 
+  const reduceMotion = useReducedMotion();
   const [profile, setProfile] = useState<DreamProfile | null>(null);
   const [dreams, setDreams] = useState<Dream[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -75,9 +77,26 @@ export default function ForestProfilePage() {
 
       <main className="container mx-auto max-w-3xl px-4 pt-10">
         {dreams.length === 0 ? (
-          <p className="mt-20 text-center text-white/70">
-            まだ ゆめが ないよ。ゆめを かいて きを そだてよう。
-          </p>
+          <div className="mt-16 flex flex-col items-center gap-4 text-center">
+            <motion.span
+              className="text-6xl"
+              animate={reduceMotion ? undefined : { y: [-4, 4, -4], scale: [1, 1.04, 1] }}
+              transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
+              aria-hidden="true"
+            >
+              🌱
+            </motion.span>
+            <p className="text-lg font-bold text-white/90">まだ みが ないね</p>
+            <p className="text-sm leading-relaxed text-white/60">
+              ゆめを かいて、さいしょの みを ならせよう。
+            </p>
+            <Link
+              href="/dream/new"
+              className="mt-2 rounded-full bg-primary px-5 py-2 text-sm font-bold text-primary-foreground shadow-lg shadow-primary/20"
+            >
+              ゆめを かく
+            </Link>
+          </div>
         ) : (
           <DreamTree profile={profile} dreams={dreams} />
         )}

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -16,6 +16,7 @@ import SearchBar from "@/app/components/SearchBar";
 import ProfileFilterChips from "@/app/components/ProfileFilterChips";
 import DreamEntryLauncher from "@/app/components/DreamEntryLauncher";
 import DreamAdventurePanel from "@/app/components/DreamAdventurePanel";
+import ForestPreviewWidget from "@/app/components/forest/ForestPreviewWidget";
 import { MorpheusGuideHome } from "@/app/components/MorpheusGuide";
 import MorpheusHero from "@/app/components/MorpheusHero";
 import MorpheusLoginRequired from "@/app/components/MorpheusLoginRequired";
@@ -380,6 +381,9 @@ export default function HomePage() {
       <aside className="w-full lg:w-1/3 flex flex-col items-center px-3 md:px-6 mt-4 lg:mt-0">
         {/* 今日の夢クエスト */}
         {!loading && !errorMessage && <DreamAdventurePanel dreams={dreams} />}
+
+        {/* もりプレビュー */}
+        {!loading && profiles.length > 0 && <ForestPreviewWidget profiles={profiles} />}
 
         {/* 連続記録バッジ */}
         <DreamStreakBadge dreams={dreams} />

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -205,10 +205,13 @@ export default function HomePage() {
       });
   }, [authStatus, user?.premium]);
 
-  // dream-createdイベントをリッスン（夢が新規作成されたときにリストを更新）
+  // dream-createdイベントをリッスン（夢が新規作成されたときにリストとプロフィールの dreams_count を更新）
   useEffect(() => {
     const handleDreamCreated = () => {
       fetchDreams();
+      getDreamProfiles()
+        .then(setProfiles)
+        .catch(() => {});
     };
 
     window.addEventListener("dream-created", handleDreamCreated);


### PR DESCRIPTION
## Summary

- **ForestScene 雰囲気強化**: ほたる8体（framer-motion、reduced-motion 対応）・霧グラデーション・地面草花（🍄🌿🌸🌱）を追加。「星と月だけの宇宙っぽい空間」から「生きている森」へ
- **木のグロー強化**: MiniTree の boxShadow を二重化（外輪32px + 内輪12px）、根元に光輪を追加
- **空状態改善 (profiles = 0)**: 黒箱ではなく 🌱 + 「プロフィールをつくる」CTA を夜空シーン内に表示
- **空状態改善 (dreams = 0)**: `/forest/[profileId]` の夢0件時をプレーンテキストから 🌱 アニメ + 「ゆめをかく」CTA に変更
- **ForestPreviewWidget**: ホームのサイドバーに小さな森プレビューを追加。プロフィール別の木をクリックで個別ページへ遷移し、「夢を書く→木が育つ」の因果をホームから見せる

## Changed files

| ファイル | 変更内容 |
|---|---|
| `ForestScene.tsx` | ほたる・霧・草花・プロフィール0件空状態 |
| `MiniTree.tsx` | グロー強化・根元光輪 |
| `forest/[profileId]/page.tsx` | 夢0件空状態（motion + CTA） |
| `ForestPreviewWidget.tsx` | 新規：ホーム用もりプレビュー |
| `home/page.tsx` | ForestPreviewWidget を sidebar に追加 |

## Test plan

- [ ] `/forest` で森シーンにほたる・霧・草花が表示されること
- [ ] `profiles.length === 0` のとき 🌱 + 「プロフィールをつくる」ボタンが表示されること
- [ ] `/forest/[profileId]` で夢0件のとき 🌱 アニメ + 「ゆめをかく」ボタンが表示されること
- [ ] `/home` のサイドバーに「ゆめのもり」プレビューが表示され、木をクリックで `/forest/[id]` へ遷移すること
- [ ] `prefers-reduced-motion: reduce` 環境でほたる・🌱 がアニメなしで表示されること（静止表示）
- [ ] TypeScript エラーなし（既存テストファイルの型エラーは pre-existing のためスコープ外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)