### PR TITLE
feat: 夢の森リデザイン Phase3 — 小動物・歩くモルペウス・Canvasパーティクル

### DIFF
--- a/frontend/app/components/forest/Critters.tsx
+++ b/frontend/app/components/forest/Critters.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+import { useReducedMotion } from "framer-motion";
+
+interface CritterDef { emoji: string; kind: "hop" | "walk" | "fly"; yPct: number; speed: number; }
+
+const CRITTERS: CritterDef[] = [
+  { emoji: "🐰", kind: "hop",  yPct: 6,  speed: 0.7 },
+  { emoji: "🦊", kind: "walk", yPct: 4,  speed: 0.5 },
+  { emoji: "🦔", kind: "walk", yPct: 3,  speed: 0.35 },
+  { emoji: "🐱", kind: "walk", yPct: 4,  speed: 0.45 },
+  { emoji: "🦉", kind: "fly",  yPct: 38, speed: 0.4 },
+  { emoji: "🦋", kind: "fly",  yPct: 50, speed: 0.6 },
+];
+
+interface CritterProps { data: CritterDef; fieldW: number; motion: boolean; }
+
+function Critter({ data, fieldW, motion }: CritterProps) {
+  const elRef = useRef<HTMLDivElement>(null);
+  const st = useRef({ x: Math.random() * fieldW, dir: Math.random() > 0.5 ? 1 : -1, ph: Math.random() * Math.PI * 2, flipTimer: 0 });
+
+  useEffect(() => {
+    const el = elRef.current;
+    if (!el) return;
+    if (!motion) {
+      el.style.left = st.current.x + "px";
+      el.style.transform = `translateX(-50%) scaleX(${st.current.dir})`;
+      return;
+    }
+    let raf: number;
+    const tick = () => {
+      const s = st.current;
+      s.ph += 0.016;
+      s.x += s.dir * data.speed;
+      if (s.x < -30) { s.dir = 1;  s.x = -30; }
+      if (s.x > fieldW + 30) { s.dir = -1; s.x = fieldW + 30; }
+      if (data.kind !== "fly") {
+        s.flipTimer++;
+        if (s.flipTimer > 180 && Math.random() < 0.01) { s.dir = -s.dir; s.flipTimer = 0; }
+      }
+      let bob = 0;
+      if (data.kind === "hop")  bob = Math.abs(Math.sin(s.ph * 3)) * -14;
+      else if (data.kind === "walk") bob = Math.sin(s.ph * 6) * 2;
+      else bob = Math.sin(s.ph * 1.5) * 10;
+      el.style.left = s.x + "px";
+      el.style.transform = `translateX(-50%) translateY(${bob.toFixed(2)}px) scaleX(${s.dir})`;
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [motion, fieldW, data]);
+
+  return (
+    <div
+      ref={elRef}
+      style={{
+        position: "absolute",
+        left: st.current.x,
+        bottom: `${data.yPct}%`,
+        fontSize: data.kind === "fly" ? 22 : 26,
+        zIndex: 12,
+        userSelect: "none",
+        filter: "drop-shadow(0 4px 6px rgba(0,0,0,0.4))",
+      }}
+      aria-hidden="true"
+    >
+      {data.emoji}
+    </div>
+  );
+}
+
+interface CrittersProps {
+  fieldW: number;
+  /** Max number of critters to show (0–6). Defaults to 4. */
+  count?: number;
+}
+
+export default function Critters({ fieldW, count = 4 }: CrittersProps) {
+  const reduceMotion = useReducedMotion();
+  const motion = !reduceMotion;
+  const list = CRITTERS.slice(0, Math.max(0, Math.min(count, CRITTERS.length)));
+
+  return (
+    <div style={{ position: "absolute", inset: 0, pointerEvents: "none", zIndex: 12 }} aria-hidden="true">
+      {list.map((c, i) => (
+        <Critter key={i} data={c} fieldW={fieldW} motion={motion} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/app/components/forest/ForestScene.tsx
+++ b/frontend/app/components/forest/ForestScene.tsx
@@ -15,23 +15,10 @@ import {
 import { getGrowthLevel, getCanopyScale } from "@/lib/forest";
 import MiniTree from "./MiniTree";
 import ForestTodayCard from "./ForestTodayCard";
-import SeasonalParticles from "./SeasonalParticles";
+import ParticleField from "./ParticleField";
+import Critters from "./Critters";
+import WalkingMorpheus from "./WalkingMorpheus";
 import TreePreviewSheet from "./TreePreviewSheet";
-
-const STARS = Array.from({ length: 40 }, (_, i) => ({
-  left: (i * 53) % 100,
-  top: (i * 37) % 70,
-  delay: (i % 7) * 0.4,
-  size: (i % 3) + 1,
-}));
-
-const FIREFLIES = Array.from({ length: 8 }, (_, i) => ({
-  left: (i * 13 + 8) % 85 + 7,
-  top: 55 + (i * 7) % 28,
-  delay: (i * 0.7) % 2.8,
-  dx: ((i % 3) - 1) * 18,
-  dy: -(8 + (i % 5) * 4),
-}));
 
 export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) {
   const reduceMotion = useReducedMotion();
@@ -187,27 +174,14 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
       style={{ background: sky }}
     >
       {/* === 固定アンビエント（パンしても動かない背景） === */}
-      {/* 星空（時間帯で濃さが変わる） */}
-      {STARS.map((s, i) => (
-        <motion.span
-          key={i}
-          className="absolute rounded-full bg-white"
-          style={{
-            left: `${s.left}%`,
-            top: `${s.top}%`,
-            width: s.size,
-            height: s.size,
-            opacity: cel.starOpacity,
-          }}
-          animate={
-            reduceMotion
-              ? undefined
-              : { opacity: [0.2 * cel.starOpacity, cel.starOpacity, 0.2 * cel.starOpacity] }
-          }
-          transition={{ duration: 3, repeat: Infinity, delay: s.delay }}
-          aria-hidden="true"
-        />
-      ))}
+      {/* 星・ほたる・季節パーティクルを1枚のCanvasに集約（30fps・reduced-motion対応） */}
+      <ParticleField
+        phase={phase}
+        season={season}
+        weather="firefly"
+        starOpacity={cel.starOpacity}
+        density={1}
+      />
 
       {/* 月（位置・色が時間帯で変わる） */}
       <div
@@ -220,25 +194,6 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
         }}
         aria-hidden="true"
       />
-
-      {/* 季節パーティクル */}
-      <SeasonalParticles season={season} />
-
-      {/* ほたる */}
-      {FIREFLIES.map((f, i) => (
-        <motion.span
-          key={i}
-          className="absolute h-1.5 w-1.5 rounded-full bg-amber-200"
-          style={{ left: `${f.left}%`, top: `${f.top}%`, opacity: 0.5 }}
-          animate={
-            reduceMotion
-              ? undefined
-              : { x: [0, f.dx, 0], y: [0, f.dy, 0], opacity: [0.15, 0.9, 0.15] }
-          }
-          transition={{ duration: 2.5 + f.delay, repeat: Infinity, ease: "easeInOut", delay: f.delay }}
-          aria-hidden="true"
-        />
-      ))}
 
       {/* きょうの もり カード（右上・固定） */}
       {!isEmpty && (
@@ -323,6 +278,12 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
                 />
               </div>
             ))}
+
+            {/* 小動物・歩くモルペウス（reduced-motion時は非表示） */}
+            {!reduceMotion && (
+              <Critters fieldW={fieldW} count={Math.min(4, 2 + profiles.length)} />
+            )}
+            {!reduceMotion && <WalkingMorpheus fieldW={fieldW} baseY={H * 0.06} />}
           </div>
         </div>
       )}

--- a/frontend/app/components/forest/ParticleField.tsx
+++ b/frontend/app/components/forest/ParticleField.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+import { useReducedMotion } from "framer-motion";
+import type { TimePhase, Season } from "@/lib/forestAtmosphere";
+
+type Weather = "firefly" | "shooting" | "rain" | "calm";
+
+interface ParticleFieldProps {
+  phase: TimePhase;
+  season: Season;
+  weather?: Weather;
+  starOpacity?: number;
+  /** Particle density multiplier. Default 1. */
+  density?: number;
+}
+
+function makeGlow(size: number, inner: string, outer: string): HTMLCanvasElement {
+  const c = document.createElement("canvas");
+  c.width = c.height = size;
+  const x = c.getContext("2d")!;
+  const g = x.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+  g.addColorStop(0, inner); g.addColorStop(0.45, outer); g.addColorStop(1, "rgba(0,0,0,0)");
+  x.fillStyle = g; x.beginPath(); x.arc(size / 2, size / 2, size / 2, 0, 7); x.fill();
+  return c;
+}
+
+function rnd(a: number, b: number) { return a + Math.random() * (b - a); }
+
+export default function ParticleField({ phase, season, weather = "firefly", starOpacity = 1, density = 1 }: ParticleFieldProps) {
+  const reduceMotion = useReducedMotion();
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const propsRef  = useRef({ phase, season, weather, starOpacity, density, motion: !reduceMotion });
+
+  useEffect(() => { propsRef.current = { phase, season, weather, starOpacity, density, motion: !reduceMotion }; });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d")!;
+    const dpr = Math.min(1.5, window.devicePixelRatio || 1);
+    let W = 0, H = 0;
+
+    const fireGlow = makeGlow(40, "rgba(253,230,138,1)", "rgba(251,191,36,0.55)");
+    const moteGlow = makeGlow(28, "rgba(199,210,254,0.85)", "rgba(199,210,254,0.18)");
+
+    type Star = { x: number; y: number; r: number; tw: number; sp: number };
+    type FF   = { x: number; y: number; vx: number; vy: number; ph: number; sp: number; r: number };
+    type Mote = { x: number; y: number; vx: number; vy: number; r: number; a: number };
+    type Petal = { x: number; y: number; vx: number; vy: number; rot: number; vr: number; sway: number; size: number };
+    type Shooter = { x: number; y: number; vx: number; vy: number; life: number };
+    type Rain  = { x: number; y: number; len: number; sp: number };
+    let st: { stars: Star[]; ffs: FF[]; motes: Mote[]; petals: Petal[]; shooters: Shooter[]; rain: Rain[]; t: number } | null = null;
+
+    const spawnPetal = (initial: boolean): Petal => ({
+      x: Math.random() * W, y: initial ? Math.random() * H : -10,
+      vx: rnd(-0.4, 0.2), vy: rnd(0.3, 0.85),
+      rot: Math.random() * 6.28, vr: rnd(-0.04, 0.04), sway: Math.random() * 6.28, size: rnd(8, 14),
+    });
+
+    function seed() {
+      const d = propsRef.current.density;
+      st = {
+        stars:    Array.from({ length: Math.round(46 * d) }, () => ({ x: Math.random() * W, y: Math.random() * H * 0.78, r: rnd(0.4, 1.6), tw: Math.random() * 6.28, sp: rnd(0.5, 1.8) })),
+        ffs:      Array.from({ length: Math.round(9 * d)  }, () => ({ x: Math.random() * W, y: rnd(H * 0.45, H * 0.95), vx: rnd(-0.25, 0.25), vy: rnd(-0.18, 0.18), ph: Math.random() * 6.28, sp: rnd(0.6, 1.4), r: rnd(1.2, 2.4) })),
+        motes:    Array.from({ length: Math.round(16 * d)  }, () => ({ x: Math.random() * W, y: Math.random() * H, vx: rnd(-0.12, 0.12), vy: rnd(-0.25, -0.05), r: rnd(0.6, 2.2), a: rnd(0.05, 0.28) })),
+        petals:   Array.from({ length: Math.round(15 * d)  }, () => spawnPetal(true)),
+        shooters: [], rain: [], t: 0,
+      };
+    }
+
+    function resize() {
+      if (!canvas) return;
+      const r = canvas.getBoundingClientRect();
+      W = r.width; H = r.height;
+      canvas.width  = Math.max(1, W * dpr);
+      canvas.height = Math.max(1, H * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      seed();
+    }
+
+    const GLYPH: Record<string, string> = { spring: "🌸", summer: "🍃", autumn: "🍁", winter: "❄️" };
+    const FRAME_MS = 1000 / 30; // ~30 fps throttle
+    let raf = 0, lastT = 0;
+
+    function frame(now: number) {
+      raf = requestAnimationFrame(frame);
+      if (now - lastT < FRAME_MS) return;
+      lastT = now;
+      if (!st) return;
+      const P = propsRef.current;
+      const moving = P.motion;
+      st.t++;
+      ctx.clearRect(0, 0, W, H);
+
+      // stars
+      ctx.fillStyle = "#ffffff";
+      for (const s of st.stars) {
+        const tw = moving ? (0.45 + 0.55 * (0.5 + 0.5 * Math.sin(st.t * 0.04 * s.sp + s.tw))) : 0.8;
+        ctx.globalAlpha = Math.max(0, P.starOpacity * tw);
+        ctx.beginPath(); ctx.arc(s.x, s.y, s.r, 0, 7); ctx.fill();
+      }
+
+      // motes
+      for (const m of st.motes) {
+        if (moving) {
+          m.x += m.vx; m.y += m.vy;
+          if (m.y < -5) { m.y = H + 5; m.x = Math.random() * W; }
+          if (m.x < -5) m.x = W + 5; if (m.x > W + 5) m.x = -5;
+        }
+        ctx.globalAlpha = m.a;
+        const sz = m.r * 6;
+        ctx.drawImage(moteGlow, m.x - sz / 2, m.y - sz / 2, sz, sz);
+      }
+
+      // fireflies
+      if (P.weather === "firefly" || P.weather === "calm") {
+        for (const f of st.ffs) {
+          if (moving) {
+            f.ph += 0.06 * f.sp;
+            f.x += f.vx + Math.sin(f.ph) * 0.3; f.y += f.vy + Math.cos(f.ph * 0.7) * 0.2;
+            if (f.x < 0) f.x = W; if (f.x > W) f.x = 0;
+            if (f.y < H * 0.4) f.vy = Math.abs(f.vy); if (f.y > H) f.vy = -Math.abs(f.vy);
+          }
+          const gl = moving ? (0.25 + 0.75 * (0.5 + 0.5 * Math.sin(f.ph))) : 0.7;
+          ctx.globalAlpha = gl;
+          const sz = f.r * 10;
+          ctx.drawImage(fireGlow, f.x - sz / 2, f.y - sz / 2, sz, sz);
+        }
+      }
+
+      // seasonal petals
+      ctx.globalAlpha = 0.85;
+      ctx.font = "13px serif"; ctx.textAlign = "center"; ctx.textBaseline = "middle";
+      const glyph = GLYPH[P.season] ?? "🌸";
+      for (const p of st.petals) {
+        if (moving) {
+          p.sway += 0.02; p.x += p.vx + Math.sin(p.sway) * 0.5; p.y += p.vy; p.rot += p.vr;
+          if (p.y > H + 12) Object.assign(p, spawnPetal(false));
+          if (p.x < -12) p.x = W + 12; if (p.x > W + 12) p.x = -12;
+        }
+        ctx.save(); ctx.translate(p.x, p.y); ctx.rotate(p.rot); ctx.fillText(glyph, 0, 0); ctx.restore();
+      }
+
+      // shooting stars
+      if (P.weather === "shooting" && moving) {
+        if (Math.random() < 0.02 && st.shooters.length < 3)
+          st.shooters.push({ x: rnd(W * 0.1, W * 0.9), y: rnd(0, H * 0.3), vx: rnd(4, 7), vy: rnd(2, 3.5), life: 1 });
+        ctx.lineWidth = 2;
+        for (const sh of st.shooters) {
+          sh.x += sh.vx; sh.y += sh.vy; sh.life -= 0.02;
+          ctx.globalAlpha = Math.max(0, sh.life);
+          ctx.strokeStyle = "rgba(255,255,255,0.9)";
+          ctx.beginPath(); ctx.moveTo(sh.x, sh.y); ctx.lineTo(sh.x - sh.vx * 10, sh.y - sh.vy * 10); ctx.stroke();
+        }
+        st.shooters = st.shooters.filter((s) => s.life > 0 && s.x < W + 50 && s.y < H + 50);
+      }
+
+      // rain
+      if (P.weather === "rain" && moving) {
+        while (st.rain.length < Math.round(56 * P.density))
+          st.rain.push({ x: Math.random() * W, y: Math.random() * H, len: rnd(8, 16), sp: rnd(6, 11) });
+        ctx.strokeStyle = "rgba(160,190,255,0.32)"; ctx.lineWidth = 1.1; ctx.globalAlpha = 1;
+        for (const d of st.rain) {
+          d.y += d.sp; d.x += 1.2;
+          if (d.y > H) { d.y = -d.len; d.x = Math.random() * W; }
+          ctx.beginPath(); ctx.moveTo(d.x, d.y); ctx.lineTo(d.x - 1.4, d.y - d.len); ctx.stroke();
+        }
+      } else if (st.rain.length) st.rain = [];
+
+      ctx.globalAlpha = 1;
+    }
+
+    resize();
+    raf = requestAnimationFrame(frame);
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas);
+    return () => { cancelAnimationFrame(raf); ro.disconnect(); };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{ position: "absolute", inset: 0, width: "100%", height: "100%", pointerEvents: "none" }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/frontend/app/components/forest/ParticleField.tsx
+++ b/frontend/app/components/forest/ParticleField.tsx
@@ -77,6 +77,7 @@ export default function ParticleField({ phase, season, weather = "firefly", star
       canvas.height = Math.max(1, H * dpr);
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       seed();
+      if (!propsRef.current.motion) frame(performance.now());
     }
 
     const GLYPH: Record<string, string> = { spring: "🌸", summer: "🍃", autumn: "🍁", winter: "❄️" };
@@ -84,12 +85,17 @@ export default function ParticleField({ phase, season, weather = "firefly", star
     let raf = 0, lastT = 0;
 
     function frame(now: number) {
-      raf = requestAnimationFrame(frame);
-      if (now - lastT < FRAME_MS) return;
-      lastT = now;
-      if (!st) return;
       const P = propsRef.current;
       const moving = P.motion;
+      if (moving && now - lastT < FRAME_MS) {
+        raf = requestAnimationFrame(frame);
+        return;
+      }
+      lastT = now;
+      if (!st) {
+        if (moving) raf = requestAnimationFrame(frame);
+        return;
+      }
       st.t++;
       ctx.clearRect(0, 0, W, H);
 
@@ -169,14 +175,15 @@ export default function ParticleField({ phase, season, weather = "firefly", star
       } else if (st.rain.length) st.rain = [];
 
       ctx.globalAlpha = 1;
+      if (moving) raf = requestAnimationFrame(frame);
     }
 
     resize();
-    raf = requestAnimationFrame(frame);
+    if (propsRef.current.motion) raf = requestAnimationFrame(frame);
     const ro = new ResizeObserver(resize);
     ro.observe(canvas);
     return () => { cancelAnimationFrame(raf); ro.disconnect(); };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [reduceMotion]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <canvas

--- a/frontend/app/components/forest/WalkingMorpheus.tsx
+++ b/frontend/app/components/forest/WalkingMorpheus.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useRef, useEffect, useState } from "react";
+import { useReducedMotion } from "framer-motion";
+import MorpheusImage from "@/app/components/MorpheusImage";
+
+const LINES = [
+  "きょうは どんな ゆめ みた？",
+  "きを タップしてみてね",
+  "もりが そだってきたね！",
+  "ゆめを かくと きが おおきくなるよ",
+];
+
+interface WalkingMorpheusProps {
+  /** World width in px (matching pannable fieldW). */
+  fieldW: number;
+  /** Bottom offset in px from the scene's bottom. Default 0. */
+  baseY?: number;
+}
+
+/**
+ * Morpheus walks along the forest floor using direct DOM ref writes so there
+ * are no per-frame React re-renders. The cute chibi photo (MorpheusImage) is
+ * shown in a circular glowing medallion — the same treatment used in ForestGuide.
+ */
+export default function WalkingMorpheus({ fieldW, baseY = 0 }: WalkingMorpheusProps) {
+  const reduceMotion = useReducedMotion();
+  const motion = !reduceMotion;
+  const outerRef = useRef<HTMLDivElement>(null);
+  const photoRef = useRef<HTMLDivElement>(null);
+  const st = useRef({ x: fieldW * 0.5, dir: 1, target: fieldW * 0.7 });
+  const [say, setSay] = useState<string | null>(null);
+
+  // pick new wander targets
+  useEffect(() => {
+    if (!motion) return;
+    const pick = () => { st.current.target = 80 + Math.random() * (fieldW - 160); };
+    pick();
+    const iv = setInterval(pick, 4200 + Math.random() * 2600);
+    return () => clearInterval(iv);
+  }, [fieldW, motion]);
+
+  // speech bubbles
+  useEffect(() => {
+    if (!motion) return;
+    let alive = true;
+    const loop = () => {
+      const wait = 5200 + Math.random() * 4200;
+      setTimeout(() => {
+        if (!alive) return;
+        setSay(LINES[Math.floor(Math.random() * LINES.length)]);
+        setTimeout(() => alive && setSay(null), 3400);
+        loop();
+      }, wait);
+    };
+    loop();
+    return () => { alive = false; };
+  }, [motion]);
+
+  // walk animation (DOM writes, no React state per frame)
+  useEffect(() => {
+    const outer = outerRef.current;
+    const photo = photoRef.current;
+    if (!outer) return;
+    if (!motion) {
+      outer.style.left = st.current.x + "px";
+      return;
+    }
+    let raf: number, t0 = performance.now();
+    const step = (now: number) => {
+      const dt = Math.min(48, now - t0); t0 = now;
+      const s = st.current;
+      const diff = s.target - s.x;
+      if (Math.abs(diff) >= 2) {
+        s.dir = Math.sign(diff) || 1;
+        s.x += Math.sign(diff) * Math.min(Math.abs(diff), 0.045 * dt);
+      }
+      outer.style.left = s.x + "px";
+      if (photo) photo.style.transform = `translateY(${(Math.sin(now / 150) * 3).toFixed(2)}px) scaleX(${s.dir})`;
+      raf = requestAnimationFrame(step);
+    };
+    raf = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(raf);
+  }, [motion]);
+
+  return (
+    <div
+      ref={outerRef}
+      style={{ position: "absolute", left: st.current.x, bottom: baseY, transform: "translateX(-50%)", zIndex: 30, pointerEvents: "none" }}
+    >
+      {/* speech bubble */}
+      {say && (
+        <div
+          style={{
+            position: "absolute", bottom: "100%", left: "50%", transform: "translateX(-50%)",
+            marginBottom: 8, whiteSpace: "nowrap",
+            background: "rgba(255,255,255,0.95)", color: "#312e81",
+            fontSize: 13, fontWeight: 700, padding: "6px 12px", borderRadius: 14,
+            boxShadow: "0 8px 24px rgba(10,8,30,0.4)",
+            animation: "forest-pop 0.3s ease both",
+          }}
+        >
+          {say}
+          <span
+            style={{
+              position: "absolute", top: "100%", left: "50%", transform: "translateX(-50%)",
+              width: 0, height: 0,
+              borderLeft: "6px solid transparent", borderRight: "6px solid transparent",
+              borderTop: "7px solid rgba(255,255,255,0.95)",
+            }}
+          />
+        </div>
+      )}
+
+      {/* circular medallion */}
+      <div ref={photoRef} style={{ transformOrigin: "center" }}>
+        <div
+          style={{
+            width: 72, height: 72, borderRadius: "50%", overflow: "hidden",
+            border: "2px solid rgba(165,180,252,0.7)",
+            background: "radial-gradient(circle at 50% 35%, #efeaff, #d9d3f7)",
+            boxShadow: "0 0 22px 4px rgba(165,180,252,0.55), 0 6px 14px rgba(8,6,28,0.45)",
+          }}
+        >
+          <MorpheusImage variant="home" size={72} priority={false} />
+        </div>
+      </div>
+
+      {/* ground shadow */}
+      <div
+        style={{
+          position: "absolute", bottom: -4, left: "50%", transform: "translateX(-50%)",
+          width: 48, height: 9, borderRadius: "50%",
+          background: "radial-gradient(ellipse, rgba(0,0,0,0.35), transparent 70%)",
+        }}
+        aria-hidden="true"
+      />
+    </div>
+  );
+}

--- a/frontend/e2e/forest-flow.spec.ts
+++ b/frontend/e2e/forest-flow.spec.ts
@@ -112,7 +112,9 @@ test.describe("夢の森", () => {
     await expect(seeTreeButton).toBeVisible();
     await seeTreeButton.click();
 
-    await expect(page).toHaveURL(/\/forest\/1$/);
+    // dev サーバーは /forest/[id] を初回オンデマンドコンパイルするため、
+    // 遷移完了まで余裕を持って待つ（既定5秒だと初回コンパイルに間に合わずflakyになる）
+    await expect(page).toHaveURL(/\/forest\/1$/, { timeout: 30000 });
     await expect(page.getByRole("heading", { name: /の き$/ })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Claude Design リデザインの **段階適用 Phase 3/4**。森を「生きている世界」にします。

> **マージ順の注意**: このPRは Phase 2（[#359](https://github.com/isekaisaru/dreamjournal-app/pull/359)）の上に積んでいます。**#359 を先にマージ**してください。すると本PRの差分は Phase 3 分のみになります。

- **ParticleField（新規・Canvas）**: 星・ほたる・季節パーティクル・浮遊塵を1枚の最適化キャンバスに集約描画（30fps throttle・reduced-motion対応）。ForestScene の DOM版 星/ほたる/SeasonalParticles を置換
- **Critters（新規）**: うさぎ🐰/きつね🦊/はりねずみ🦔/猫🐱/ふくろう🦉/蝶🦋 が森を歩き回る（rAF・DOM直書き）
- **WalkingMorpheus（新規）**: モルペウスが森を歩き、ときどき吹き出しでひとこと
- Critters/WalkingMorpheus は pannable world 内に配置し木と一緒にパン/ズーム。reduced-motion 時は非表示

## 適合で直した点

- **ParticleField 型エラー**: nested `resize()` 内の `canvas` null narrowing 喪失をガード追加で解消
- **Critters のタップ奪い**: `pointerEvents:auto`＋boopで木の上に乗るとタップを奪う不具合 → 装飾専用(none)に変更
- **E2E flaky 解消**: dev の `/forest/[id]` 初回オンデマンドコンパイルに備え遷移待ちを30秒に延長

## Test plan

- [x] `yarn build` 成功・TypeScript 通過
- [x] Jest 205件パス
- [x] E2E `forest-flow.spec.ts` パス
- [ ] Vercel プレビューで小動物/モルペウス歩行・Canvasの星/ほたる/季節パーティクルを確認
- [ ] `prefers-reduced-motion: reduce` で停止/非表示になる