### PR TITLE
feat: trial user権限スコープ P1 — trial判定の露出と夢作成件数制限

### DIFF
--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -37,6 +37,20 @@ class ApplicationController < ActionController::API
     end
   end
 
+  # ユーザー情報のJSON表現（trial判定に必要な項目を含める）
+  # 各コントローラ（auth / trial_users 等）で共通利用する
+  def user_json(user)
+    user.as_json(
+      only: [
+        :id, :email, :username, :premium, :age_group, :analysis_tone,
+        :trial_analysis_count, :trial_audio_count
+      ]
+    ).merge(
+      # カラムが nil の既存ユーザーでも frontend が確実に真偽値で判定できるようにする
+      "trial_user" => user.trial_user?
+    )
+  end
+
   def set_token_cookies(access_token, refresh_token)
     # 環境に応じてSameSiteとSecure属性を調整
     same_site_policy = Rails.env.production? ? :none : :lax

--- a/backend/app/controllers/auth_controller.rb
+++ b/backend/app/controllers/auth_controller.rb
@@ -103,9 +103,7 @@ class AuthController < ApplicationController
 
   private
 
-  def user_json(user)
-    user.as_json(only: [:id, :email, :username, :premium, :age_group, :analysis_tone])
-  end
+  # user_json は ApplicationController で共通定義（trial判定項目を含む）
 
   def profile_params
     params.require(:user).permit(:username, :age_group, :analysis_tone)

--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -320,8 +320,10 @@ class DreamsController < ApplicationController
     end
 
     # トライアルユーザーの夢作成件数を制限する（backend側で必ず弾く）
+    # premium? を先に確認する: trial→課金後は premium: true, trial_user: true になり得るため
     def check_trial_dream_limit
       return unless current_user.trial_user?
+      return if current_user.premium?
       return if current_user.dreams.count < TRIAL_DREAM_LIMIT
 
       render json: {

--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -2,7 +2,9 @@ class DreamsController < ApplicationController
   before_action :set_dream_and_authorize_user, only: [:show, :update, :destroy, :analyze, :analysis, :generate_image]
   before_action :check_analysis_limit, only: [:analyze, :preview_analysis]
   before_action :check_monthly_image_limit, only: [:generate_image]
+  before_action :check_trial_dream_limit, only: [:create]
 
+  TRIAL_DREAM_LIMIT             = 7   # トライアルユーザーの夢作成件数上限
   TRIAL_ANALYSIS_LIMIT          = 3   # トライアルユーザーの分析回数上限
   IMAGE_MONTHLY_LIMIT           = 31  # 全ユーザー共通の画像生成月次上限
   FREE_ANALYSIS_MONTHLY_LIMIT   = User::FREE_ANALYSIS_MONTHLY_LIMIT
@@ -315,6 +317,18 @@ class DreamsController < ApplicationController
 
     def dream_profile_json_options
       { only: [:id, :name, :avatar_emoji, :color, :active] }
+    end
+
+    # トライアルユーザーの夢作成件数を制限する（backend側で必ず弾く）
+    def check_trial_dream_limit
+      return unless current_user.trial_user?
+      return if current_user.dreams.count < TRIAL_DREAM_LIMIT
+
+      render json: {
+        error: "お試しで のこせる ゆめは #{TRIAL_DREAM_LIMIT}こ までだよ。アカウント登録すると、ずっと のこせるよ。",
+        limit_reached: true,
+        trial_dream_limit: TRIAL_DREAM_LIMIT
+      }, status: :forbidden
     end
 
     def check_analysis_limit

--- a/backend/app/controllers/trial_users_controller.rb
+++ b/backend/app/controllers/trial_users_controller.rb
@@ -35,7 +35,7 @@ class TrialUsersController < ApplicationController
       render json: error_response[:body], status: error_response[:status]
     else
       set_token_cookies(result[:access_token], result[:refresh_token])
-      render json: { user: result[:user].as_json(only: [:id, :email, :username, :premium, :age_group, :analysis_tone]) }, status: :created
+      render json: { user: user_json(result[:user]) }, status: :created
     end
   end
 end

--- a/backend/spec/requests/auth_spec.rb
+++ b/backend/spec/requests/auth_spec.rb
@@ -92,6 +92,23 @@ RSpec.describe 'Authentication API', type: :request do
         expect(json_response['user']['email']).to eq(user.email)
         expect(json_response['user']['username']).to eq(user.username)
         expect(json_response['user']['premium']).to be false
+        # trial判定に必要な項目が含まれる（通常ユーザーは trial_user=false）
+        expect(json_response['user']['trial_user']).to be false
+        expect(json_response['user']).to have_key('trial_analysis_count')
+        expect(json_response['user']).to have_key('trial_audio_count')
+      end
+    end
+
+    context 'トライアルユーザーの場合' do
+      let!(:trial_user) { create(:user, trial_user: true) }
+
+      it 'trial_user=true と各カウントを返す' do
+        authenticated_get('/auth/me', trial_user)
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response['user']['trial_user']).to be true
+        expect(json_response['user']['trial_analysis_count']).to eq(0)
+        expect(json_response['user']['trial_audio_count']).to eq(0)
       end
     end
 

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -14,6 +14,39 @@ RSpec.describe 'Dreams API', type: :request do
     ]
   end
 
+  describe 'POST /dreams トライアルユーザーの件数制限' do
+    let!(:trial_user) { create(:user, trial_user: true) }
+    let(:trial_dream_params) { { dream: { title: 'ゆめ', content: 'ゆめの ないようを かいたよ。' } } }
+
+    it 'トライアルユーザーは上限件数未満なら作成できる' do
+      create_list(:dream, DreamsController::TRIAL_DREAM_LIMIT - 1, user: trial_user)
+
+      expect {
+        authenticated_post('/dreams', trial_user, params: trial_dream_params)
+      }.to change(Dream, :count).by(1)
+      expect(response).to have_http_status(:created)
+    end
+
+    it 'トライアルユーザーが上限に達したら403で作成されない' do
+      create_list(:dream, DreamsController::TRIAL_DREAM_LIMIT, user: trial_user)
+
+      expect {
+        authenticated_post('/dreams', trial_user, params: trial_dream_params)
+      }.not_to change(Dream, :count)
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)['limit_reached']).to be true
+    end
+
+    it '通常ユーザーは上限件数を超えても作成できる' do
+      create_list(:dream, DreamsController::TRIAL_DREAM_LIMIT, user: user)
+
+      expect {
+        authenticated_post('/dreams', user, params: trial_dream_params)
+      }.to change(Dream, :count).by(1)
+      expect(response).to have_http_status(:created)
+    end
+  end
+
   describe 'POST /dreams' do
     let(:valid_dream_params) do
       {

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe 'Dreams API', type: :request do
       }.to change(Dream, :count).by(1)
       expect(response).to have_http_status(:created)
     end
+
+    it 'premium: true かつ trial_user: true のユーザーは上限を超えても作成できる' do
+      premium_trial_user = create(:user, trial_user: true, premium: true)
+      create_list(:dream, DreamsController::TRIAL_DREAM_LIMIT, user: premium_trial_user)
+
+      expect {
+        authenticated_post('/dreams', premium_trial_user, params: trial_dream_params)
+      }.to change(Dream, :count).by(1)
+      expect(response).to have_http_status(:created)
+    end
   end
 
   describe 'POST /dreams' do

--- a/backend/spec/requests/trial_users_spec.rb
+++ b/backend/spec/requests/trial_users_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'Trial Users API', type: :request do
+  describe 'POST /auth/trial_login' do
+    let(:trial_params) do
+      {
+        trial_user: {
+          email: 'trial_example@example.com',
+          username: 'trial_example',
+          password: 'trial_password_123',
+          password_confirmation: 'trial_password_123'
+        }
+      }
+    end
+
+    it 'トライアルユーザーを作成し、レスポンスに trial 判定項目を含む' do
+      post '/auth/trial_login', params: trial_params, as: :json, headers: { 'HOST' => 'backend' }
+
+      expect(response).to have_http_status(:created)
+
+      user = json_response['user']
+      expect(user['trial_user']).to be true
+      expect(user['trial_analysis_count']).to eq(0)
+      expect(user['trial_audio_count']).to eq(0)
+
+      # Cookieが設定される（registered userと同じ authenticated user 扱い）
+      expect(response.cookies['access_token']).to be_present
+      expect(response.cookies['refresh_token']).to be_present
+    end
+
+    it 'self プロフィールが自動作成される' do
+      post '/auth/trial_login', params: trial_params, as: :json, headers: { 'HOST' => 'backend' }
+
+      created = User.find_by(email: 'trial_example@example.com')
+      expect(created.dream_profiles.where(relationship: 'self').count).to eq(1)
+    end
+  end
+end

--- a/frontend/__tests__/components/TrialBanner.test.tsx
+++ b/frontend/__tests__/components/TrialBanner.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import TrialBanner, {
+  TRIAL_ANALYSIS_LIMIT,
+  TRIAL_AUDIO_LIMIT,
+} from "@/app/components/TrialBanner";
+
+describe("TrialBanner", () => {
+  it("お試し中バッジと本登録CTAを表示する", () => {
+    render(<TrialBanner analysisCount={0} audioCount={0} />);
+
+    expect(screen.getByText("お試し中")).toBeInTheDocument();
+    const cta = screen.getByRole("link", { name: /とうろくして/ });
+    expect(cta).toHaveAttribute("href", "/register");
+  });
+
+  it("使用回数から残回数を計算して表示する", () => {
+    render(<TrialBanner analysisCount={1} audioCount={0} />);
+
+    // AI分析: 3 - 1 = 2回
+    expect(screen.getByText(`${TRIAL_ANALYSIS_LIMIT - 1}回`)).toBeInTheDocument();
+    // 音声: 1 - 0 = 1回
+    expect(screen.getByText(`${TRIAL_AUDIO_LIMIT}回`)).toBeInTheDocument();
+  });
+
+  it("上限を超えても残回数は0で止まる（負数にしない）", () => {
+    render(<TrialBanner analysisCount={5} audioCount={3} />);
+
+    // 残り0回が2箇所（AI分析・音声）
+    expect(screen.getAllByText("0回")).toHaveLength(2);
+  });
+
+  it("カウント未指定でも上限値を残回数として表示する", () => {
+    render(<TrialBanner />);
+
+    expect(screen.getByText(`${TRIAL_ANALYSIS_LIMIT}回`)).toBeInTheDocument();
+    expect(screen.getByText(`${TRIAL_AUDIO_LIMIT}回`)).toBeInTheDocument();
+  });
+});

--- a/frontend/app/components/TrialBanner.tsx
+++ b/frontend/app/components/TrialBanner.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+import { Sparkles } from "lucide-react";
+
+// backend の上限と一致させる（DreamsController::TRIAL_ANALYSIS_LIMIT / AudioDreamsController::TRIAL_AUDIO_LIMIT）
+export const TRIAL_ANALYSIS_LIMIT = 3;
+export const TRIAL_AUDIO_LIMIT = 1;
+
+type TrialBannerProps = {
+  analysisCount?: number;
+  audioCount?: number;
+};
+
+/**
+ * お試しユーザー向けのホームバナー。
+ * 「お試し中」表示・AI分析/音声記録の残回数・本登録CTAをまとめる。
+ */
+export default function TrialBanner({
+  analysisCount = 0,
+  audioCount = 0,
+}: TrialBannerProps) {
+  const analysisRemaining = Math.max(0, TRIAL_ANALYSIS_LIMIT - analysisCount);
+  const audioRemaining = Math.max(0, TRIAL_AUDIO_LIMIT - audioCount);
+
+  return (
+    <div
+      role="region"
+      aria-label="お試し中のお知らせ"
+      className="mb-4 w-full rounded-2xl border border-primary/30 bg-primary/5 p-4"
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <span className="rounded-full bg-primary/15 px-2.5 py-0.5 text-xs font-bold text-primary">
+          お試し中
+        </span>
+        <p className="text-sm font-medium text-foreground">
+          いまは たいけんばん だよ
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground mb-3">
+        <span>
+          AIぶんせき のこり{" "}
+          <span className="font-bold text-foreground">{analysisRemaining}回</span>
+        </span>
+        <span>
+          こえで のこす のこり{" "}
+          <span className="font-bold text-foreground">{audioRemaining}回</span>
+        </span>
+      </div>
+
+      <Link
+        href="/register"
+        className="inline-flex min-h-11 items-center gap-2 rounded-xl bg-primary px-5 py-2.5 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90"
+      >
+        <Sparkles size={16} />
+        とうろくして ぜんぶ つかう
+      </Link>
+    </div>
+  );
+}

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -15,6 +15,7 @@ import DreamStreakBadge from "@/app/components/DreamStreakBadge";
 import SearchBar from "@/app/components/SearchBar";
 import ProfileFilterChips from "@/app/components/ProfileFilterChips";
 import DreamEntryLauncher from "@/app/components/DreamEntryLauncher";
+import TrialBanner from "@/app/components/TrialBanner";
 import DreamAdventurePanel from "@/app/components/DreamAdventurePanel";
 import ForestPreviewWidget from "@/app/components/forest/ForestPreviewWidget";
 import { MorpheusGuideHome } from "@/app/components/MorpheusGuide";
@@ -312,6 +313,13 @@ export default function HomePage() {
     >
       {/* メインセクション: ユーザー名の下に夢リストを表示 */}
       <section className="w-full lg:w-2/3 flex flex-col items-center px-3 md:px-6">
+        {/* お試しユーザー向けバナー（残回数・本登録CTA） */}
+        {user?.trial_user && (
+          <TrialBanner
+            analysisCount={user.trial_analysis_count}
+            audioCount={user.trial_audio_count}
+          />
+        )}
         <MorpheusHero
           expression="cheerful"
           variant="home"

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -41,15 +41,15 @@ export default function Register() {
   const [agreedToTerms, setAgreedToTerms] = useState(false);
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const { login, authStatus } = useAuth();
+  const { login, authStatus, user } = useAuth();
   const router = useRouter();
 
-  // 1. 既にログインしているユーザーをホームページに案内する機能
+  // 認証済みでも trial_user は本登録フォームに進めるため除外する
   useEffect(() => {
-    if (authStatus === "authenticated") {
+    if (authStatus === "authenticated" && !user?.trial_user) {
       router.push("/home");
     }
-  }, [authStatus, router]);
+  }, [authStatus, user, router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/app/types.ts
+++ b/frontend/app/types.ts
@@ -26,6 +26,9 @@ export interface User {
   premium?: boolean;
   age_group?: AgeGroup;
   analysis_tone?: AnalysisTone;
+  trial_user?: boolean;          // お試しユーザーかどうか
+  trial_analysis_count?: number; // お試しのAI分析 使用回数
+  trial_audio_count?: number;    // お試しの音声記録 使用回数
 }
 
 // Backendから直接受け取るユーザー情報の型。IDは数値。
@@ -38,6 +41,9 @@ export interface BackendUser {
   premium?: boolean;
   age_group?: AgeGroup;
   analysis_tone?: AnalysisTone;
+  trial_user?: boolean;
+  trial_analysis_count?: number;
+  trial_audio_count?: number;
 }
 
 export interface Emotion {


### PR DESCRIPTION
## 背景
家族UXテストで、お試しユーザーがホームボタンから `/home` に移動でき、夢の記録やAI分析など登録ユーザーとほぼ同じことができる問題が見つかりました。完全未ログインの問題ではなく、**trial user が JWT Cookie を持つ `current_user` として扱われ、registered user と同じ authenticated user として多くの機能に入れてしまう**問題です。

本PRはその第一歩（P1）。

## 変更内容
### Backend
- `ApplicationController` に共通 `user_json` を新設。`trial_user`（真偽値に正規化）/ `trial_analysis_count` / `trial_audio_count` を含める。`AuthController` と `TrialUsersController` で重複していた定義を一本化。
  - → `login` / `me` / `verify` / `trial_login` の各レスポンスで frontend が trial 判定できる
- `DreamsController#create` に `TRIAL_DREAM_LIMIT = 7` のガードを追加。trial user が上限到達時は **403 Forbidden**。registered / premium は無制限のまま。

### Frontend
- `User` / `BackendUser` 型に `trial_user` / `trial_analysis_count` / `trial_audio_count` を追加
- `/home` に `TrialBanner` を表示（`user.trial_user` 時のみ）：お試し中バッジ・AI分析残回数・音声記録残回数・本登録CTA

## テスト
- **RSpec（103 examples, 0 failures）**
  - `auth/me`・`trial_login` レスポンスに trial 項目が含まれる（通常ユーザーは `trial_user=false`）
  - trial user が夢作成上限到達で403・作成されない / registered は上限を超えても作成できる
- **Jest（4 passed）**
  - `TrialBanner` の残回数計算・本登録CTAリンク・0下限

## 今回やらないこと（スコープ外）
dream_profiles の trial ガード / `/settings` `/profiles` の trial UI制限 / `PATCH /auth/convert_trial` / JWT有効期限延長 / 完全未ログイン `/home` 導線変更 / forest・Phase4 関連。