### PR TITLE
fix: 月間ふりかえりで同率1位の感情を複数表示する

### DIFF
--- a/frontend/__tests__/lib/monthlySummary.test.ts
+++ b/frontend/__tests__/lib/monthlySummary.test.ts
@@ -1,0 +1,64 @@
+import { buildMonthlySummary } from "@/lib/monthlySummary";
+import type { Dream } from "@/app/types";
+
+// 感情ラベル変換は恒等にして、同率判定ロジックだけを検証する
+jest.mock("@/app/components/EmotionTag", () => ({
+  getChildFriendlyEmotionLabel: (label: string) => label,
+}));
+
+const dreamWith = (tags: string[]): Dream =>
+  ({
+    id: Math.random(),
+    title: "ゆめ",
+    content: "ないよう",
+    created_at: "2026-06-01T00:00:00Z",
+    analysis_status: "done",
+    analysis_json: { emotion_tags: tags },
+  }) as unknown as Dream;
+
+describe("buildMonthlySummary トップ感情の同率表示", () => {
+  it("1位が単独のときは1つだけ表示する", () => {
+    const dreams = [
+      dreamWith(["うれしい"]),
+      dreamWith(["うれしい"]),
+      dreamWith(["こわい"]),
+    ];
+    const summary = buildMonthlySummary(dreams, "6がつ");
+
+    expect(summary.message).toContain("いちばん多かった きもちは「うれしい」だったよ。");
+    expect(summary.message).not.toContain("と「");
+  });
+
+  it("1位が同率のときは複数を「と」でつなぐ", () => {
+    const dreams = [
+      dreamWith(["うれしい"]),
+      dreamWith(["うれしい"]),
+      dreamWith(["こわい"]),
+      dreamWith(["こわい"]),
+    ];
+    const summary = buildMonthlySummary(dreams, "6がつ");
+
+    expect(summary.message).toContain(
+      "いちばん多かった きもちは「うれしい」と「こわい」だったよ。"
+    );
+  });
+
+  it("同率が多すぎるときは3つまで表示し「など」をつける", () => {
+    const dreams = [
+      dreamWith(["A"]),
+      dreamWith(["B"]),
+      dreamWith(["C"]),
+      dreamWith(["D"]),
+    ];
+    const summary = buildMonthlySummary(dreams, "6がつ");
+
+    expect(summary.message).toContain("「A」と「B」と「C」など");
+  });
+
+  it("感情タグが無いときは案内メッセージを出す", () => {
+    const dreams = [dreamWith([]), dreamWith([])];
+    const summary = buildMonthlySummary(dreams, "6がつ");
+
+    expect(summary.message).toContain("これから きもちタグが ふえると");
+  });
+});

--- a/frontend/lib/monthlySummary.ts
+++ b/frontend/lib/monthlySummary.ts
@@ -45,6 +45,12 @@ export function buildMonthlySummary(
     .slice(0, 3)
     .map(([label, count]) => ({ label, count }));
 
+  // 同率1位をすべて拾う（メッセージで「と」つなぎにするため）
+  const maxCount = Math.max(0, ...Object.values(emotionCounts));
+  const topTiedLabels = Object.entries(emotionCounts)
+    .filter(([, count]) => count === maxCount)
+    .map(([label]) => label);
+
   const highlights = [
     `${dreamCount}この ゆめ`,
     `${recordedDays}にち きろく`,
@@ -52,8 +58,13 @@ export function buildMonthlySummary(
   ];
 
   let message = `${fallbackMonthLabel}は ${dreamCount}この ゆめを きろくしたよ。`;
-  if (topEmotions[0]) {
-    message += ` いちばん多かった きもちは「${topEmotions[0].label}」だったよ。`;
+  if (topTiedLabels.length > 0) {
+    // 多すぎると読みにくいので3つまで表示し、残りは「など」でまとめる
+    const TIE_DISPLAY_LIMIT = 3;
+    const shown = topTiedLabels.slice(0, TIE_DISPLAY_LIMIT);
+    const joined = shown.map((label) => `「${label}」`).join("と");
+    const suffix = topTiedLabels.length > TIE_DISPLAY_LIMIT ? "など" : "";
+    message += ` いちばん多かった きもちは${joined}${suffix}だったよ。`;
   } else if (dreamCount > 0) {
     message += " これから きもちタグが ふえると、もっと たのしく ふりかえれるよ。";
   }


### PR DESCRIPTION
## 背景

月間ふりかえりページの「いちばん多かった きもちは『X』だったよ」というメッセージが、同率1位の感情があっても `topEmotions[0]` の1つしか表示していなかった（家族UXテストの指摘）。

## 変更内容（`monthlySummary.ts` のみ）

- 最大カウントと同数の感情をすべて拾い、「と」でつないで表示
  - 単独: 「うれしい」だったよ
  - 同率: 「うれしい」と「こわい」だったよ
- 読みやすさのため3つまで表示し、超過分は「など」でまとめる
- `topEmotions`（チップ一覧）は元から同率を並べて表示しており変更不要 → 最小差分

## テスト

Jest 4件追加（**4 passed**）:
- 1位が単独 → 1つだけ表示
- 1位が同率2件 → 「と」でつなぐ
- 同率多数 → 3つまで＋「など」
- 感情タグなし → 案内メッセージ

## スコープ外

週間サマリー（`DreamStatsWidget.tsx` の「今週いちばん多い きもち」）も同じ構造だが、本PRは月間に限定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)