### PR TITLE
fix: 音声記録の未認証フォールバックを削除

### DIFF
--- a/backend/app/controllers/audio_dreams_controller.rb
+++ b/backend/app/controllers/audio_dreams_controller.rb
@@ -6,10 +6,11 @@ class AudioDreamsController < ApplicationController
   TRIAL_AUDIO_LIMIT = 1 # トライアルユーザーの音声分析上限（Whisper+GPTで高コスト）
 
   def create
-    # ユーザー認証: トークンからcurrent_userを取得するロジックが必要
-    # ApplicationControllerでcurrent_userがセットされている前提
-    # なければ User.first (仮: 開発用) またはエラーにする
-    user = current_user || User.first 
+    user = current_user
+    unless user
+      render json: { error: "認証されていません。ログインしてください。" }, status: :unauthorized
+      return
+    end
 
     # 1. Dreamレコードを作成 (ステータス: pending)
     dream = user.dreams.new(

--- a/backend/spec/requests/audio_dreams_spec.rb
+++ b/backend/spec/requests/audio_dreams_spec.rb
@@ -1,10 +1,50 @@
 require 'rails_helper'
+require 'tempfile'
 
 RSpec.describe 'AudioDreams API', type: :request do
   let!(:user) { create(:user) }
+  let(:audio_tempfile) do
+    file = Tempfile.new(['audio', '.webm'])
+    file.binmode
+    file.write('fake webm audio for request specs')
+    file.rewind
+    file
+  end
+
+  around do |example|
+    original_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    example.run
+  ensure
+    ActiveJob::Base.queue_adapter = original_adapter
+  end
+
+  after do
+    audio_tempfile.close!
+  end
+
+  def audio_upload
+    audio_tempfile.rewind
+    Rack::Test::UploadedFile.new(audio_tempfile.path, 'audio/webm')
+  end
 
   describe 'POST /analyze_audio_dream' do
     context '認証済みユーザーの場合' do
+      it '自分のユーザーに紐づく音声夢を作成する' do
+        expect {
+          post '/analyze_audio_dream',
+               params: { file: audio_upload },
+               headers: auth_headers(user)
+        }.to change { user.dreams.count }.by(1)
+
+        expect(response).to have_http_status(:ok)
+
+        dream = user.dreams.order(:created_at).last
+        expect(dream.title).to include('音声記録')
+        expect(dream.content).to eq('音声解析中...')
+        expect(dream.analysis_status).to eq('pending')
+      end
+
       it 'トライアルの永続カウンタ上限に達している場合は403を返す' do
         user.update!(trial_user: true, trial_audio_count: 1)
 
@@ -24,6 +64,19 @@ RSpec.describe 'AudioDreams API', type: :request do
 
     context '認証されていない場合' do
       it_behaves_like 'unauthorized request', :post, '/analyze_audio_dream'
+
+      it 'User.firstに音声夢を作成しない' do
+        first_user = user
+
+        expect {
+          post '/analyze_audio_dream',
+               params: { file: audio_upload },
+               headers: { 'HOST' => 'backend' }
+        }.not_to change(Dream, :count)
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(first_user.dreams.reload).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

家族ユーザーテストで「音声記録ができない」という報告をきっかけに調査した結果、`AudioDreamsController` に開発用の仮実装がそのまま本番に残っていることが判明。最小差分で修正します。

## 修正内容

**`backend/app/controllers/audio_dreams_controller.rb`**

- `current_user || User.first` → `current_user` のみに変更
- `current_user` が nil の場合は即 `401 Unauthorized` を返して処理を中断
- 既存の音声解析処理・`AnalyzeDreamJob` の流れは変更なし

## セキュリティ上の理由

`User.first` フォールバックは **開発用の仮実装** がそのまま本番に残ったものです。以下のリスクがありました：

- 認証トークンが無効または欠落した状態でリクエストを送ると、DB の最初のユーザー（通常は管理者や最初の登録者）に音声夢が作成される
- Whisper + GPT の二重課金が意図しないユーザーに計上される
- 他ユーザーの夢記録が汚染される

## 追加した spec

| ケース | 検証内容 |
|---|---|
| 認証済み：自分に紐づく音声夢を作成 | `user.dreams.count` が 1 増加・200 OK・title/content/status を検証 |
| 未認証：401 を返す | 既存 shared example `'unauthorized request'` |
| 未認証：`User.first` へ夢を作成しない | `Dream.count` が変化しない・first_user の dreams が空 |
| ActiveJob をキュー待ちにする | `around` ブロックで `:test` adapter に切り替え（Job を実際には実行しない） |

## 実行した確認コマンド

```
ruby -c backend/app/controllers/audio_dreams_controller.rb  # Syntax OK
ruby -c backend/spec/requests/audio_dreams_spec.rb          # Syntax OK
git diff --check                                             # 差分なし

# Docker コンテナ内で実行（dream-journal-app-backend-test-1）:
bundle exec rspec spec/requests/audio_dreams_spec.rb --format documentation
# => 5 examples, 0 failures
```

## 実行できなかったコマンド

```bash
cd backend && bundle exec rspec ...  # ローカル実行
```

**理由**: `puma`, `jbuilder`, `bootsnap` など多数の gem がローカル rbenv 環境に未インストール（`Bundler::GemNotFound`）。バックエンドテストは Docker 内でのみ実行可能なため、稼働中の `dream-journal-app-backend-test-1` コンテナへファイルをコピーして実行・確認済み。

## 差分スコープ

- `backend/app/controllers/audio_dreams_controller.rb` のみ
- `backend/spec/requests/audio_dreams_spec.rb` のみ
- forest / Phase4 関連・フロントエンド・その他ファイルへの変更なし
