### PR TITLE
feat: 夢クエストの条件緩和と達成時の報酬表示

### DIFF
--- a/frontend/__tests__/components/DreamAdventurePanel.test.tsx
+++ b/frontend/__tests__/components/DreamAdventurePanel.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, within } from "@testing-library/react";
+
+import DreamAdventurePanel from "@/app/components/DreamAdventurePanel";
+import type { Dream } from "@/app/types";
+
+// アニメーション・画像は描画に不要なので素の要素に置き換える
+jest.mock("framer-motion", () => ({
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_target, tag: string) =>
+        ({
+          children,
+          ...props
+        }: {
+          children?: React.ReactNode;
+          [key: string]: unknown;
+        }) => {
+          const Tag = tag as keyof JSX.IntrinsicElements;
+          // framer 固有の props は除去して描画する
+          const {
+            initial: _i,
+            animate: _a,
+            transition: _t,
+            ...rest
+          } = props as Record<string, unknown>;
+          return <Tag {...rest}>{children}</Tag>;
+        },
+    }
+  ),
+}));
+
+jest.mock("@/app/components/MorpheusImage", () => ({
+  __esModule: true,
+  default: () => <div data-testid="morpheus" />,
+}));
+
+const today = new Date().toLocaleDateString("en-CA", {
+  timeZone: "Asia/Tokyo",
+});
+
+const dream = (overrides: Partial<Dream> = {}): Dream =>
+  ({
+    id: Math.random(),
+    title: "ゆめ",
+    content: "ないよう",
+    created_at: `${today}T01:00:00+09:00`,
+    ...overrides,
+  }) as unknown as Dream;
+
+const dreamWithEmotion = () =>
+  dream({ analysis_json: { emotion_tags: ["うれしい"] } } as Partial<Dream>);
+
+describe("DreamAdventurePanel 夢クエスト", () => {
+  it("感情タグが1つ以上あれば「きもちを1つえらぶ」が達成になる", () => {
+    render(<DreamAdventurePanel dreams={[dreamWithEmotion()]} />);
+
+    const quest = screen.getByText("きもちを1つえらぶ").closest("li");
+    expect(quest).not.toBeNull();
+    expect(within(quest as HTMLElement).getByText("1/1")).toBeInTheDocument();
+    expect(within(quest as HTMLElement).getByText("★")).toBeInTheDocument();
+  });
+
+  it("感情タグが無いと「きもちを1つえらぶ」は未達成になる", () => {
+    render(<DreamAdventurePanel dreams={[dream()]} />);
+
+    const quest = screen.getByText("きもちを1つえらぶ").closest("li");
+    expect(within(quest as HTMLElement).getByText("0/1")).toBeInTheDocument();
+    expect(within(quest as HTMLElement).queryByText("★")).not.toBeInTheDocument();
+  });
+
+  it("月間クエストの文言が「今月の夢を5つあつめる」になっている", () => {
+    render(<DreamAdventurePanel dreams={[dream()]} />);
+
+    expect(screen.getByText("今月の夢を5つあつめる")).toBeInTheDocument();
+    expect(screen.queryByText("今月の夢を5つのこす")).not.toBeInTheDocument();
+  });
+
+  it("達成済みクエストがあると達成メッセージ（報酬表示）が出る", () => {
+    render(<DreamAdventurePanel dreams={[dreamWithEmotion()]} />);
+
+    // 今日の夢1つ＋感情タグの2クエスト達成
+    expect(screen.getByText("夢クエスト達成中！")).toBeInTheDocument();
+    expect(screen.getByText("小さな夢バッジに近づいたよ")).toBeInTheDocument();
+  });
+
+  it("達成クエストが無いと報酬表示は出ない", () => {
+    // 今日でも今月でもない過去の、感情タグ無し夢のみ → 達成0
+    const past = dream({ created_at: "2000-01-01T00:00:00+09:00" });
+    render(<DreamAdventurePanel dreams={[past]} />);
+
+    expect(screen.queryByText(/夢クエスト.*達成/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/app/components/DreamAdventurePanel.tsx
+++ b/frontend/app/components/DreamAdventurePanel.tsx
@@ -71,6 +71,28 @@ function getMorpheusVariant(completedQuestCount: number): MorpheusImageVariant {
   return "landing";
 }
 
+// クエスト達成時の「できた！」を伝える報酬メッセージ
+// 達成数が増えるほど、すこしずつ喜びが大きくなる
+function getRewardMessage(completedQuestCount: number, totalQuestCount: number) {
+  if (completedQuestCount <= 0) return null;
+  if (completedQuestCount >= totalQuestCount) {
+    return {
+      title: "今日の夢クエスト ぜんぶ達成！",
+      detail: "森に新しいきらめきが増えたよ",
+    };
+  }
+  if (completedQuestCount >= 2) {
+    return {
+      title: "夢クエスト達成中！",
+      detail: "小さな夢バッジに近づいたよ",
+    };
+  }
+  return {
+    title: "今日の夢クエスト達成！",
+    detail: "夢の地図が少し光ったよ",
+  };
+}
+
 export default function DreamAdventurePanel({ dreams }: DreamAdventurePanelProps) {
   const todayStr = new Date().toLocaleDateString("en-CA", {
     timeZone: "Asia/Tokyo",
@@ -94,14 +116,14 @@ export default function DreamAdventurePanel({ dreams }: DreamAdventurePanelProps
     },
     {
       id: "emotion-star",
-      label: "きもちタグつきの夢を3つのこす",
-      helper: "夢を書くとき「きもち」をえらぶとたまるよ",
-      done: taggedDreamCount >= 3,
-      progressLabel: `${Math.min(taggedDreamCount, 3)}/3`,
+      label: "きもちを1つえらぶ",
+      helper: "夢を書いたあと、今のきもちを1つえらんでみよう",
+      done: taggedDreamCount >= 1,
+      progressLabel: `${Math.min(taggedDreamCount, 1)}/1`,
     },
     {
       id: "month-map",
-      label: "今月の夢を5つのこす",
+      label: "今月の夢を5つあつめる",
       helper: "5こたまると、月のまとめが楽しくなるよ",
       done: currentMonthDreams.length >= 5,
       progressLabel: `${Math.min(currentMonthDreams.length, 5)}/5`,
@@ -112,6 +134,7 @@ export default function DreamAdventurePanel({ dreams }: DreamAdventurePanelProps
   const progress = Math.round((completedQuestCount / quests.length) * 100);
   const title = getAdventureTitle(dreams.length, completedQuestCount);
   const morpheusVariant = getMorpheusVariant(completedQuestCount);
+  const reward = getRewardMessage(completedQuestCount, quests.length);
   const hasWindowBadge = imageDreamCount > 0;
   const hasStreakBadge = currentStreak >= 3;
   const hasMonthBadge = currentMonthDreams.length >= 5;
@@ -189,6 +212,31 @@ export default function DreamAdventurePanel({ dreams }: DreamAdventurePanelProps
           </motion.li>
         ))}
       </ul>
+
+      {reward && (
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.32 }}
+          role="status"
+          className="relative mt-4 flex items-center gap-3 rounded-2xl border border-amber-200/70 bg-gradient-to-r from-amber-50 to-sky-50 px-3 py-3 dark:border-amber-300/20 dark:from-amber-300/10 dark:to-sky-300/10"
+        >
+          <span
+            className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-amber-200 text-base text-amber-900 dark:bg-amber-300/30 dark:text-amber-100"
+            aria-hidden="true"
+          >
+            <Sparkles className="h-4 w-4" />
+          </span>
+          <div className="min-w-0">
+            <p className="text-sm font-bold leading-snug text-amber-900 dark:text-amber-100">
+              {reward.title}
+            </p>
+            <p className="mt-0.5 text-xs text-amber-800/80 dark:text-amber-100/80">
+              {reward.detail}
+            </p>
+          </div>
+        </motion.div>
+      )}
 
       <div className="relative mt-4 rounded-2xl border border-white/70 bg-white/60 px-3 py-3 dark:border-white/10 dark:bg-white/5">
         <div className="mb-2 flex items-center gap-2 text-sm font-bold">


### PR DESCRIPTION
## 背景

ホームの「今日の小さな夢クエスト」(`DreamAdventurePanel`) の2つ目「きもちタグつきの夢を3つのこす」が、YumeTreeの「がんばらなくて大丈夫。できたぶんだけ、夢の地図が少しずつ光るよ。」というやさしい世界観に対して少し重かった。また達成しても「できた！」と伝わる瞬間の手応えが弱かった（家族UXテストの指摘）。

## 変更内容（`DreamAdventurePanel.tsx` のみ）

### 1. クエスト条件の緩和
- 「きもちタグつきの夢を3つのこす」(0/3〜3/3) → **「きもちを1つえらぶ」(0/1〜1/1)**
- 感情タグが1つでも付いた夢があれば達成（既存の `taggedDreamCount` を `>=1` に）
- helper も「夢を書いたあと、今のきもちを1つえらんでみよう」にやさしく

### 2. 月間クエストの文言
- 「今月の夢を5つのこす」→ **「今月の夢を5つあつめる」**（条件の5件は据え置き）

### 3. 達成時の報酬表示
- クエスト一覧の直後に達成バナーを追加。達成数で文言が変化：
  - 1つ達成: 「今日の夢クエスト達成！／夢の地図が少し光ったよ」
  - 2つ達成: 「夢クエスト達成中！／小さな夢バッジに近づいたよ」
  - 全達成: 「今日の夢クエスト ぜんぶ達成！／森に新しいきらめきが増えたよ」
- 既存の amber/sky 配色・framer-motion・dark対応に合わせた最小UI

## なぜ条件を緩和したか

「3つ」は毎日の達成には遠く、途中であきらめやすい。YumeTreeは「がんばらなくて大丈夫」がモットーなので、1つでも気持ちを選べば達成にし、できたことを毎日きちんとほめることで、小さな達成感を継続的に得られるようにした。

## テスト

Jest 5件追加（**5 passed**）:
- 感情タグ1つ以上で「きもちを1つえらぶ」が達成（★/1/1）
- 感情タグ無しは未達成（0/1）
- 月間クエスト文言が「今月の夢を5つあつめる」
- 達成済みクエストがあると報酬表示が出る
- 達成0なら報酬表示は出ない

## スコープ外

backend/API/DB変更、Trial P3、ライトテーマ全体改善、アカウント削除UI、週間サマリー同率表示、大規模デザイン刷新。