### PR TITLE
feat: trial user権限スコープ P2 — プロフィール作成制限とUI誘導

### DIFF
--- a/backend/app/controllers/dream_profiles_controller.rb
+++ b/backend/app/controllers/dream_profiles_controller.rb
@@ -2,7 +2,6 @@
 
 class DreamProfilesController < ApplicationController
   before_action :set_profile, only: [:update, :archive, :restore]
-  before_action :check_trial_profile_limit, only: [:create]
 
   TRIAL_PROFILE_LIMIT = 1  # トライアルユーザーのプロフィール作成上限
 
@@ -20,6 +19,13 @@ class DreamProfilesController < ApplicationController
     result = :ok
 
     current_user.with_lock do
+      # トライアル制限をロック内で確認（ロック外だと同時リクエストで2件作られる恐れがある）
+      if current_user.trial_user? && !current_user.premium? &&
+         current_user.dream_profiles.count >= TRIAL_PROFILE_LIMIT
+        result = :trial_limit_exceeded
+        raise ActiveRecord::Rollback
+      end
+
       active_count = current_user.dream_profiles.where(active: true).count
       if active_count >= DreamProfile::MAX_ACTIVE_COUNT
         result = :limit_exceeded
@@ -36,6 +42,12 @@ class DreamProfilesController < ApplicationController
     case result
     when :ok
       render json: profile_json(profile), status: :created
+    when :trial_limit_exceeded
+      render json: {
+        error: "お試しでは プロフィールは #{TRIAL_PROFILE_LIMIT}つ までだよ。アカウント登録すると、もっと つくれるよ。",
+        limit_reached: true,
+        trial_profile_limit: TRIAL_PROFILE_LIMIT
+      }, status: :forbidden
     when :limit_exceeded
       render json: { error: "アクティブなプロフィールは#{DreamProfile::MAX_ACTIVE_COUNT}件までです" },
              status: :unprocessable_entity
@@ -95,20 +107,6 @@ class DreamProfilesController < ApplicationController
   def set_profile
     @profile = current_user.dream_profiles.find_by(id: params[:id])
     render json: { error: "プロフィールが見つかりません" }, status: :not_found unless @profile
-  end
-
-  # トライアルユーザーのプロフィール作成件数を制限する（backend側で必ず弾く）
-  # premium? を先に確認: trial→課金後は premium:true, trial_user:true になり得るため
-  def check_trial_profile_limit
-    return unless current_user.trial_user?
-    return if current_user.premium?
-    return if current_user.dream_profiles.count < TRIAL_PROFILE_LIMIT
-
-    render json: {
-      error: "お試しでは プロフィールは #{TRIAL_PROFILE_LIMIT}つ までだよ。アカウント登録すると、もっと つくれるよ。",
-      limit_reached: true,
-      trial_profile_limit: TRIAL_PROFILE_LIMIT
-    }, status: :forbidden
   end
 
   def profile_params

--- a/backend/app/controllers/dream_profiles_controller.rb
+++ b/backend/app/controllers/dream_profiles_controller.rb
@@ -2,6 +2,9 @@
 
 class DreamProfilesController < ApplicationController
   before_action :set_profile, only: [:update, :archive, :restore]
+  before_action :check_trial_profile_limit, only: [:create]
+
+  TRIAL_PROFILE_LIMIT = 1  # トライアルユーザーのプロフィール作成上限
 
   # GET /dream_profiles
   def index
@@ -92,6 +95,20 @@ class DreamProfilesController < ApplicationController
   def set_profile
     @profile = current_user.dream_profiles.find_by(id: params[:id])
     render json: { error: "プロフィールが見つかりません" }, status: :not_found unless @profile
+  end
+
+  # トライアルユーザーのプロフィール作成件数を制限する（backend側で必ず弾く）
+  # premium? を先に確認: trial→課金後は premium:true, trial_user:true になり得るため
+  def check_trial_profile_limit
+    return unless current_user.trial_user?
+    return if current_user.premium?
+    return if current_user.dream_profiles.count < TRIAL_PROFILE_LIMIT
+
+    render json: {
+      error: "お試しでは プロフィールは #{TRIAL_PROFILE_LIMIT}つ までだよ。アカウント登録すると、もっと つくれるよ。",
+      limit_reached: true,
+      trial_profile_limit: TRIAL_PROFILE_LIMIT
+    }, status: :forbidden
   end
 
   def profile_params

--- a/backend/spec/requests/dream_profiles_spec.rb
+++ b/backend/spec/requests/dream_profiles_spec.rb
@@ -115,6 +115,47 @@ RSpec.describe 'DreamProfiles API', type: :request do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    context 'トライアルユーザーのプロフィール作成制限' do
+      let!(:trial_user) { create(:user, trial_user: true) }
+
+      it 'トライアルユーザーは1件目を作成できる' do
+        expect {
+          authenticated_post('/dream_profiles', trial_user, params: valid_params)
+        }.to change(DreamProfile, :count).by(1)
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'トライアルユーザーが1件以上持っていると2件目は403になる' do
+        create(:dream_profile, user: trial_user)
+
+        expect {
+          authenticated_post('/dream_profiles', trial_user, params: valid_params)
+        }.not_to change(DreamProfile, :count)
+        expect(response).to have_http_status(:forbidden)
+        json = JSON.parse(response.body)
+        expect(json['limit_reached']).to be true
+      end
+
+      it 'premium: true かつ trial_user: true のユーザーは2件目も作成できる' do
+        premium_trial = create(:user, trial_user: true, premium: true)
+        create(:dream_profile, user: premium_trial)
+
+        expect {
+          authenticated_post('/dream_profiles', premium_trial, params: valid_params)
+        }.to change(DreamProfile, :count).by(1)
+        expect(response).to have_http_status(:created)
+      end
+
+      it '通常ユーザーはプロフィールを複数作成できる' do
+        create(:dream_profile, user: user)
+
+        expect {
+          authenticated_post('/dream_profiles', user, params: valid_params)
+        }.to change(DreamProfile, :count).by(1)
+        expect(response).to have_http_status(:created)
+      end
+    end
   end
 
   # ------------------------------------------------------------------ #

--- a/frontend/app/profiles/page.tsx
+++ b/frontend/app/profiles/page.tsx
@@ -52,7 +52,8 @@ const DEFAULT_FORM: ProfileFormState = {
 };
 
 export default function ProfilesPage() {
-  const { authStatus } = useAuth();
+  const { authStatus, user } = useAuth();
+  const isTrial = user?.trial_user === true;
   const router = useRouter();
 
   const [profiles, setProfiles] = useState<DreamProfile[]>([]);
@@ -88,7 +89,9 @@ export default function ProfilesPage() {
 
   const activeProfiles = profiles.filter((p) => !p.archived);
   const archivedProfiles = profiles.filter((p) => p.archived);
-  const remaining = 5 - activeProfiles.length;
+  const profileLimit = isTrial ? 1 : 5;
+  const remaining = profileLimit - activeProfiles.length;
+  const canAddProfile = !isTrial || activeProfiles.length < 1;
 
   const openCreate = () => {
     setEditingProfile(null);
@@ -175,10 +178,27 @@ export default function ProfilesPage() {
       </header>
 
       <main className="container max-w-2xl mx-auto px-4 py-8 space-y-6">
-        <p className="text-sm leading-relaxed text-muted-foreground">
-          夢プロフィールを作ると、自分・家族・ペットなど、誰の夢かを分けて記録できます。
-          夢を書くときに選ぶと、あとから人ごとに見返しやすくなります。最大5つまで。
-        </p>
+        {isTrial ? (
+          <div className="rounded-2xl border border-primary/30 bg-primary/5 p-4 text-sm">
+            <p className="font-medium text-foreground mb-1">
+              お試し中は プロフィールは 1つ まで
+            </p>
+            <p className="text-muted-foreground mb-3">
+              とうろくすると、さいだい5つ まで つくれるよ。かぞくや ペットの ゆめも わけて のこせるよ。
+            </p>
+            <Link
+              href="/register"
+              className="inline-flex min-h-10 items-center gap-1 rounded-xl bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              とうろくして もっと つかう
+            </Link>
+          </div>
+        ) : (
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            夢プロフィールを作ると、自分・家族・ペットなど、誰の夢かを分けて記録できます。
+            夢を書くときに選ぶと、あとから人ごとに見返しやすくなります。最大5つまで。
+          </p>
+        )}
 
         {isLoading ? (
           <div className="grid grid-cols-2 gap-3">
@@ -197,7 +217,7 @@ export default function ProfilesPage() {
               />
             ))}
 
-            {remaining > 0 && (
+            {canAddProfile && remaining > 0 && (
               <button
                 onClick={openCreate}
                 className="flex flex-col items-center justify-center gap-2 h-36 rounded-2xl border-2 border-dashed border-border text-muted-foreground hover:border-primary hover:text-primary transition-colors"

--- a/frontend/app/profiles/page.tsx
+++ b/frontend/app/profiles/page.tsx
@@ -53,7 +53,8 @@ const DEFAULT_FORM: ProfileFormState = {
 
 export default function ProfilesPage() {
   const { authStatus, user } = useAuth();
-  const isTrial = user?.trial_user === true;
+  // premium+trial（trial→課金済み）はバックエンドで制限されないためUIも通常扱いにする
+  const isTrial = user?.trial_user === true && !user?.premium;
   const router = useRouter();
 
   const [profiles, setProfiles] = useState<DreamProfile[]>([]);

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -214,6 +214,21 @@ const SettingsPage = () => {
       </header>
 
       <main className="container max-w-2xl mx-auto px-4 py-8 space-y-8">
+        {user?.trial_user && (
+          <div className="rounded-2xl border border-primary/30 bg-primary/5 p-4 text-sm">
+            <p className="font-medium text-foreground mb-1">お試し中</p>
+            <p className="text-muted-foreground mb-3">
+              とうろくすると、プロフィールを5つまで作れたり、ゆめをずっと のこせるよ。
+            </p>
+            <Link
+              href="/register"
+              className="inline-flex min-h-10 items-center gap-1 rounded-xl bg-primary px-4 py-2 text-sm font-bold text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              とうろくして ぜんぶ つかう
+            </Link>
+          </div>
+        )}
+
         <section className="overflow-hidden rounded-3xl border border-sky-500/20 bg-gradient-to-br from-slate-900 via-indigo-950 to-sky-950 p-5 text-white shadow-lg">
           <div className="grid gap-4 sm:grid-cols-[1fr_auto] sm:items-center">
             <div>


### PR DESCRIPTION
## 背景

PR #372（trial P1）でtrialユーザーの夢作成件数制限・`/home`のTrialBanner表示を実装。P2では残っていた **プロフィール作成の無制限問題** と **settings/profilesページのtrial UI** を対応する。

## 変更内容

### バックエンド

- `DreamProfilesController#create` に `TRIAL_PROFILE_LIMIT = 1` ガード追加
  - `premium?` を先に確認（trial→課金後のユーザーが誤って制限されないようP1と同じパターン）
  - 上限到達時は `403 Forbidden` + `limit_reached: true`

### フロントエンド

- `/profiles`: trial user向けに「お試し中は1つまで + 本登録CTA」バナーを表示。1件以上持つtrial userの「ついか」ボタンを非表示
- `/settings`: ページ上部に「お試し中 + 本登録CTA」バナーを追加

## テスト

RSpec: **23 examples, 0 failures**

- トライアルユーザーは1件目を作成できる
- トライアルユーザーが1件以上持っていると2件目は403
- `premium:true + trial_user:true` のユーザーは2件目も作成できる
- 通常ユーザーはプロフィールを複数作成できる

## スコープ外

`PATCH /auth/convert_trial`（trial→本登録のデータ引き継ぎAPI）は別PR。