### PR TITLE
feat: 夢の森に季節・時刻演出を追加（Cグループ）

### DIFF
--- a/docs/superpowers/specs/2026-06-13-forest-seasonal-effects-design.md
+++ b/docs/superpowers/specs/2026-06-13-forest-seasonal-effects-design.md
@@ -1,0 +1,94 @@
+# 夢の森 季節・時刻演出（Cグループ）設計
+
+作成日: 2026-06-13
+ブランチ: `feat/forest-seasonal-effects`
+
+## 目的
+
+夢の森（`/forest` と `/forest/[profileId]`）を、時刻と季節に応じて変化させ「世界が生きている」感を強める。前提として、A+B（PR #356）で霧・ほたる・草花・空状態は実装済み。
+
+## スコープ（ユーザー承認済み）
+
+含む:
+1. **昼夜で空が変わる** — 方向B「ずっと幻想的」: 常に暗めの夢トーンを保ち、時刻で色相だけ寄せる
+2. **季節パーティクル** — 桜（春）/ 新緑（夏・控えめ）/ 紅葉（秋）/ 雪（冬）が舞い落ちる
+3. **月／星が時刻で動く** — 月の位置・星の濃さを時刻で変える
+
+含まない（今回見送り）:
+- 舞う葉（個別ツリー専用の追加演出）— 季節パーティクルで代替されるため不要
+- リアルな昼夜（明るい青空＋太陽）— 方向Aは却下。夢の世界観を優先
+
+## 設計方針
+
+ロジックは純粋関数に切り出し、単体テストする（既存 `lib/forest.ts` / `__tests__/lib/forest.test.ts` と同じ作法）。見た目は森シーンと単独ツリーページの両方に適用し、世界観を統一する。
+
+### 1. 新規ロジック `frontend/lib/forestAtmosphere.ts`（純粋関数）
+
+```
+type TimePhase = "dawn" | "day" | "dusk" | "night";
+type Season = "spring" | "summer" | "autumn" | "winter";
+
+getTimePhase(date: Date): TimePhase
+  // hour: 5-9 dawn / 10-15 day / 16-18 dusk / それ以外 night
+
+getSkyGradient(phase: TimePhase): string
+  // 方向Bパレットの CSS linear-gradient 文字列を返す
+  // dawn=薄紫 / day=青緑 / dusk=赤紫 / night=紺（現状の #241a40→#1a1336→#0e0a1c）
+
+getSeason(date: Date): Season
+  // month: 3-5 spring / 6-8 summer / 9-11 autumn / 12,1,2 winter（北半球・日本）
+
+getCelestial(phase: TimePhase): { moonXPct: number; moonYPct: number; starOpacity: number }
+  // 月の位置（夜に空を弧で移動）・星の濃さ。読込時の静的値なので reduced-motion でも安全
+```
+
+すべて入力 `Date` → 出力が決定論的な純粋関数。`new Date()` は呼び出し側で生成して渡す（テスト容易性）。
+
+### 2. 新規コンポーネント `frontend/app/components/forest/SeasonalParticles.tsx`
+
+- props: `{ season: Season }`
+- 季節の絵文字（🌸 / 🍃 / 🍁 / ❄️）を 14〜16 個、決定論的な位置・速度で上から下へゆっくり落とす
+- 夏は既存のほたるが主役なので新緑は控えめ（個数を半分程度）
+- `useReducedMotion()` が true のとき: **落下アニメを止め、静止した装飾を数個だけ表示**
+- `aria-hidden="true"`（装飾要素）
+
+### 3. 既存への接続
+
+`frontend/app/components/forest/ForestScene.tsx`:
+- ハードコードの空グラデを `getSkyGradient(getTimePhase(now))` に置換（`now` はコンポーネント内で `useMemo` 生成）
+- 月の位置を `getCelestial(phase)` の値に
+- 星の `opacity` ベースに `starOpacity` を反映
+- `<SeasonalParticles season={getSeason(now)} />` を追加
+
+`frontend/app/forest/[profileId]/page.tsx`:
+- ページ背景の固定紺グラデを同じ `getSkyGradient` に統一
+- 同じく `<SeasonalParticles>` を追加
+
+### 4. テスト `frontend/__tests__/lib/forestAtmosphere.test.ts`
+
+- `getTimePhase`: 各時間帯の境界値（4,5,9,10,15,16,18,19 時など）
+- `getSeason`: 各季節の境界月（2,3,5,6,8,9,11,12 月）
+- `getSkyGradient`: 4 phase すべてで非空文字列を返し、互いに異なること
+- `getCelestial`: 同じ phase なら同じ値（決定論）、night で星が濃いこと
+
+## reduced-motion の扱い
+
+| 要素 | 通常 | reduced-motion |
+|---|---|---|
+| 空の色（時間帯） | 適用 | 適用（色変化は motion でない） |
+| 月／星の位置 | 適用 | 適用（読込時の静的値） |
+| 星の瞬き | アニメ | 停止（既存通り） |
+| 季節パーティクル落下 | アニメ | 停止・静止表示 |
+
+## パフォーマンス
+
+- パーティクルは 14〜16 個に制限
+- 位置・遅延は決定論的（seeded）にして再描画でのレイアウトスラッシュを防ぐ
+- `now` は `useMemo` で1回だけ生成（再レンダーで時刻が動かないように）
+
+## 非対象（YAGNI）
+
+- 分単位のなめらかな時刻補間（時間帯の4段階で十分）
+- 天気（雨など）
+- ユーザーが時刻・季節を手動切り替えするUI
+- DesignSync 連携（CLIトークンの制約により別途 /login が必要。今回は実装優先）

--- a/frontend/__tests__/lib/forestAtmosphere.test.ts
+++ b/frontend/__tests__/lib/forestAtmosphere.test.ts
@@ -1,0 +1,82 @@
+import {
+  getTimePhase,
+  getSeason,
+  getSkyGradient,
+  getCelestial,
+  type TimePhase,
+} from "../../lib/forestAtmosphere";
+
+// 指定した「時」のDateを作る（年月日は固定）
+const at = (hour: number) => new Date(2026, 5, 13, hour, 0, 0);
+// 指定した「月(1-12)」のDateを作る
+const inMonth = (month: number) => new Date(2026, month - 1, 15, 12, 0, 0);
+
+describe("getTimePhase", () => {
+  it.each<[number, TimePhase]>([
+    [4, "night"],
+    [5, "dawn"],
+    [9, "dawn"],
+    [10, "day"],
+    [15, "day"],
+    [16, "dusk"],
+    [18, "dusk"],
+    [19, "night"],
+    [23, "night"],
+    [0, "night"],
+  ])("%i時 → %s", (hour, phase) => {
+    expect(getTimePhase(at(hour))).toBe(phase);
+  });
+});
+
+describe("getSeason", () => {
+  it.each<[number, string]>([
+    [2, "winter"],
+    [3, "spring"],
+    [5, "spring"],
+    [6, "summer"],
+    [8, "summer"],
+    [9, "autumn"],
+    [11, "autumn"],
+    [12, "winter"],
+    [1, "winter"],
+  ])("%i月 → %s", (month, season) => {
+    expect(getSeason(inMonth(month))).toBe(season);
+  });
+});
+
+describe("getSkyGradient", () => {
+  const phases: TimePhase[] = ["dawn", "day", "dusk", "night"];
+
+  it("各phaseで非空文字列を返す", () => {
+    phases.forEach((p) => {
+      expect(getSkyGradient(p)).toMatch(/gradient/);
+    });
+  });
+
+  it("4つのphaseはすべて異なる", () => {
+    const grads = phases.map(getSkyGradient);
+    expect(new Set(grads).size).toBe(4);
+  });
+});
+
+describe("getCelestial", () => {
+  it("同じphaseなら同じ値を返す（決定論）", () => {
+    expect(getCelestial("night")).toEqual(getCelestial("night"));
+  });
+
+  it("夜は昼より星が濃い", () => {
+    expect(getCelestial("night").starOpacity).toBeGreaterThan(
+      getCelestial("day").starOpacity
+    );
+  });
+
+  it("月の位置は0〜100%の範囲内", () => {
+    (["dawn", "day", "dusk", "night"] as TimePhase[]).forEach((p) => {
+      const c = getCelestial(p);
+      expect(c.moonXPct).toBeGreaterThanOrEqual(0);
+      expect(c.moonXPct).toBeLessThanOrEqual(100);
+      expect(c.moonYPct).toBeGreaterThanOrEqual(0);
+      expect(c.moonYPct).toBeLessThanOrEqual(100);
+    });
+  });
+});

--- a/frontend/app/components/forest/ForestScene.tsx
+++ b/frontend/app/components/forest/ForestScene.tsx
@@ -1,9 +1,17 @@
 "use client";
 
+import { useMemo } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import Link from "next/link";
 import type { DreamProfile } from "@/app/types";
+import {
+  getTimePhase,
+  getSeason,
+  getSkyGradient,
+  getCelestial,
+} from "@/lib/forestAtmosphere";
 import MiniTree from "./MiniTree";
+import SeasonalParticles from "./SeasonalParticles";
 
 const STARS = Array.from({ length: 40 }, (_, i) => ({
   left: (i * 53) % 100,
@@ -33,25 +41,49 @@ const GROUND_DECO = [
 export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) {
   const reduceMotion = useReducedMotion();
 
+  // 読込時の時刻・季節を1回だけ確定（再レンダーで動かないよう useMemo）
+  const now = useMemo(() => new Date(), []);
+  const phase = getTimePhase(now);
+  const season = getSeason(now);
+  const sky = getSkyGradient(phase);
+  const { moonXPct, moonYPct, starOpacity } = getCelestial(phase);
+
   return (
-    <div className="relative min-h-[70vh] overflow-hidden rounded-3xl bg-gradient-to-b from-[#241a40] via-[#1a1336] to-[#0e0a1c]">
-      {/* 星空 */}
+    <div
+      className="relative min-h-[70vh] overflow-hidden rounded-3xl"
+      style={{ background: sky }}
+    >
+      {/* 星空（時間帯で濃さが変わる: 夜=濃い / 昼=ほぼ見えない） */}
       {STARS.map((s, i) => (
         <motion.span
           key={i}
           className="absolute rounded-full bg-white"
-          style={{ left: `${s.left}%`, top: `${s.top}%`, width: s.size, height: s.size }}
-          animate={reduceMotion ? undefined : { opacity: [0.2, 1, 0.2] }}
+          style={{
+            left: `${s.left}%`,
+            top: `${s.top}%`,
+            width: s.size,
+            height: s.size,
+            opacity: starOpacity,
+          }}
+          animate={
+            reduceMotion
+              ? undefined
+              : { opacity: [0.2 * starOpacity, starOpacity, 0.2 * starOpacity] }
+          }
           transition={{ duration: 3, repeat: Infinity, delay: s.delay }}
           aria-hidden="true"
         />
       ))}
 
-      {/* 月 */}
+      {/* 月（位置が時間帯で変わる） */}
       <div
-        className="absolute right-8 top-8 h-16 w-16 rounded-full bg-[#fef3c7] shadow-[0_0_50px_20px_rgba(254,243,199,0.35)]"
+        className="absolute h-16 w-16 -translate-x-1/2 rounded-full bg-[#fef3c7] shadow-[0_0_50px_20px_rgba(254,243,199,0.35)]"
+        style={{ left: `${moonXPct}%`, top: `${moonYPct}%` }}
         aria-hidden="true"
       />
+
+      {/* 季節パーティクル（🌸/🍃/🍁/❄️） */}
+      <SeasonalParticles season={season} />
 
       {/* ほたる（reduced-motion 時は静止した光点として表示） */}
       {FIREFLIES.map((f, i) => (

--- a/frontend/app/components/forest/SeasonalParticles.tsx
+++ b/frontend/app/components/forest/SeasonalParticles.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useMemo } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import type { Season } from "@/lib/forestAtmosphere";
+
+const SEASON_EMOJI: Record<Season, string> = {
+  spring: "🌸",
+  summer: "🍃",
+  autumn: "🍁",
+  winter: "❄️",
+};
+
+// 夏はほたる（ForestScene側）が主役なので控えめにする。
+const SEASON_COUNT: Record<Season, number> = {
+  spring: 16,
+  summer: 7,
+  autumn: 16,
+  winter: 18,
+};
+
+/**
+ * 季節に応じて 🌸/🍃/🍁/❄️ をゆっくり舞い落とす装飾レイヤー。
+ * 位置・速度は決定論的（再描画で動かない）。reduced-motion では落下を止め静止表示。
+ *
+ * @param behind true なら本文の背面（z-[1]）に置く。テキストが多いページ（単独ツリー）向け。
+ *               既定 false は前面（z-[15]）で森シーンの木の手前に降らせる。
+ */
+export default function SeasonalParticles({
+  season,
+  behind = false,
+}: {
+  season: Season;
+  behind?: boolean;
+}) {
+  const reduceMotion = useReducedMotion();
+  const emoji = SEASON_EMOJI[season];
+  const count = SEASON_COUNT[season];
+  const layerClass = behind ? "z-[1]" : "z-[15]";
+
+  const particles = useMemo(
+    () =>
+      Array.from({ length: count }, (_, i) => ({
+        left: (i * 61 + 7) % 96,
+        size: 10 + ((i * 7) % 10), // 10〜19px
+        duration: 7 + ((i * 13) % 6), // 7〜12秒
+        delay: (i * 0.9) % 6,
+        drift: ((i % 3) - 1) * 24, // -24/0/24px の横揺れ
+        rotate: (i % 2 === 0 ? 1 : -1) * (20 + (i % 4) * 15),
+      })),
+    [count]
+  );
+
+  // reduced-motion: 落下を止め、上部に数個だけ静止表示
+  if (reduceMotion) {
+    return (
+      <div
+        className={`pointer-events-none absolute inset-0 overflow-hidden ${layerClass}`}
+        aria-hidden="true"
+      >
+        {particles.slice(0, 5).map((p, i) => (
+          <span
+            key={i}
+            className="absolute"
+            style={{
+              left: `${p.left}%`,
+              top: `${8 + i * 6}%`,
+              fontSize: p.size,
+              opacity: 0.5,
+            }}
+          >
+            {emoji}
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`pointer-events-none absolute inset-0 overflow-hidden ${layerClass}`}
+      aria-hidden="true"
+    >
+      {particles.map((p, i) => (
+        <motion.span
+          key={i}
+          className="absolute"
+          style={{ left: `${p.left}%`, fontSize: p.size }}
+          initial={{ top: "-8%", x: 0, opacity: 0 }}
+          animate={{
+            top: "108%",
+            x: [0, p.drift, 0],
+            opacity: [0, 0.85, 0.85, 0],
+            rotate: [0, p.rotate],
+          }}
+          transition={{
+            duration: p.duration,
+            delay: p.delay,
+            repeat: Infinity,
+            ease: "linear",
+          }}
+        >
+          {emoji}
+        </motion.span>
+      ))}
+    </div>
+  );
+}

--- a/frontend/app/forest/[profileId]/page.tsx
+++ b/frontend/app/forest/[profileId]/page.tsx
@@ -71,10 +71,11 @@ export default function ForestProfilePage() {
 
   return (
     <div
-      className="relative min-h-screen overflow-hidden pb-24 text-white"
+      className="relative min-h-screen pb-24 text-white"
       style={{ background: sky }}
     >
-      {/* 季節パーティクル（本文の背面に降らせて可読性を保つ） */}
+      {/* 季節パーティクル（本文の背面・自前で overflow-hidden するのでルートは clip しない。
+          ルートに overflow-hidden を付けると sticky ヘッダーが流れて消えるため外している） */}
       <SeasonalParticles season={season} behind />
 
       <header className="sticky top-0 z-10 bg-black/20 backdrop-blur-md">

--- a/frontend/app/forest/[profileId]/page.tsx
+++ b/frontend/app/forest/[profileId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { ChevronLeft } from "lucide-react";
@@ -10,10 +10,12 @@ import Loading from "@/app/loading";
 import { getDreamProfiles, getDreamsForProfile } from "@/lib/apiClient";
 import type { Dream, DreamProfile } from "@/app/types";
 import { RECENT_FRUIT_COUNT } from "@/lib/forest";
+import { getTimePhase, getSeason, getSkyGradient } from "@/lib/forestAtmosphere";
 import { toast } from "@/lib/toast";
 import DreamTree from "@/app/components/forest/DreamTree";
 import PastDreamsList from "@/app/components/forest/PastDreamsList";
 import ForestGuide from "@/app/components/forest/ForestGuide";
+import SeasonalParticles from "@/app/components/forest/SeasonalParticles";
 
 export default function ForestProfilePage() {
   const { authStatus } = useAuth();
@@ -25,6 +27,11 @@ export default function ForestProfilePage() {
   const [profile, setProfile] = useState<DreamProfile | null>(null);
   const [dreams, setDreams] = useState<Dream[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+
+  // 読込時の時刻・季節を1回だけ確定（森シーンと同じ雰囲気に揃える）
+  const now = useMemo(() => new Date(), []);
+  const sky = getSkyGradient(getTimePhase(now));
+  const season = getSeason(now);
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -63,7 +70,13 @@ export default function ForestProfilePage() {
   const pastDreams = dreams.slice(RECENT_FRUIT_COUNT);
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-[#241a40] via-[#1a1336] to-[#0e0a1c] pb-24 text-white">
+    <div
+      className="relative min-h-screen overflow-hidden pb-24 text-white"
+      style={{ background: sky }}
+    >
+      {/* 季節パーティクル（本文の背面に降らせて可読性を保つ） */}
+      <SeasonalParticles season={season} behind />
+
       <header className="sticky top-0 z-10 bg-black/20 backdrop-blur-md">
         <div className="container mx-auto flex h-14 max-w-3xl items-center px-4">
           <Link href="/forest" className="flex items-center text-white/80 hover:text-white">
@@ -75,7 +88,7 @@ export default function ForestProfilePage() {
         </div>
       </header>
 
-      <main className="container mx-auto max-w-3xl px-4 pt-10">
+      <main className="container relative z-[2] mx-auto max-w-3xl px-4 pt-10">
         {dreams.length === 0 ? (
           <div className="mt-16 flex flex-col items-center gap-4 text-center">
             <motion.span

--- a/frontend/lib/forestAtmosphere.ts
+++ b/frontend/lib/forestAtmosphere.ts
@@ -1,0 +1,61 @@
+// 夢の森の「時刻」と「季節」による雰囲気を決める純粋関数群。
+// すべて入力 Date → 出力が決定的。new Date() は呼び出し側で生成して渡す（テスト容易性）。
+
+export type TimePhase = "dawn" | "day" | "dusk" | "night";
+export type Season = "spring" | "summer" | "autumn" | "winter";
+
+/** 時刻 → 時間帯。朝5-9 / 昼10-15 / 夕16-18 / それ以外は夜。 */
+export function getTimePhase(date: Date): TimePhase {
+  const h = date.getHours();
+  if (h >= 5 && h <= 9) return "dawn";
+  if (h >= 10 && h <= 15) return "day";
+  if (h >= 16 && h <= 18) return "dusk";
+  return "night";
+}
+
+/** 月 → 季節（北半球・日本）。春3-5 / 夏6-8 / 秋9-11 / 冬12,1,2。 */
+export function getSeason(date: Date): Season {
+  const m = date.getMonth() + 1; // 1-12
+  if (m >= 3 && m <= 5) return "spring";
+  if (m >= 6 && m <= 8) return "summer";
+  if (m >= 9 && m <= 11) return "autumn";
+  return "winter";
+}
+
+// 方向B「ずっと幻想的」: 常に暗めの夢トーンを保ち、時刻で色相だけ寄せる。
+// 夜は A+B で確定済みの紺をそのまま使う。
+const SKY_GRADIENTS: Record<TimePhase, string> = {
+  // 朝＝薄紫
+  dawn: "linear-gradient(180deg, #3a2f5e 0%, #2a2150 55%, #181030 100%)",
+  // 昼＝青緑
+  day: "linear-gradient(180deg, #25425e 0%, #1d3850 55%, #122535 100%)",
+  // 夕＝赤紫
+  dusk: "linear-gradient(180deg, #4a2a55 0%, #3a2048 55%, #1f1230 100%)",
+  // 夜＝紺（現状維持）
+  night: "linear-gradient(180deg, #241a40 0%, #1a1336 55%, #0e0a1c 100%)",
+};
+
+/** 時間帯 → 空グラデーション（CSS linear-gradient 文字列）。 */
+export function getSkyGradient(phase: TimePhase): string {
+  return SKY_GRADIENTS[phase];
+}
+
+export interface Celestial {
+  moonXPct: number; // 月の左位置（%）
+  moonYPct: number; // 月の上位置（%）
+  starOpacity: number; // 星全体の濃さ（0〜1の基準値）
+}
+
+// 月の位置・星の濃さを時間帯で変える。読込時の静的値なので reduced-motion でも安全。
+// 月は夜に空を弧で移動するイメージ: 夕方=右下→夜=高く中央寄り→朝=左へ沈む。
+const CELESTIAL: Record<TimePhase, Celestial> = {
+  dawn: { moonXPct: 18, moonYPct: 26, starOpacity: 0.35 },
+  day: { moonXPct: 50, moonYPct: 14, starOpacity: 0.12 },
+  dusk: { moonXPct: 82, moonYPct: 22, starOpacity: 0.5 },
+  night: { moonXPct: 60, moonYPct: 12, starOpacity: 1 },
+};
+
+/** 時間帯 → 月の位置と星の濃さ。 */
+export function getCelestial(phase: TimePhase): Celestial {
+  return CELESTIAL[phase];
+}


### PR DESCRIPTION
## Summary

夢の森（`/forest` と `/forest/[profileId]`）に**時刻と季節の演出**を追加。方向B「ずっと幻想的」で、常に夢っぽい暗めトーンを保ちつつ時刻で色相を寄せる方針（リアルな明るい昼空は不採用）。

- **時刻で空の色が変わる**: 朝=薄紫 / 昼=青緑 / 夕=赤紫 / 夜=紺。星の濃さも時刻連動（夜=濃い / 昼=ほぼ見えない）
- **月が時刻で動く**: 時間帯ごとに月の位置が変化
- **季節パーティクル**: 🌸春 / 🍃夏(控えめ) / 🍁秋 / ❄️冬 が舞い落ちる。夏はほたるが主役なので控えめ
- 森シーンと単独ツリーページの両方に適用し世界観を統一

## 設計

[docs/superpowers/specs/2026-06-13-forest-seasonal-effects-design.md](docs/superpowers/specs/2026-06-13-forest-seasonal-effects-design.md)

ロジックは純粋関数に切り出してTDD（既存 `lib/forest.ts` と同じ作法）。

## Changed files

| ファイル | 変更 |
|---|---|
| `lib/forestAtmosphere.ts` | 新規：getTimePhase / getSeason / getSkyGradient / getCelestial（純粋関数） |
| `__tests__/lib/forestAtmosphere.test.ts` | 新規：境界値・決定論を24件で検証 |
| `components/forest/SeasonalParticles.tsx` | 新規：季節の舞い落ちる装飾（前面/背面切替・reduced-motion対応） |
| `components/forest/ForestScene.tsx` | 空の色相・月の位置・星の濃さを時刻連動、季節パーティクル追加 |
| `forest/[profileId]/page.tsx` | ページ背景も同じ空に統一、季節パーティクルを背面に追加 |

## reduced-motion

| 要素 | 通常 | reduced-motion |
|---|---|---|
| 空の色（時間帯） | 適用 | 適用（色変化はmotionでない） |
| 月／星の位置 | 適用 | 適用（読込時の静的値） |
| 星の瞬き | アニメ | 停止（既存通り） |
| 季節パーティクル落下 | アニメ | 停止・静止表示 |

## Test plan

- [ ] `/forest` で時間帯に応じた空の色・月の位置・季節パーティクルが表示される
- [ ] `/forest/[profileId]` の背景も同じ空に揃い、季節パーティクルが本文の背面に降る
- [ ] 昼間は星がほぼ見えず、夜は濃く瞬く
- [ ] `prefers-reduced-motion: reduce` でパーティクルが落下せず静止表示になる
- [x] Jest 204件パス（新規24件）・`yarn build` 成功・TypeScript チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)