### PR TITLE
feat: 夢の森リデザイン Phase2 — パン/ズーム探索＋木プレビューシート

### DIFF
--- a/frontend/__tests__/components/TreePreviewSheet.test.tsx
+++ b/frontend/__tests__/components/TreePreviewSheet.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import TreePreviewSheet from "@/app/components/forest/TreePreviewSheet";
+import type { Dream, DreamProfile } from "@/app/types";
+import { getDreamsForProfile } from "@/lib/apiClient";
+
+jest.mock("@/lib/apiClient", () => ({
+  getDreamsForProfile: jest.fn(),
+}));
+
+const mockedGetDreamsForProfile = getDreamsForProfile as jest.MockedFunction<
+  typeof getDreamsForProfile
+>;
+
+function profile(overrides: Partial<DreamProfile>): DreamProfile {
+  return {
+    id: 1,
+    name: "自分",
+    avatar_emoji: "🧑",
+    color: "#8b5cf6",
+    relationship: "self",
+    active: true,
+    position: 1,
+    archived: false,
+    created_at: "2026-06-14T00:00:00Z",
+    updated_at: "2026-06-14T00:00:00Z",
+    dreams_count: 1,
+    ...overrides,
+  };
+}
+
+function dream(overrides: Partial<Dream>): Dream {
+  return {
+    id: 1,
+    title: "古い木のゆめ",
+    userId: 1,
+    created_at: "2026-06-14T00:00:00Z",
+    updated_at: "2026-06-14T00:00:00Z",
+    emotions: [{ id: 1, name: "喜び" }],
+    ...overrides,
+  };
+}
+
+describe("TreePreviewSheet", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("clears the previous recent dream when loading another profile fails", async () => {
+    mockedGetDreamsForProfile
+      .mockResolvedValueOnce([dream({ title: "前の木のゆめ" })])
+      .mockRejectedValueOnce(new Error("temporary failure"));
+
+    const { rerender } = render(
+      <TreePreviewSheet
+        profile={profile({ id: 1, name: "自分" })}
+        onOpen={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(await screen.findByText(/前の木のゆめ/)).toBeInTheDocument();
+
+    rerender(
+      <TreePreviewSheet
+        profile={profile({ id: 2, name: "家族", dreams_count: 2 })}
+        onOpen={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockedGetDreamsForProfile).toHaveBeenCalledWith(2);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/前の木のゆめ/)).not.toBeInTheDocument();
+      expect(screen.queryByText("さいきんの ゆめ：")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/app/components/forest/ForestScene.tsx
+++ b/frontend/app/components/forest/ForestScene.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -10,10 +10,13 @@ import {
   getSeason,
   getSkyGradient,
   getCelestial,
+  HAZE,
 } from "@/lib/forestAtmosphere";
+import { getGrowthLevel, getCanopyScale } from "@/lib/forest";
 import MiniTree from "./MiniTree";
 import ForestTodayCard from "./ForestTodayCard";
 import SeasonalParticles from "./SeasonalParticles";
+import TreePreviewSheet from "./TreePreviewSheet";
 
 const STARS = Array.from({ length: 40 }, (_, i) => ({
   left: (i * 53) % 100,
@@ -30,41 +33,161 @@ const FIREFLIES = Array.from({ length: 8 }, (_, i) => ({
   dy: -(8 + (i % 5) * 4),
 }));
 
-const GROUND_DECO = [
-  { left: 4, emoji: "🍄" },
-  { left: 16, emoji: "🌿" },
-  { left: 29, emoji: "🌸" },
-  { left: 57, emoji: "🌿" },
-  { left: 70, emoji: "🍄" },
-  { left: 82, emoji: "🌱" },
-  { left: 91, emoji: "🌿" },
-];
-
 export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) {
   const reduceMotion = useReducedMotion();
   const router = useRouter();
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [W, setW] = useState(960);
+  const [H, setH] = useState(560);
+  const fieldW = Math.max(W, 1180); // 森の世界はビューポートより広く、パンで探索できる
 
-  // 読込時の時刻・季節を1回だけ確定（再レンダーで動かないよう useMemo）
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => {
+      setW(el.clientWidth);
+      setH(el.clientHeight);
+    });
+    ro.observe(el);
+    setW(el.clientWidth);
+    setH(el.clientHeight);
+    return () => ro.disconnect();
+  }, []);
+
+  // 読込時の時刻・季節を1回だけ確定
   const now = useMemo(() => new Date(), []);
   const phase = getTimePhase(now);
   const season = getSeason(now);
   const sky = getSkyGradient(phase);
-  const { moonXPct, moonYPct, starOpacity } = getCelestial(phase);
+  const cel = getCelestial(phase);
+  const haze = HAZE[phase];
 
-  // 「きょうの もり」カード用の集計
+  // パン & ズーム
+  const [view, setView] = useState({ x: 0, y: 0, z: 1 });
+  const dragRef = useRef<{ sx: number; sy: number; vx: number; vy: number } | null>(null);
+  const movedRef = useRef(false);
+  const pointers = useRef(new Map<number, { x: number; y: number }>());
+  const pinch = useRef<{ dist: number; z: number } | null>(null);
+  const [hinted, setHinted] = useState(true);
+
+  const clamp = useCallback(
+    (v: { x: number; y: number; z: number }) => {
+      const z = Math.max(0.7, Math.min(2.2, v.z));
+      return {
+        z,
+        x: Math.max(Math.min(v.x, 40), Math.min(-(fieldW * z - W) - 40, 40)),
+        y: Math.max(Math.min(v.y, 60), Math.min(-(H * z - H) - 40, 60)),
+      };
+    },
+    [fieldW, W, H]
+  );
+
+  // ポインタ捕捉は「ドラッグと判定してから」遅延して行う。
+  // pointerdown で即捕捉すると子の木ボタンの click が発火せず、タップで
+  // プレビューシートが開かなくなるため（重要）。
+  const capturedRef = useRef(false);
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    pointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    movedRef.current = false;
+    capturedRef.current = false;
+    setHinted(false);
+    if (pointers.current.size === 1) {
+      dragRef.current = { sx: e.clientX, sy: e.clientY, vx: view.x, vy: view.y };
+    } else if (pointers.current.size === 2) {
+      const pts = [...pointers.current.values()];
+      pinch.current = { dist: Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y), z: view.z };
+      dragRef.current = null;
+    }
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!pointers.current.has(e.pointerId)) return;
+    pointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (pointers.current.size >= 2 && pinch.current) {
+      if (!capturedRef.current) {
+        try {
+          (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+        } catch {
+          /* ignore */
+        }
+        capturedRef.current = true;
+      }
+      const pts = [...pointers.current.values()];
+      const dist = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+      setView((v) => clamp({ ...v, z: pinch.current!.z * (dist / pinch.current!.dist) }));
+    } else if (dragRef.current) {
+      const dx = e.clientX - dragRef.current.sx;
+      const dy = e.clientY - dragRef.current.sy;
+      if (Math.abs(dx) + Math.abs(dy) > 6) {
+        movedRef.current = true;
+        // ドラッグと確定してから捕捉する（タップの click は妨げない）
+        if (!capturedRef.current) {
+          try {
+            (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+          } catch {
+            /* ignore */
+          }
+          capturedRef.current = true;
+        }
+      }
+      setView((v) => clamp({ ...v, x: dragRef.current!.vx + dx, y: dragRef.current!.vy + dy }));
+    }
+  };
+  const onPointerUp = (e: React.PointerEvent) => {
+    pointers.current.delete(e.pointerId);
+    if (pointers.current.size < 2) pinch.current = null;
+    if (pointers.current.size === 0) {
+      dragRef.current = null;
+      capturedRef.current = false;
+    }
+  };
+  const onWheel = (e: React.WheelEvent) => {
+    e.preventDefault();
+    setView((v) => clamp({ ...v, z: v.z * (e.deltaY > 0 ? 0.92 : 1.08) }));
+    setHinted(false);
+  };
+
+  // 木タップ → プレビューシート（ドラッグ中は選択しない）
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const selected = profiles.find((p) => p.id === selectedId) ?? null;
+  const selectTree = (p: DreamProfile) => {
+    if (!movedRef.current) setSelectedId(p.id);
+  };
+
+  // 木の配置（横に広げ、奇数列は少し奥に）
+  const planted = useMemo(() => {
+    const n = profiles.length;
+    const margin = 120;
+    return profiles.map((p, i) => {
+      const t = n === 1 ? 0.5 : i / (n - 1);
+      const x = margin + t * (fieldW - margin * 2);
+      const row = i % 2;
+      return {
+        p,
+        x,
+        depth: row === 0 ? 1 : 0.82,
+        groundY: row === 0 ? 0.1 : 0.2,
+        lvl: getGrowthLevel(p.dreams_count ?? 0).level,
+      };
+    });
+  }, [profiles, fieldW]);
+
   const totalDreams = profiles.reduce((s, p) => s + (p.dreams_count ?? 0), 0);
   const topProfile = profiles.reduce<DreamProfile | null>((top, p) => {
     if ((p.dreams_count ?? 0) === 0) return top;
     if (!top || (p.dreams_count ?? 0) > (top.dreams_count ?? 0)) return p;
     return top;
   }, null);
+  const isEmpty = profiles.length === 0;
 
   return (
     <div
-      className="relative min-h-[70vh] overflow-hidden rounded-3xl"
+      ref={wrapRef}
+      className="relative min-h-[70vh] touch-none overflow-hidden rounded-3xl"
       style={{ background: sky }}
     >
-      {/* 星空（時間帯で濃さが変わる: 夜=濃い / 昼=ほぼ見えない） */}
+      {/* === 固定アンビエント（パンしても動かない背景） === */}
+      {/* 星空（時間帯で濃さが変わる） */}
       {STARS.map((s, i) => (
         <motion.span
           key={i}
@@ -74,36 +197,34 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
             top: `${s.top}%`,
             width: s.size,
             height: s.size,
-            opacity: starOpacity,
+            opacity: cel.starOpacity,
           }}
           animate={
             reduceMotion
               ? undefined
-              : { opacity: [0.2 * starOpacity, starOpacity, 0.2 * starOpacity] }
+              : { opacity: [0.2 * cel.starOpacity, cel.starOpacity, 0.2 * cel.starOpacity] }
           }
           transition={{ duration: 3, repeat: Infinity, delay: s.delay }}
           aria-hidden="true"
         />
       ))}
 
-      {/* 月（位置が時間帯で変わる） */}
+      {/* 月（位置・色が時間帯で変わる） */}
       <div
-        className="absolute h-16 w-16 -translate-x-1/2 rounded-full bg-[#fef3c7] shadow-[0_0_50px_20px_rgba(254,243,199,0.35)]"
-        style={{ left: `${moonXPct}%`, top: `${moonYPct}%` }}
+        className="pointer-events-none absolute h-16 w-16 -translate-x-1/2 -translate-y-1/2 rounded-full"
+        style={{
+          left: `${cel.moonXPct}%`,
+          top: `${cel.moonYPct}%`,
+          background: cel.glow,
+          boxShadow: `0 0 50px 20px ${cel.glow}55`,
+        }}
         aria-hidden="true"
       />
 
-      {/* きょうの もり ダッシュボード（右上オーバーレイ） */}
-      {profiles.length > 0 && (
-        <div className="absolute right-3 top-3 z-20">
-          <ForestTodayCard totalDreams={totalDreams} topProfile={topProfile} />
-        </div>
-      )}
-
-      {/* 季節パーティクル（🌸/🍃/🍁/❄️） */}
+      {/* 季節パーティクル */}
       <SeasonalParticles season={season} />
 
-      {/* ほたる（reduced-motion 時は静止した光点として表示） */}
+      {/* ほたる */}
       {FIREFLIES.map((f, i) => (
         <motion.span
           key={i}
@@ -119,62 +240,152 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
         />
       ))}
 
-      {/* 地面 */}
-      <div
-        className="absolute bottom-0 h-28 w-full bg-gradient-to-t from-[#2a2150] to-transparent"
-        aria-hidden="true"
-      />
+      {/* きょうの もり カード（右上・固定） */}
+      {!isEmpty && (
+        <div className="absolute right-3 top-3 z-20">
+          <ForestTodayCard totalDreams={totalDreams} topProfile={topProfile} />
+        </div>
+      )}
 
-      {/* 霧 */}
-      <div
-        className="pointer-events-none absolute bottom-0 h-20 w-full"
-        style={{ background: "linear-gradient(to top, rgba(70,45,150,0.40), rgba(50,30,110,0.12) 55%, transparent)" }}
-        aria-hidden="true"
-      />
-
-      {/* 地面の草花 */}
-      <div className="absolute bottom-5 left-0 right-0 z-[5]" aria-hidden="true">
-        {GROUND_DECO.map((d, i) => (
-          <span key={i} className="absolute text-xs" style={{ left: `${d.left}%`, bottom: 0 }}>
-            {d.emoji}
-          </span>
-        ))}
-      </div>
-
-      {/* 木を並べる / プロフィール0件の空状態 */}
-      <div className="relative z-10 flex flex-wrap items-end justify-center gap-6 px-6 pb-16 pt-24">
-        {profiles.length === 0 ? (
-          <div className="flex flex-col items-center gap-4 py-10 text-center">
-            <motion.span
-              className="text-5xl"
-              animate={reduceMotion ? undefined : { y: [-4, 4, -4], scale: [1, 1.05, 1] }}
-              transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
+      {/* === パン/ズームできる森の世界 === */}
+      {!isEmpty && (
+        <div
+          className="absolute inset-0"
+          style={{ cursor: dragRef.current ? "grabbing" : "grab" }}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          onWheel={onWheel}
+        >
+          <div
+            className="absolute left-0 top-0 h-full"
+            style={{
+              width: fieldW,
+              transform: `translate(${view.x}px, ${view.y}px) scale(${view.z})`,
+              transformOrigin: "0 0",
+            }}
+          >
+            {/* なだらかな丘 */}
+            <svg
+              viewBox={`0 0 ${fieldW} ${H}`}
+              width={fieldW}
+              height={H}
+              preserveAspectRatio="none"
+              className="absolute inset-0"
               aria-hidden="true"
             >
-              🌱
-            </motion.span>
-            <p className="text-base font-bold text-white/90">まだ きが ないよ</p>
-            <p className="text-sm leading-relaxed text-white/60">
-              プロフィールを つくると、<br />
-              ゆめの きが ここに そだつよ。
-            </p>
-            <Link
-              href="/profiles"
-              className="mt-2 rounded-full bg-primary px-5 py-2 text-sm font-bold text-primary-foreground shadow-lg shadow-primary/20"
-            >
-              プロフィールを つくる
-            </Link>
-          </div>
-        ) : (
-          profiles.map((p) => (
-            <MiniTree
-              key={p.id}
-              profile={p}
-              onSelect={() => router.push(`/forest/${p.id}`)}
+              <defs>
+                <linearGradient id="forest-hill-far" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0" stopColor="#2a2150" stopOpacity="0.6" />
+                  <stop offset="1" stopColor="#1b1438" stopOpacity="0.9" />
+                </linearGradient>
+                <linearGradient id="forest-hill-near" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0" stopColor="#241c46" />
+                  <stop offset="1" stopColor="#120d28" />
+                </linearGradient>
+              </defs>
+              <path
+                d={`M0 ${H * 0.74} Q ${fieldW * 0.25} ${H * 0.66} ${fieldW * 0.5} ${H * 0.73} T ${fieldW} ${H * 0.72} L ${fieldW} ${H} L0 ${H} Z`}
+                fill="url(#forest-hill-far)"
+              />
+              <path
+                d={`M0 ${H * 0.86} Q ${fieldW * 0.3} ${H * 0.78} ${fieldW * 0.62} ${H * 0.86} T ${fieldW} ${H * 0.84} L ${fieldW} ${H} L0 ${H} Z`}
+                fill="url(#forest-hill-near)"
+              />
+            </svg>
+
+            {/* 地面の霞 */}
+            <div
+              className="pointer-events-none absolute bottom-0 left-0 h-28"
+              style={{ background: `linear-gradient(to top, ${haze}, transparent)`, width: fieldW }}
+              aria-hidden="true"
             />
-          ))
-        )}
-      </div>
+
+            {/* 木 */}
+            {planted.map(({ p, x, depth, groundY, lvl }) => (
+              <div
+                key={p.id}
+                className="absolute"
+                style={{
+                  left: x,
+                  bottom: `${groundY * 100}%`,
+                  transform: "translateX(-50%)",
+                  zIndex: depth > 0.9 ? 8 : 5,
+                  opacity: depth > 0.9 ? 1 : 0.94,
+                }}
+              >
+                <MiniTree
+                  profile={p}
+                  isSelected={selectedId === p.id}
+                  onSelect={() => selectTree(p)}
+                  height={Math.round((120 + lvl * 22) * getCanopyScale(lvl) * 0.9 + 80)}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ズームコントロール（左上・木/今日カード/モルペウスと重ならない位置） */}
+      {!isEmpty && (
+        <div className="absolute left-3 top-3 z-30 flex flex-col gap-2">
+          {(
+            [
+              ["＋", "ズームイン", () => setView((v) => clamp({ ...v, z: v.z * 1.2 }))],
+              ["－", "ズームアウト", () => setView((v) => clamp({ ...v, z: v.z * 0.83 }))],
+              ["⟳", "もとに もどす", () => setView({ x: 0, y: 0, z: 1 })],
+            ] as const
+          ).map(([t, lab, fn], i) => (
+            <button
+              key={i}
+              onClick={fn}
+              aria-label={lab}
+              className="h-10 w-10 rounded-xl border border-white/25 bg-[rgba(12,12,32,0.65)] text-[18px] font-bold text-white/90 backdrop-blur-lg hover:bg-[rgba(12,12,32,0.85)]"
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* ドラッグヒント */}
+      {hinted && !selected && !isEmpty && (
+        <div className="pointer-events-none absolute bottom-[74px] left-1/2 z-[35] -translate-x-1/2 rounded-full border border-white/20 bg-[rgba(12,12,32,0.65)] px-4 py-2 text-[12.5px] font-semibold text-white/85 backdrop-blur-lg">
+          👆 ドラッグで うごかせる・ピンチで ズーム
+        </div>
+      )}
+
+      {/* 空状態（プロフィール0件） */}
+      {isEmpty && (
+        <div className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-4 p-6 text-center">
+          <motion.span
+            className="text-5xl"
+            animate={reduceMotion ? undefined : { y: [-4, 4, -4], scale: [1, 1.05, 1] }}
+            transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
+            aria-hidden="true"
+          >
+            🌱
+          </motion.span>
+          <p className="text-base font-bold text-white/90">まだ きが ないよ</p>
+          <p className="max-w-xs text-sm leading-relaxed text-white/60">
+            プロフィールを つくると、ゆめの きが ここに そだつよ。
+          </p>
+          <Link
+            href="/profiles"
+            className="mt-2 rounded-full bg-primary px-5 py-2 text-sm font-bold text-primary-foreground shadow-lg shadow-primary/20"
+          >
+            プロフィールを つくる
+          </Link>
+        </div>
+      )}
+
+      {/* 木タップ時のプレビューシート */}
+      <TreePreviewSheet
+        profile={selected}
+        onOpen={(p) => router.push(`/forest/${p.id}`)}
+        onClose={() => setSelectedId(null)}
+      />
     </div>
   );
 }

--- a/frontend/app/components/forest/TreePreviewSheet.tsx
+++ b/frontend/app/components/forest/TreePreviewSheet.tsx
@@ -31,6 +31,7 @@ export default function TreePreviewSheet({ profile, onOpen, onClose }: TreePrevi
     if (!profile) { setRecentDream(null); return; }
     let cancelled = false;
     setLoading(true);
+    setRecentDream(null);
     getDreamsForProfile(profile.id)
       .then((dreams) => { if (!cancelled) setRecentDream(dreams[0] ?? null); })
       .catch(() => {/* silently ignore — sheet still useful without recent dream */})

--- a/frontend/app/components/forest/TreePreviewSheet.tsx
+++ b/frontend/app/components/forest/TreePreviewSheet.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import Link from "next/link";
+import { X } from "lucide-react";
+import type { DreamProfile, Dream } from "@/app/types";
+import { getGrowthLevel, EMOTION_COLORS } from "@/lib/forest";
+import { getDreamsForProfile } from "@/lib/apiClient";
+
+interface TreePreviewSheetProps {
+  profile: DreamProfile | null;
+  onOpen: (profile: DreamProfile) => void;
+  onClose: () => void;
+}
+
+/**
+ * 木をタップしたときに下からスライドアップするプレビューシート。
+ * プロフィール・直近の夢・感情タグを表示し、「この きを 見る ›」で詳細へ遷移。
+ *
+ * データ要件:
+ *  - profile.dreams_count は getDreamProfiles() で取得済み。
+ *  - 直近の夢（title, emotions）は getDreamsForProfile() で lazy-fetch する。
+ *    ネットワーク負荷が気になるなら、ForestScene 側でプリフェッチして渡してもよい。
+ */
+export default function TreePreviewSheet({ profile, onOpen, onClose }: TreePreviewSheetProps) {
+  const [recentDream, setRecentDream] = useState<Dream | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!profile) { setRecentDream(null); return; }
+    let cancelled = false;
+    setLoading(true);
+    getDreamsForProfile(profile.id)
+      .then((dreams) => { if (!cancelled) setRecentDream(dreams[0] ?? null); })
+      .catch(() => {/* silently ignore — sheet still useful without recent dream */})
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [profile?.id]);
+
+  const lvl = profile ? getGrowthLevel(profile.dreams_count ?? 0) : null;
+
+  return (
+    <AnimatePresence>
+      {profile && (
+        <motion.div
+          key={profile.id}
+          initial={{ y: 32, opacity: 0, scale: 0.97 }}
+          animate={{ y: 0, opacity: 1, scale: 1 }}
+          exit={{ y: 24, opacity: 0, scale: 0.97 }}
+          transition={{ type: "spring", stiffness: 320, damping: 26 }}
+          style={{ borderColor: `${profile.color}55` }}
+          className="absolute bottom-4 left-1/2 z-[45] w-[min(420px,calc(100%-120px))] -translate-x-1/2 rounded-[22px] border bg-gradient-to-br from-[rgba(28,26,60,0.96)] to-[rgba(16,14,40,0.96)] p-4 text-white shadow-[0_20px_50px_rgba(6,4,20,0.55)]"
+        >
+          {/* close */}
+          <button
+            onClick={onClose}
+            aria-label="とじる"
+            className="absolute right-3 top-3 flex h-6 w-6 items-center justify-center rounded-full bg-white/10 text-white/60 hover:bg-white/20 hover:text-white"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+
+          {/* header */}
+          <div className="mb-2.5 flex items-center gap-2.5">
+            <div
+              className="flex h-10 w-10 items-center justify-center rounded-full text-2xl"
+              style={{ background: `${profile.color}26`, border: `1.5px solid ${profile.color}88` }}
+            >
+              {profile.avatar_emoji}
+            </div>
+            <div>
+              <p className="text-[17px] font-black">{profile.name}の き</p>
+              <p className="text-[12.5px] font-bold" style={{ color: profile.color }}>
+                {lvl?.name}（{lvl?.reading}）・ ゆめ {profile.dreams_count ?? 0}こ
+              </p>
+            </div>
+          </div>
+
+          {/* recent dream */}
+          {!loading && recentDream && (
+            <div className="mb-3 text-[13px] leading-relaxed text-white/80">
+              <span className="text-white/50">さいきんの ゆめ：</span>
+              「{recentDream.title}」
+              {(recentDream.emotions?.length ?? 0) > 0 && (
+                <div className="mt-1.5 flex flex-wrap gap-1.5">
+                  {recentDream.emotions!.map((e) => (
+                    <span
+                      key={e.id}
+                      className="rounded-full px-2 py-0.5 text-[11.5px] font-bold"
+                      style={{ background: `${EMOTION_COLORS[e.name] ?? profile.color}22`, color: EMOTION_COLORS[e.name] ?? profile.color }}
+                    >
+                      {e.name}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+          {loading && <p className="mb-3 text-[12px] text-white/40">よみこんでいるよ…</p>}
+
+          {/* CTA */}
+          <button
+            onClick={() => onOpen(profile)}
+            style={{ background: `linear-gradient(135deg, ${profile.color}, #7c3aed)`, boxShadow: `0 8px 22px ${profile.color}44` }}
+            className="w-full rounded-[13px] py-2.5 text-[14.5px] font-black text-white"
+          >
+            この きを 見る ›
+          </button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/e2e/forest-flow.spec.ts
+++ b/frontend/e2e/forest-flow.spec.ts
@@ -97,15 +97,20 @@ test.describe("夢の森", () => {
     ]);
   });
 
-  test("森 → 木 → へ遷移できる", async ({ page }) => {
+  test("森 → 木タップ → プレビューシート → 詳細へ遷移できる", async ({ page }) => {
     await page.goto("/forest");
 
     await expect(
       page.getByRole("heading", { name: "ゆめの もり" })
     ).toBeVisible();
 
-    // 「自分」の木をクリック（aria-label の前方一致で絞り込み）
-    await page.getByRole("button", { name: /自分 の木/ }).first().click();
+    // 「自分」の木をタップ → 下からプレビューシートが出る（直接遷移ではない）
+    await page.getByRole("button", { name: /自分の き/ }).first().click();
+
+    // プレビューシートの「この きを 見る ›」で詳細へ遷移
+    const seeTreeButton = page.getByRole("button", { name: /この きを 見る/ });
+    await expect(seeTreeButton).toBeVisible();
+    await seeTreeButton.click();
 
     await expect(page).toHaveURL(/\/forest\/1$/);
     await expect(page.getByRole("heading", { name: /の き$/ })).toBeVisible();


### PR DESCRIPTION
## Summary

Claude Design リデザインの **段階適用 Phase 2/4**。森を「眺めるだけ」から「探索できる世界」にします。

- **パン/ズーム**: ドラッグで移動・ホイール/2本指ピンチでズーム（0.7〜2.2x）・リセット
- **木を横に広く配置**: 奥行き2列で森の広がりを表現。なだらかな丘SVG＋時刻連動の霞
- **木タップでプレビューシート**: 下からスライドアップし、最近の夢・感情タグを表示。「この きを 見る ›」で詳細へ
- ズームコントロールは**左上**（今日カード=右上・モルペウス=右下・木=下部との衝突回避）
- 既存の星/月/季節パーティクル/ほたる/今日カード/空状態は維持

## 重要な不具合修正（実機にも影響）

pannable world の `onPointerDown` で即 `setPointerCapture` すると、ポインタがworld divに捕捉され**子の木ボタンの `click` が発火せず、タップしてもシートが開かない**。E2Eがこれを検出。ポインタ捕捉を「ドラッグ確定後（移動>6px）」に遅延させて解消（タップ＝click発火／ドラッグ＝堅牢な捕捉を両立）。

## E2E 更新

木タップが「直接遷移」→「プレビューシート経由」に変わったため、`forest-flow.spec.ts` を更新（木タップ→シートの「この きを 見る」→詳細遷移）。

## 後続フェーズ（このPRには含まない）

- Phase 3: 小動物・歩くモルペウス・Canvasパーティクル
- Phase 4: `/forest/[profileId]` 刷新・実の色の凡例

## Test plan

- [x] `yarn build` 成功・TypeScript 通過
- [x] Jest 204件パス
- [x] E2E `forest-flow.spec.ts` パス（クリーンサーバーで確認）
- [ ] Vercel プレビューで `/forest` のドラッグ/ズーム・木タップ→シート→詳細遷移を確認
- [ ] `prefers-reduced-motion: reduce` で過剰なアニメが止まる

🤖 Generated with [Claude Code](https://claude.com/claude-code)