### PR TITLE
feat: 夢の森リデザイン Phase4 — 詳細画面刷新・実の色の凡例（最終）

### DIFF
--- a/frontend/app/components/forest/FruitLegend.tsx
+++ b/frontend/app/components/forest/FruitLegend.tsx
@@ -2,21 +2,29 @@
 
 import { useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import { EMOTION_COLORS } from "@/lib/forest";
 
-const LEGEND_ROWS = [
-  ["#fbbf24", "うれしい・たのしい"],
-  ["#34d399", "あんしん・しあわせ"],
-  ["#22d3ee", "きたい・ふしぎ"],
-  ["#60a5fa", "かなしい"],
-  ["#f87171", "こわい・おこり"],
-  ["#a78bfa", "おどろき"],
-] as const;
+// EMOTION_COLORS のキーに対応するひらがな読み
+const READINGS: Record<string, string> = {
+  喜び: "よろこび",
+  楽しい: "たのしい",
+  幸せ: "しあわせ",
+  愛: "あい",
+  安心: "あんしん",
+  期待: "きたい",
+  驚き: "おどろき",
+  悲しい: "かなしい",
+  不安: "ふあん",
+  怒り: "おこり",
+  恐怖: "こわい",
+  混乱: "こんらん",
+};
 
-/**
- * 実の色 = 感情タグ の凡例。詳細画面（/forest/:id）の左上に配置する。
- * 「みの いろって？」トグルで展開。YumeTree 独自の感情タグ機能と
- * 視覚的につながり、子どもに意味を教えられる。
- */
+const LEGEND_ROWS = Object.entries(EMOTION_COLORS).map(([name, color]) => ({
+  color,
+  label: READINGS[name] ?? name,
+}));
+
 export default function FruitLegend() {
   const [open, setOpen] = useState(false);
 
@@ -39,14 +47,14 @@ export default function FruitLegend() {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: -4, scale: 0.96 }}
             transition={{ duration: 0.18 }}
-            className="mt-2 w-48 rounded-2xl border border-white/20 bg-[rgba(14,14,36,0.92)] p-3 backdrop-blur-xl"
+            className="mt-2 max-h-[60vh] w-48 overflow-y-auto rounded-2xl border border-white/20 bg-[rgba(14,14,36,0.92)] p-3 backdrop-blur-xl"
           >
             <p className="mb-2 text-[12px] leading-relaxed text-white/70">
               みの いろは、ゆめの{" "}
               <b className="text-white">きもち</b> を あらわしているよ。
             </p>
             <div className="flex flex-col gap-1.5">
-              {LEGEND_ROWS.map(([color, label]) => (
+              {LEGEND_ROWS.map(({ color, label }) => (
                 <div key={color} className="flex items-center gap-2">
                   <span
                     className="h-3 w-3 flex-none rounded-full"

--- a/frontend/app/components/forest/FruitLegend.tsx
+++ b/frontend/app/components/forest/FruitLegend.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+const LEGEND_ROWS = [
+  ["#fbbf24", "うれしい・たのしい"],
+  ["#34d399", "あんしん・しあわせ"],
+  ["#22d3ee", "きたい・ふしぎ"],
+  ["#60a5fa", "かなしい"],
+  ["#f87171", "こわい・おこり"],
+  ["#a78bfa", "おどろき"],
+] as const;
+
+/**
+ * 実の色 = 感情タグ の凡例。詳細画面（/forest/:id）の左上に配置する。
+ * 「みの いろって？」トグルで展開。YumeTree 独自の感情タグ機能と
+ * 視覚的につながり、子どもに意味を教えられる。
+ */
+export default function FruitLegend() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="absolute left-4 top-14 z-[42]">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls="fruit-legend-panel"
+        className="flex items-center gap-1.5 rounded-full border border-white/20 bg-[rgba(12,12,32,0.6)] px-3 py-1.5 text-[12px] font-bold text-white/85 backdrop-blur-lg"
+      >
+        🍎 みの いろって？
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            id="fruit-legend-panel"
+            initial={{ opacity: 0, y: -4, scale: 0.96 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -4, scale: 0.96 }}
+            transition={{ duration: 0.18 }}
+            className="mt-2 w-48 rounded-2xl border border-white/20 bg-[rgba(14,14,36,0.92)] p-3 backdrop-blur-xl"
+          >
+            <p className="mb-2 text-[12px] leading-relaxed text-white/70">
+              みの いろは、ゆめの{" "}
+              <b className="text-white">きもち</b> を あらわしているよ。
+            </p>
+            <div className="flex flex-col gap-1.5">
+              {LEGEND_ROWS.map(([color, label]) => (
+                <div key={color} className="flex items-center gap-2">
+                  <span
+                    className="h-3 w-3 flex-none rounded-full"
+                    style={{
+                      background: `radial-gradient(circle at 35% 30%, #fff, ${color})`,
+                      boxShadow: `0 0 6px ${color}`,
+                    }}
+                  />
+                  <span className="text-[12px] text-white/80">{label}</span>
+                </div>
+              ))}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/frontend/app/forest/[profileId]/page.tsx
+++ b/frontend/app/forest/[profileId]/page.tsx
@@ -54,7 +54,7 @@ function DreamPreviewModal({
         initial={reduceMotion ? undefined : { opacity: 0, scale: 0.9, y: 8 }}
         animate={{ opacity: 1, scale: 1, y: 0 }}
         transition={{ type: "spring", stiffness: 300, damping: 22 }}
-        className="w-[min(360px,90%)] rounded-[22px] p-5 text-white"
+        className="w-[min(360px,90%)] max-h-[85vh] overflow-y-auto rounded-[22px] p-5 text-white"
         style={{
           background: "linear-gradient(160deg, rgba(30,28,66,0.96), rgba(18,16,44,0.96))",
           border: `1px solid ${profileColor}55`,

--- a/frontend/app/forest/[profileId]/page.tsx
+++ b/frontend/app/forest/[profileId]/page.tsx
@@ -9,29 +9,121 @@ import { useAuth } from "@/context/AuthContext";
 import Loading from "@/app/loading";
 import { getDreamProfiles, getDreamsForProfile } from "@/lib/apiClient";
 import type { Dream, DreamProfile } from "@/app/types";
-import { RECENT_FRUIT_COUNT } from "@/lib/forest";
-import { getTimePhase, getSeason, getSkyGradient } from "@/lib/forestAtmosphere";
+import {
+  getTimePhase,
+  getSeason,
+  getSkyGradient,
+  getCelestial,
+  HAZE,
+} from "@/lib/forestAtmosphere";
+import {
+  getGrowthLevel,
+  nextLevelInfo,
+  RECENT_FRUIT_COUNT,
+  fruitColor,
+  EMOTION_COLORS,
+} from "@/lib/forest";
 import { toast } from "@/lib/toast";
-import DreamTree from "@/app/components/forest/DreamTree";
+import ForestTree from "@/app/components/forest/ForestTree";
 import PastDreamsList from "@/app/components/forest/PastDreamsList";
 import ForestGuide from "@/app/components/forest/ForestGuide";
 import SeasonalParticles from "@/app/components/forest/SeasonalParticles";
+import FruitLegend from "@/app/components/forest/FruitLegend";
+import ParticleField from "@/app/components/forest/ParticleField";
 
+// ---- 実タップで開く夢プレビューモーダル -----------------------------------
+function DreamPreviewModal({
+  dream,
+  profileColor,
+  onClose,
+}: {
+  dream: Dream | null;
+  profileColor: string;
+  onClose: () => void;
+}) {
+  const reduceMotion = useReducedMotion();
+  if (!dream) return null;
+  const emos = dream.emotions ?? [];
+  return (
+    <div
+      onClick={onClose}
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-black/55 p-5 backdrop-blur-sm"
+    >
+      <motion.div
+        onClick={(e) => e.stopPropagation()}
+        initial={reduceMotion ? undefined : { opacity: 0, scale: 0.9, y: 8 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        transition={{ type: "spring", stiffness: 300, damping: 22 }}
+        className="w-[min(360px,90%)] rounded-[22px] p-5 text-white"
+        style={{
+          background: "linear-gradient(160deg, rgba(30,28,66,0.96), rgba(18,16,44,0.96))",
+          border: `1px solid ${profileColor}55`,
+          boxShadow: `0 24px 60px rgba(6,4,20,0.6), 0 0 0 1px ${profileColor}22`,
+        }}
+      >
+        {/* 日付＋感情チップ */}
+        <div className="mb-2.5 flex items-center gap-2">
+          <span
+            className="h-3.5 w-3.5 flex-none rounded-full"
+            style={{
+              background: `radial-gradient(circle at 35% 30%, #fff, ${fruitColor(dream, profileColor)})`,
+              boxShadow: `0 0 8px ${fruitColor(dream, profileColor)}`,
+            }}
+          />
+          <span className="text-xs text-white/50">{dream.created_at?.slice(0, 10)}</span>
+          {emos[0] && (
+            <span
+              className="ml-auto rounded-full px-2.5 py-0.5 text-[12px] font-bold"
+              style={{
+                background: `${EMOTION_COLORS[emos[0].name] ?? profileColor}22`,
+                color: EMOTION_COLORS[emos[0].name] ?? profileColor,
+              }}
+            >
+              {emos[0].name}
+            </span>
+          )}
+        </div>
+        <h3 className="mb-2 text-[19px] font-black">{dream.title}</h3>
+        {dream.content && (
+          <p className="mb-4 text-[14px] leading-relaxed text-white/75">{dream.content}</p>
+        )}
+        <Link
+          href={`/dream/${dream.id}`}
+          className="mb-2 block w-full rounded-[12px] py-2.5 text-center text-[14px] font-black text-white"
+          style={{ background: `linear-gradient(135deg, ${profileColor}, #7c3aed)` }}
+        >
+          くわしく 見る
+        </Link>
+        <button
+          onClick={onClose}
+          className="w-full rounded-[12px] bg-white/10 py-2 text-[13px] font-bold text-white/70"
+        >
+          とじる
+        </button>
+      </motion.div>
+    </div>
+  );
+}
+
+// ---- メインページ ---------------------------------------------------------
 export default function ForestProfilePage() {
   const { authStatus } = useAuth();
   const router = useRouter();
   const params = useParams();
   const profileId = Number(params.profileId);
-
   const reduceMotion = useReducedMotion();
+
   const [profile, setProfile] = useState<DreamProfile | null>(null);
   const [dreams, setDreams] = useState<Dream[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [preview, setPreview] = useState<Dream | null>(null);
 
-  // 読込時の時刻・季節を1回だけ確定（森シーンと同じ雰囲気に揃える）
   const now = useMemo(() => new Date(), []);
-  const sky = getSkyGradient(getTimePhase(now));
+  const phase = getTimePhase(now);
   const season = getSeason(now);
+  const sky = getSkyGradient(phase);
+  const cel = getCelestial(phase);
+  const haze = HAZE[phase];
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -42,13 +134,12 @@ export default function ForestProfilePage() {
       ]);
       const found = allProfiles.find((p) => p.id === profileId && !p.archived);
       if (!found) {
-        router.replace("/forest"); // 他人/存在しない/アーカイブ済みは森へ
+        router.replace("/forest");
         return;
       }
       setProfile(found);
       setDreams(profileDreams);
     } catch {
-      // 取得失敗時は空白画面に落とさず、森へ退避する
       toast.error("きを よみこめませんでした。");
       router.replace("/forest");
     } finally {
@@ -67,57 +158,151 @@ export default function ForestProfilePage() {
   if (authStatus === "checking" || isLoading) return <Loading />;
   if (!profile) return null;
 
+  const lvl = getGrowthLevel(dreams.length);
+  const nx = nextLevelInfo(dreams.length);
   const pastDreams = dreams.slice(RECENT_FRUIT_COUNT);
+  const newDreamHref = `/dream/new?dream_profile_id=${profile.id}`;
 
   return (
-    <div
-      className="relative min-h-screen pb-24 text-white"
-      style={{ background: sky }}
-    >
-      {/* 季節パーティクル（本文の背面・自前で overflow-hidden するのでルートは clip しない。
-          ルートに overflow-hidden を付けると sticky ヘッダーが流れて消えるため外している） */}
+    <div className="relative min-h-screen pb-24 text-white" style={{ background: sky }}>
+      {/* アンビエント（自前で overflow-hidden するためルートは clip しない＝sticky維持） */}
+      <ParticleField phase={phase} season={season} weather="firefly" starOpacity={cel.starOpacity} />
       <SeasonalParticles season={season} behind />
 
+      {/* 月 */}
+      <div
+        className="pointer-events-none absolute -translate-x-1/2 -translate-y-1/2 rounded-full animate-moon-pulse"
+        style={{
+          left: `${cel.moonXPct}%`,
+          top: `${cel.moonYPct}%`,
+          width: 70,
+          height: 70,
+          background: cel.glow,
+          boxShadow: `0 0 56px 22px ${cel.glow}55`,
+        }}
+        aria-hidden="true"
+      />
+
+      {/* sticky ヘッダー */}
       <header className="sticky top-0 z-10 bg-black/20 backdrop-blur-md">
         <div className="container mx-auto flex h-14 max-w-3xl items-center px-4">
           <Link href="/forest" className="flex items-center text-white/80 hover:text-white">
             <ChevronLeft className="mr-1 h-5 w-5" /> もり
           </Link>
-          <h1 className="ml-3 text-lg font-bold">
+          <h1 className="ml-3 whitespace-nowrap text-lg font-bold">
             {profile.avatar_emoji} {profile.name} の き
           </h1>
+          <span
+            className="ml-auto rounded-full px-3 py-1 text-[13px] font-black"
+            style={{
+              background: `${profile.color}22`,
+              border: `1px solid ${profile.color}66`,
+              color: profile.color,
+            }}
+          >
+            {lvl.name}（{lvl.reading}）
+          </span>
         </div>
       </header>
 
+      {/* 実の色の凡例トグル */}
+      <FruitLegend />
+
+      {/* 地面の霞 */}
+      <div
+        className="pointer-events-none absolute bottom-0 left-0 right-0 h-32"
+        style={{ background: `linear-gradient(to top, ${haze}, transparent)` }}
+        aria-hidden="true"
+      />
+
       <main className="container relative z-[2] mx-auto max-w-3xl px-4 pt-10">
-        {dreams.length === 0 ? (
-          <div className="mt-16 flex flex-col items-center gap-4 text-center">
-            <motion.span
-              className="text-6xl"
-              animate={reduceMotion ? undefined : { y: [-4, 4, -4], scale: [1, 1.04, 1] }}
-              transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
-              aria-hidden="true"
-            >
-              🌱
-            </motion.span>
-            <p className="text-lg font-bold text-white/90">まだ みが ないね</p>
-            <p className="text-sm leading-relaxed text-white/60">
-              ゆめを かいて、さいしょの みを ならせよう。
-            </p>
-            <Link
-              href={`/dream/new?dream_profile_id=${profile.id}`}
-              className="mt-2 rounded-full bg-primary px-5 py-2 text-sm font-bold text-primary-foreground shadow-lg shadow-primary/20"
-            >
-              ゆめを かく
-            </Link>
+        {/* 大きな木 */}
+        <div className="flex justify-center pb-6">
+          {dreams.length === 0 ? (
+            <div className="mt-10 flex flex-col items-center gap-4 text-center">
+              <motion.span
+                className="text-6xl"
+                animate={reduceMotion ? undefined : { y: [-4, 4, -4], scale: [1, 1.04, 1] }}
+                transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
+                aria-hidden="true"
+              >
+                🌱
+              </motion.span>
+              <p className="text-lg font-bold text-white/90">まだ みが ないね</p>
+              <p className="text-sm leading-relaxed text-white/60">
+                ゆめを かいて、さいしょの みを ならせよう。
+              </p>
+              <Link
+                href={newDreamHref}
+                className="mt-2 rounded-full px-5 py-2 text-sm font-bold text-white shadow-lg"
+                style={{ background: "linear-gradient(135deg, #7c3aed, #38bdf8)" }}
+              >
+                ゆめを かく
+              </Link>
+            </div>
+          ) : (
+            <ForestTree
+              profile={profile}
+              dreams={dreams}
+              level={lvl.level}
+              height={380}
+              variant="detail"
+              usePhysics={true}
+              showFruits
+              onTapFruit={(d) => setPreview(d)}
+            />
+          )}
+        </div>
+
+        {/* 進捗バー */}
+        {dreams.length > 0 && (
+          <div className="mx-4 mb-4 flex items-center gap-3 rounded-2xl border border-white/20 bg-black/30 px-4 py-3 backdrop-blur-lg">
+            <span className="whitespace-nowrap text-[13px] font-black" style={{ color: profile.color }}>
+              {lvl.name}
+            </span>
+            <div className="h-2.5 flex-1 overflow-hidden rounded-full bg-white/10">
+              <div
+                className="h-full rounded-full transition-[width] duration-700"
+                style={{ width: `${nx.pct}%`, background: `linear-gradient(90deg, ${profile.color}, #fde68a)` }}
+              />
+            </div>
+            <span className="whitespace-nowrap text-[12px] text-white/60">
+              {nx.atMax ? "さいだいまで そだった！" : `あと ${nx.remaining}こ`}
+            </span>
           </div>
-        ) : (
-          <DreamTree profile={profile} dreams={dreams} />
         )}
+
+        {/* 統計＋CTA */}
+        <div className="mx-4 mb-6 flex gap-2">
+          <div className="flex flex-1 items-center justify-center gap-1.5 rounded-2xl border border-white/20 bg-black/30 py-2 text-[13px] font-bold backdrop-blur-lg">
+            <span>🌙</span>
+            <span style={{ color: "#7dd3fc", fontWeight: 800 }}>{dreams.length}</span> ゆめ
+          </div>
+          <div className="flex flex-1 items-center justify-center gap-1.5 rounded-2xl border border-white/20 bg-black/30 py-2 text-[13px] font-bold backdrop-blur-lg">
+            <span>🍎</span>
+            <span style={{ color: "#fbbf24", fontWeight: 800 }}>
+              {Math.min(dreams.length, RECENT_FRUIT_COUNT)}
+            </span>{" "}
+            みのり
+          </div>
+          <Link
+            href={newDreamHref}
+            className="flex flex-[1.4] items-center justify-center gap-1.5 rounded-2xl py-2 text-[13.5px] font-black text-white shadow-[0_8px_20px_rgba(124,58,237,0.4)]"
+            style={{ background: "linear-gradient(135deg, #7c3aed, #38bdf8)" }}
+          >
+            ✎ ゆめを かく
+          </Link>
+        </div>
+
+        {/* 昔の夢リスト */}
         <PastDreamsList dreams={pastDreams} />
       </main>
 
+      {/* モルペウス案内人（吹き出し＋メダリオンを内包） */}
       <ForestGuide variant="tree" profile={profile} dreamCount={dreams.length} />
+
+      {/* 実タップ時の夢プレビューモーダル */}
+      <DreamPreviewModal dream={preview} profileColor={profile.color} onClose={() => setPreview(null)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Claude Design リデザインの **段階適用 Phase 4/4（最終）**。1本の木の詳細画面を刷新し、ハンドオフ全12項目を完了します。

- **`/forest/[profileId]` 刷新**: 立体SVGの木 `ForestTree`(detail) に光る実を表示。**実タップで夢プレビューモーダル**（タイトル・本文・感情チップ・「くわしく見る」で `/dream/[id]` へ）
- **進捗バー**: 育ちレベルの進捗（`nextLevelInfo`）＋ ゆめ/みのり統計 ＋ 書くCTA
- **FruitLegend（新規）**: 実の色＝感情の凡例トグル「🍎 みの いろって？」（子どもに色の意味を伝える）
- ParticleField(Canvas)＋SeasonalParticles の二層アンビエント・時刻連動の空/月/霞

## 適合で直した点（ハンドオフからの修正）

- **重複モルペウス**: handoff は独自メダリオン＋ForestGuide で右下にモルペウス2つ → メダリオン削除し ForestGuide に統一
- **CTAのプロフィール事前選択維持**: handoff の `/home` → `/dream/new?dream_profile_id=X`（Phase1改善を維持）
- **モーダルを fixed 化**: `absolute` → アプリ慣例の `fixed`（HarvestCelebration と同様、スクロール時も中央表示）
- **FruitLegend**: 未使用の `EMOTION_COLORS` import を除去

## 既知の後始末（別タスク候補）

詳細画面が `DreamTree` から `ForestTree` に移行したため、`DreamTree.tsx` / `DreamFruit.tsx` が未使用になりました（ビルドには影響なし）。別PRで削除可。

## Test plan

- [x] `yarn build` 成功・TypeScript 通過・lint OK
- [x] Jest 205件パス
- [x] E2E `forest-flow.spec.ts` パス
- [ ] Vercel プレビューで実タップ→モーダル・進捗バー・「みの いろって？」凡例を確認
- [ ] `prefers-reduced-motion: reduce` でモーダル/木の演出が静止する
