### PR TITLE
feat: 音声記録の入口UXを改善（残り回数・録音前の一拍・見た目区別）

### DIFF
--- a/frontend/__tests__/components/DreamEntryLauncher.test.tsx
+++ b/frontend/__tests__/components/DreamEntryLauncher.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import DreamEntryLauncher from "@/app/components/DreamEntryLauncher";
+import { useAuth } from "@/context/AuthContext";
+import useVoiceRecorder from "@/hooks/useVoiceRecorder";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+}));
+
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@/hooks/useVoiceRecorder", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("@/lib/audioAnalysis", () => ({
+  uploadAndAnalyzeAudio: jest.fn(),
+}));
+
+jest.mock("@/lib/toast", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockedUseVoiceRecorder = useVoiceRecorder as jest.MockedFunction<
+  typeof useVoiceRecorder
+>;
+
+type AuthValue = ReturnType<typeof useAuth>;
+
+const makeAuthValue = (user: Partial<NonNullable<AuthValue["user"]>> | null) =>
+  ({
+    authStatus: "authenticated",
+    isLoggedIn: true,
+    user: user as AuthValue["user"],
+    userId: "1",
+    login: jest.fn(),
+    logout: jest.fn(),
+    deleteUser: jest.fn(),
+    error: null,
+  }) as AuthValue;
+
+const startRecording = jest.fn(() => Promise.resolve());
+const stopRecording = jest.fn();
+
+const openSheet = () => {
+  fireEvent.click(screen.getByRole("button", { name: /ゆめを のこす/ }));
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedUseVoiceRecorder.mockReturnValue({
+    isRecording: false,
+    error: null,
+    startRecording,
+    stopRecording,
+  } as ReturnType<typeof useVoiceRecorder>);
+});
+
+describe("DreamEntryLauncher", () => {
+  it("トライアルユーザーには残り回数バッジを表示する", () => {
+    mockedUseAuth.mockReturnValue(
+      makeAuthValue({ trial_user: true, premium: false, trial_audio_count: 0 })
+    );
+    render(<DreamEntryLauncher buttonLabel="ゆめを のこす" />);
+    openSheet();
+
+    expect(screen.getByText("のこり 1かい")).toBeInTheDocument();
+  });
+
+  it("通常ユーザーには残り回数バッジを表示しない", () => {
+    mockedUseAuth.mockReturnValue(makeAuthValue({ trial_user: false }));
+    render(<DreamEntryLauncher buttonLabel="ゆめを のこす" />);
+    openSheet();
+
+    expect(screen.queryByText(/のこり/)).not.toBeInTheDocument();
+  });
+
+  it("残り0回のトライアルユーザーは録音できず本登録CTAが出る", () => {
+    mockedUseAuth.mockReturnValue(
+      makeAuthValue({ trial_user: true, premium: false, trial_audio_count: 1 })
+    );
+    render(<DreamEntryLauncher buttonLabel="ゆめを のこす" />);
+    openSheet();
+
+    const voiceButton = screen.getByRole("button", { name: /こえで はなす/ });
+    fireEvent.click(voiceButton);
+
+    expect(startRecording).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("link", { name: /とうろくして もっと はなす/ })
+    ).toBeInTheDocument();
+  });
+
+  it("こえで はなすは1回目で録音せず、2回目で録音を始める", () => {
+    mockedUseAuth.mockReturnValue(
+      makeAuthValue({ trial_user: false, premium: false })
+    );
+    render(<DreamEntryLauncher buttonLabel="ゆめを のこす" />);
+    openSheet();
+
+    // 1回目: 確認状態になり、まだ録音しない
+    fireEvent.click(screen.getByRole("button", { name: /こえで はなす/ }));
+    expect(startRecording).not.toHaveBeenCalled();
+    expect(screen.getByText("はなしはじめる")).toBeInTheDocument();
+
+    // 2回目: 録音を始める
+    fireEvent.click(screen.getByRole("button", { name: /はなしはじめる/ }));
+    expect(startRecording).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/__tests__/components/DreamEntryLauncher.test.tsx
+++ b/frontend/__tests__/components/DreamEntryLauncher.test.tsx
@@ -1,8 +1,10 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 
 import DreamEntryLauncher from "@/app/components/DreamEntryLauncher";
 import { useAuth } from "@/context/AuthContext";
 import useVoiceRecorder from "@/hooks/useVoiceRecorder";
+import { uploadAndAnalyzeAudio } from "@/lib/audioAnalysis";
+import type { User } from "@/app/types";
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
@@ -30,16 +32,25 @@ const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const mockedUseVoiceRecorder = useVoiceRecorder as jest.MockedFunction<
   typeof useVoiceRecorder
 >;
+const mockedUpload = uploadAndAnalyzeAudio as jest.MockedFunction<
+  typeof uploadAndAnalyzeAudio
+>;
 
 type AuthValue = ReturnType<typeof useAuth>;
 
-const makeAuthValue = (user: Partial<NonNullable<AuthValue["user"]>> | null) =>
+// 可変の user。login で更新され、useAuth は毎レンダーこれを読む
+let currentUser: Partial<User> | null = null;
+
+const makeAuthValue = (): AuthValue =>
   ({
     authStatus: "authenticated",
     isLoggedIn: true,
-    user: user as AuthValue["user"],
+    user: currentUser as AuthValue["user"],
     userId: "1",
-    login: jest.fn(),
+    // login は本物と同じく user を差し替える（残り回数の即時反映を再現）
+    login: ((u: User) => {
+      currentUser = u;
+    }) as AuthValue["login"],
     logout: jest.fn(),
     deleteUser: jest.fn(),
     error: null,
@@ -47,6 +58,7 @@ const makeAuthValue = (user: Partial<NonNullable<AuthValue["user"]>> | null) =>
 
 const startRecording = jest.fn(() => Promise.resolve());
 const stopRecording = jest.fn();
+let capturedOnBlobReady: ((blob: Blob) => Promise<void> | void) | null = null;
 
 const openSheet = () => {
   fireEvent.click(screen.getByRole("button", { name: /ゆめを のこす/ }));
@@ -54,19 +66,23 @@ const openSheet = () => {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockedUseVoiceRecorder.mockReturnValue({
-    isRecording: false,
-    error: null,
-    startRecording,
-    stopRecording,
-  } as ReturnType<typeof useVoiceRecorder>);
+  currentUser = null;
+  capturedOnBlobReady = null;
+  mockedUseAuth.mockImplementation(() => makeAuthValue());
+  mockedUseVoiceRecorder.mockImplementation((opts) => {
+    capturedOnBlobReady = opts?.onBlobReady ?? null;
+    return {
+      isRecording: false,
+      error: null,
+      startRecording,
+      stopRecording,
+    } as ReturnType<typeof useVoiceRecorder>;
+  });
 });
 
 describe("DreamEntryLauncher", () => {
   it("トライアルユーザーには残り回数バッジを表示する", () => {
-    mockedUseAuth.mockReturnValue(
-      makeAuthValue({ trial_user: true, premium: false, trial_audio_count: 0 })
-    );
+    currentUser = { trial_user: true, premium: false, trial_audio_count: 0 };
     render(<DreamEntryLauncher buttonLabel="ゆめを のこす" />);
     openSheet();
 
@@ -74,7 +90,7 @@ describe("DreamEntryLauncher", () => {
   });
 
   it("通常ユーザーには残り回数バッジを表示しない", () => {
-    mockedUseAuth.mockReturnValue(makeAuthValue({ trial_user: false }));
+    currentUser = { trial_user: false };
     render(<DreamEntryLauncher buttonLabel="ゆめを のこす" />);
     openSheet();
 
@@ -82,9 +98,7 @@ describe("DreamEntryLauncher", () => {
   });
 
   it("残り0回のトライアルユーザーは録音できず本登録CTAが出る", () => {
-    mockedUseAuth.mockReturnValue(
-      makeAuthValue({ trial_user: true, premium: false, trial_audio_count: 1 })
-    );
+    currentUser = { trial_user: true, premium: false, trial_audio_count: 1 };
     render(<DreamEntryLauncher buttonLabel="ゆめを のこす" />);
     openSheet();
 
@@ -98,9 +112,7 @@ describe("DreamEntryLauncher", () => {
   });
 
   it("こえで はなすは1回目で録音せず、2回目で録音を始める", () => {
-    mockedUseAuth.mockReturnValue(
-      makeAuthValue({ trial_user: false, premium: false })
-    );
+    currentUser = { trial_user: false, premium: false };
     render(<DreamEntryLauncher buttonLabel="ゆめを のこす" />);
     openSheet();
 
@@ -112,5 +124,27 @@ describe("DreamEntryLauncher", () => {
     // 2回目: 録音を始める
     fireEvent.click(screen.getByRole("button", { name: /はなしはじめる/ }));
     expect(startRecording).toHaveBeenCalledTimes(1);
+  });
+
+  it("トライアルユーザーは録音完了後に残り0回のCTAへ切り替わる", async () => {
+    currentUser = { trial_user: true, premium: false, trial_audio_count: 0 };
+    mockedUpload.mockResolvedValue({ message: "ok" } as Awaited<
+      ReturnType<typeof uploadAndAnalyzeAudio>
+    >);
+    render(<DreamEntryLauncher buttonLabel="ゆめを のこす" />);
+    openSheet();
+    expect(screen.getByText("のこり 1かい")).toBeInTheDocument();
+
+    // 録音完了（onBlobReady 呼び出し）をシミュレート
+    await act(async () => {
+      await capturedOnBlobReady?.(new Blob());
+    });
+
+    // 成功でシートは自動で閉じるので、もう一度開く
+    openSheet();
+    expect(screen.getByText("のこり 0かい")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /とうろくして もっと はなす/ })
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/app/components/DreamEntryLauncher.tsx
+++ b/frontend/app/components/DreamEntryLauncher.tsx
@@ -6,12 +6,14 @@ import { useCallback, useEffect, useState } from "react";
 import { Loader2, Mic, Pencil, Sparkles, Square, X } from "lucide-react";
 
 import type { AnalysisResult } from "@/app/types";
+import { useAuth } from "@/context/AuthContext";
 import useVoiceRecorder from "@/hooks/useVoiceRecorder";
 import { uploadAndAnalyzeAudio } from "@/lib/audioAnalysis";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 
 import { Button, type ButtonProps } from "./ui/button";
+import { TRIAL_AUDIO_LIMIT } from "./TrialBanner";
 
 type DreamEntryLauncherProps = {
   buttonLabel: string;
@@ -31,11 +33,20 @@ export default function DreamEntryLauncher({
   showSparkles = false,
 }: DreamEntryLauncherProps) {
   const router = useRouter();
+  const { user } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
-  const [status, setStatus] = useState<"idle" | "preparing" | "recording">(
-    "idle"
+  const [status, setStatus] = useState<
+    "idle" | "confirming" | "preparing" | "recording"
+  >("idle");
+
+  // お試しユーザー（課金前）だけ音声の残り回数を表示・制限する
+  const isTrial = user?.trial_user === true && !user?.premium;
+  const audioRemaining = Math.max(
+    0,
+    TRIAL_AUDIO_LIMIT - (user?.trial_audio_count ?? 0)
   );
+  const audioLimitReached = isTrial && audioRemaining === 0;
 
   const handleAnalysisResult = useCallback(
     (result: AnalysisResult) => {
@@ -79,6 +90,8 @@ export default function DreamEntryLauncher({
     if (isRecording) {
       stopRecording();
     }
+    // 次に開いたときに「かくにん中」が残らないよう待機状態へ戻す
+    setStatus("idle");
     setIsOpen(false);
   }, [isProcessing, isRecording, stopRecording]);
 
@@ -118,18 +131,31 @@ export default function DreamEntryLauncher({
   const handleVoiceToggle = async () => {
     if (isProcessing) return;
 
-    if (navigator?.vibrate) navigator.vibrate(200);
-
+    // 録音中なら止める
     if (status === "recording") {
+      if (navigator?.vibrate) navigator.vibrate(200);
       stopRecording();
       return;
     }
 
-    setStatus("preparing");
-    try {
-      await startRecording();
-    } catch {
-      setStatus("idle");
+    // お試しの残り回数が0なら開始させない
+    if (audioLimitReached) return;
+
+    // 1回目のタップでは録音せず、説明を見せて一拍おく
+    if (status === "idle") {
+      setStatus("confirming");
+      return;
+    }
+
+    // 「かくにん中」からもう一度押されたら録音を始める
+    if (status === "confirming") {
+      if (navigator?.vibrate) navigator.vibrate(200);
+      setStatus("preparing");
+      try {
+        await startRecording();
+      } catch {
+        setStatus("idle");
+      }
     }
   };
 
@@ -196,10 +222,11 @@ export default function DreamEntryLauncher({
             </div>
 
             <div className="mt-6 space-y-3">
+              {/* ことばで かく：むらさき系のタイルで「文字」を表す */}
               <Link
                 href="/dream/new"
                 onClick={() => setIsOpen(false)}
-                className="flex min-h-16 w-full items-center justify-between rounded-2xl border border-border bg-background px-4 py-4 text-left transition-colors hover:bg-muted"
+                className="flex min-h-16 w-full items-center justify-between rounded-2xl border border-violet-200/70 bg-violet-50/60 px-4 py-4 text-left transition-colors hover:bg-violet-50"
               >
                 <div>
                   <p className="text-base font-bold text-foreground">
@@ -209,41 +236,60 @@ export default function DreamEntryLauncher({
                     おもいだせる ぶんだけ、ゆっくり かけるよ
                   </p>
                 </div>
-                <div className="rounded-full bg-primary/10 p-3 text-primary">
-                  <Pencil className="h-5 w-5" />
+                <div className="rounded-full bg-violet-100 p-3.5 text-violet-600">
+                  <Pencil className="h-6 w-6" />
                 </div>
               </Link>
 
+              {/* こえで はなす：みず色系のタイルで「音声」を表す */}
               <button
                 type="button"
                 onClick={handleVoiceToggle}
-                disabled={isProcessing}
+                disabled={isProcessing || audioLimitReached}
                 className={cn(
                   "flex min-h-16 w-full items-center justify-between rounded-2xl border px-4 py-4 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                   status === "recording"
                     ? "border-red-300 bg-red-50 text-red-700"
-                    : "border-border bg-background hover:bg-muted",
-                  isProcessing ? "cursor-not-allowed opacity-70" : ""
+                    : status === "confirming"
+                      ? "border-sky-400 bg-sky-100/70"
+                      : "border-sky-200/70 bg-sky-50/60 hover:bg-sky-50",
+                  isProcessing || audioLimitReached
+                    ? "cursor-not-allowed opacity-70"
+                    : ""
                 )}
                 aria-pressed={status === "recording"}
               >
                 <div>
-                  <p className="text-base font-bold text-foreground">
-                    {status === "recording"
-                      ? "こえを とめる"
-                      : "こえで はなす"}
-                  </p>
+                  <div className="flex items-center gap-2">
+                    <p className="text-base font-bold text-foreground">
+                      {status === "recording"
+                        ? "こえを とめる"
+                        : status === "confirming"
+                          ? "はなしはじめる"
+                          : "こえで はなす"}
+                    </p>
+                    {/* お試しユーザーには残り回数バッジを見せる */}
+                    {isTrial && status !== "recording" ? (
+                      <span className="rounded-full bg-sky-100 px-2 py-0.5 text-xs font-bold text-sky-700">
+                        のこり {audioRemaining}かい
+                      </span>
+                    ) : null}
+                  </div>
                   <p className="mt-1 text-sm text-muted-foreground">
                     {isProcessing
                       ? "モルペウスが まとめているよ"
                       : status === "recording"
                         ? "おわったら もういちど おしてね"
-                        : "ボタンを おして、そのまま はなしてみよう"}
+                        : status === "confirming"
+                          ? "マイクを つかうよ。よういが できたら もういちど おしてね"
+                          : audioLimitReached
+                            ? "きょうの おためしは おしまい だよ"
+                            : "ボタンを おして、そのまま はなしてみよう"}
                   </p>
                 </div>
                 <div
                   className={cn(
-                    "relative rounded-full p-3",
+                    "relative rounded-full p-3.5",
                     status === "recording"
                       ? "bg-red-100 text-red-600"
                       : "bg-sky-100 text-sky-600"
@@ -254,18 +300,31 @@ export default function DreamEntryLauncher({
                       <span className="absolute inset-0 rounded-full border border-red-300/80 animate-ping" />
                       <span className="absolute -inset-2 rounded-full border border-red-200/70 animate-[ping_1.8s_ease-out_infinite]" />
                     </>
+                  ) : status === "confirming" ? (
+                    <span className="absolute inset-0 rounded-full border border-sky-300/80 animate-ping" />
                   ) : null}
                   {isProcessing ? (
-                    <Loader2 className="h-5 w-5 animate-spin" />
+                    <Loader2 className="h-6 w-6 animate-spin" />
                   ) : status === "recording" ? (
-                    <Square className="h-5 w-5 fill-current" />
+                    <Square className="h-6 w-6 fill-current" />
                   ) : status === "preparing" ? (
-                    <Loader2 className="h-5 w-5 animate-spin" />
+                    <Loader2 className="h-6 w-6 animate-spin" />
                   ) : (
-                    <Mic className="h-5 w-5" />
+                    <Mic className="h-6 w-6" />
                   )}
                 </div>
               </button>
+
+              {/* お試しの音声が残り0回のときは本登録へ誘導する */}
+              {audioLimitReached ? (
+                <Link
+                  href="/register"
+                  onClick={() => setIsOpen(false)}
+                  className="flex items-center justify-center gap-1 rounded-xl bg-primary px-4 py-2.5 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90"
+                >
+                  とうろくして もっと はなす
+                </Link>
+              ) : null}
             </div>
 
             {error ? (

--- a/frontend/app/components/DreamEntryLauncher.tsx
+++ b/frontend/app/components/DreamEntryLauncher.tsx
@@ -33,7 +33,7 @@ export default function DreamEntryLauncher({
   showSparkles = false,
 }: DreamEntryLauncherProps) {
   const router = useRouter();
-  const { user } = useAuth();
+  const { user, login } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
   const [status, setStatus] = useState<
@@ -64,6 +64,15 @@ export default function DreamEntryLauncher({
       setIsProcessing(true);
       try {
         const result = await uploadAndAnalyzeAudio(blob);
+        // お試しユーザーは録音成功で使用回数が1増える。backendの再取得を待たず
+        // グローバルのuserを更新し、残り回数表示（このボタン・/homeのTrialBanner）を
+        // 即座に最新化する（premiumは制限対象外なので更新しない）
+        if (user && user.trial_user && !user.premium) {
+          login({
+            ...user,
+            trial_audio_count: (user.trial_audio_count ?? 0) + 1,
+          });
+        }
         handleAnalysisResult(result);
       } catch (err) {
         console.error("Failed to analyze audio dream", err);
@@ -76,7 +85,7 @@ export default function DreamEntryLauncher({
         setIsProcessing(false);
       }
     },
-    [handleAnalysisResult]
+    [handleAnalysisResult, login, user]
   );
 
   const { isRecording, error, startRecording, stopRecording } =


### PR DESCRIPTION
## 背景

家族UXテストで、ホームの「ゆめを のこす」→ボトムシートの音声記録まわりに3つの混乱点があった。音声バグ修正（PR #371）とtrial権限（#372/#374）の後続として、入口の体験を整える。

## 変更内容（`DreamEntryLauncher.tsx` のみ）

### 1. トライアルの残り回数表示
- お試しユーザー（課金前）に「のこり Nかい」バッジを表示
- 残り0回はボタンを無効化し「とうろくして もっと はなす」CTAを表示
- `useAuth` の `trial_user` / `premium` / `trial_audio_count` と `TRIAL_AUDIO_LIMIT` を参照

### 2. 録音開始前の一拍・説明
- `confirming` 状態を追加し、「こえで はなす」を2タップ化
- 1回目: 録音せず「マイクを つかうよ。よういが できたら もういちど おしてね」と説明
- 2回目: 録音開始

### 3. 2つの選択肢の見た目区別
- 「ことばで かく」= むらさき系タイル / 「こえで はなす」= みず色系タイル
- アイコンを大きくし、色で役割を区別

## テスト

Jest 4件追加（**4 passed**）:
- お試しユーザーに残回数バッジを表示
- 通常ユーザーには非表示
- 残0回は録音不可＋本登録CTA
- 「こえで はなす」は1回目で録音せず2回目で開始