### PR TITLE
fix: スマホ音声入力でマイク権限取得と録音形式判定を安定化

### DIFF
--- a/frontend/__tests__/hooks/useVoiceRecorder.test.tsx
+++ b/frontend/__tests__/hooks/useVoiceRecorder.test.tsx
@@ -1,0 +1,118 @@
+import { act, renderHook } from "@testing-library/react";
+
+import useVoiceRecorder from "@/hooks/useVoiceRecorder";
+
+jest.mock("@/lib/toast", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+type RecorderOptions = ConstructorParameters<typeof MediaRecorder>[1];
+
+const makeTrack = () =>
+  ({
+    muted: false,
+    stop: jest.fn(),
+  }) as unknown as MediaStreamTrack;
+
+const makeStream = () => {
+  const track = makeTrack();
+  return {
+    getAudioTracks: jest.fn(() => [track]),
+    getTracks: jest.fn(() => [track]),
+  } as unknown as MediaStream;
+};
+
+describe("useVoiceRecorder", () => {
+  let constructorOptions: Array<RecorderOptions | undefined>;
+  let getUserMedia: jest.Mock;
+  let enumerateDevices: jest.Mock;
+
+  beforeEach(() => {
+    constructorOptions = [];
+    getUserMedia = jest.fn(async () => makeStream());
+    enumerateDevices = jest.fn(async () => []);
+
+    class FakeMediaRecorder {
+      static isTypeSupported = jest.fn(() => false);
+      state = "inactive";
+      ondataavailable: ((event: BlobEvent) => void) | null = null;
+      onstop: (() => void) | null = null;
+
+      constructor(_stream: MediaStream, options?: RecorderOptions) {
+        constructorOptions.push(options);
+      }
+
+      start() {
+        this.state = "recording";
+      }
+
+      stop() {
+        this.state = "inactive";
+        this.onstop?.();
+      }
+    }
+
+    Object.defineProperty(global, "MediaRecorder", {
+      configurable: true,
+      writable: true,
+      value: FakeMediaRecorder,
+    });
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia,
+        enumerateDevices,
+      },
+    });
+  });
+
+  it("マイク権限取得後にデバイス一覧を確認する", async () => {
+    const calls: string[] = [];
+    getUserMedia.mockImplementation(async () => {
+      calls.push("getUserMedia");
+      return makeStream();
+    });
+    enumerateDevices.mockImplementation(async () => {
+      calls.push("enumerateDevices");
+      return [];
+    });
+
+    const { result } = renderHook(() =>
+      useVoiceRecorder({ onBlobReady: jest.fn() })
+    );
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    expect(calls).toEqual(["getUserMedia", "enumerateDevices"]);
+  });
+
+  it("対応MIMEが見つからない場合はmimeTypeなしでMediaRecorderを作る", async () => {
+    const { result } = renderHook(() =>
+      useVoiceRecorder({ onBlobReady: jest.fn() })
+    );
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    expect(constructorOptions).toEqual([undefined]);
+  });
+
+  it("デバイス一覧取得に失敗しても最初に取得したマイクで録音を始める", async () => {
+    enumerateDevices.mockRejectedValue(new Error("not allowed"));
+
+    const { result } = renderHook(() =>
+      useVoiceRecorder({ onBlobReady: jest.fn() })
+    );
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+    expect(constructorOptions).toHaveLength(1);
+    expect(result.current.isRecording).toBe(true);
+  });
+});

--- a/frontend/app/api/analyze_audio_dream/route.ts
+++ b/frontend/app/api/analyze_audio_dream/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    if (!audioFile.type.startsWith("audio/")) {
+    if (audioFile.type && !audioFile.type.startsWith("audio/")) {
       return NextResponse.json(
         { error: "無効なファイルタイプです。" },
         { status: 400 }

--- a/frontend/hooks/useVoiceRecorder.ts
+++ b/frontend/hooks/useVoiceRecorder.ts
@@ -5,9 +5,41 @@ import { toast } from "@/lib/toast";
 
 const MIN_BLOB_SIZE = 2048; // 2KB 未満は「ほぼ無音」とみなす
 const MIN_DURATION_MS = 800; // 0.8 秒未満の録音は無効
+const AUDIO_CONSTRAINTS: MediaTrackConstraints = {
+  echoCancellation: true,
+  noiseSuppression: true,
+  autoGainControl: true,
+};
+const AUDIO_MIME_TYPES = [
+  "audio/webm;codecs=opus",
+  "audio/webm",
+  "audio/ogg;codecs=opus",
+  "audio/mp4",
+  "audio/aac",
+];
 
 type UseVoiceRecorderOptions = {
   onBlobReady: (blob: Blob) => void;
+};
+
+export const selectSupportedAudioMimeType = (): string => {
+  if (
+    typeof MediaRecorder === "undefined" ||
+    typeof MediaRecorder.isTypeSupported !== "function"
+  ) {
+    return "";
+  }
+
+  return AUDIO_MIME_TYPES.find((type) => MediaRecorder.isTypeSupported(type)) ?? "";
+};
+
+export const createAudioRecorder = (
+  stream: MediaStream,
+  mimeType: string
+): MediaRecorder => {
+  return mimeType
+    ? new MediaRecorder(stream, { mimeType })
+    : new MediaRecorder(stream);
 };
 
 const useVoiceRecorder = ({ onBlobReady }: UseVoiceRecorderOptions) => {
@@ -31,13 +63,26 @@ const useVoiceRecorder = ({ onBlobReady }: UseVoiceRecorderOptions) => {
     startedAtRef.current = null;
   }, []);
 
-  // 「モニター系の無音マイク」を避けてマイクを選択
+  // 先に権限を取得し、許可後に可能なら「モニター系の無音マイク」を避けて選択する
   const getPreferredAudioStream = async (): Promise<MediaStream> => {
     if (!navigator.mediaDevices?.getUserMedia) {
       throw new Error("このブラウザは音声録音に対応していません。");
     }
 
-    const devices = await navigator.mediaDevices.enumerateDevices();
+    const initialStream = await navigator.mediaDevices.getUserMedia({
+      audio: AUDIO_CONSTRAINTS,
+    });
+
+    if (!navigator.mediaDevices.enumerateDevices) {
+      return initialStream;
+    }
+
+    let devices: MediaDeviceInfo[] = [];
+    try {
+      devices = await navigator.mediaDevices.enumerateDevices();
+    } catch {
+      return initialStream;
+    }
     const inputs = devices.filter((d) => d.kind === "audioinput");
 
     const realMics = inputs.filter((d) => {
@@ -51,18 +96,22 @@ const useVoiceRecorder = ({ onBlobReady }: UseVoiceRecorderOptions) => {
 
     const target = realMics[0] ?? inputs[0];
 
-    if (!target) {
-      throw new Error("利用できるマイクが見つかりません。");
+    if (!target?.deviceId) {
+      return initialStream;
     }
 
-    return navigator.mediaDevices.getUserMedia({
-      audio: {
-        deviceId: target.deviceId ? { exact: target.deviceId } : undefined,
-        echoCancellation: true,
-        noiseSuppression: true,
-        autoGainControl: true,
-      },
-    });
+    try {
+      const preferredStream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          ...AUDIO_CONSTRAINTS,
+          deviceId: { exact: target.deviceId },
+        },
+      });
+      initialStream.getTracks().forEach((track) => track.stop());
+      return preferredStream;
+    } catch {
+      return initialStream;
+    }
   };
 
   const startRecording = useCallback(async () => {
@@ -77,6 +126,9 @@ const useVoiceRecorder = ({ onBlobReady }: UseVoiceRecorderOptions) => {
       if (!track) {
         throw new Error("音声トラックの取得に失敗しました。");
       }
+      if (typeof MediaRecorder === "undefined") {
+        throw new Error("このブラウザは音声録音に対応していません。");
+      }
 
       // Chrome × モニターで「無音デバイス」を掴んでないかチェック
       setTimeout(() => {
@@ -90,26 +142,10 @@ const useVoiceRecorder = ({ onBlobReady }: UseVoiceRecorderOptions) => {
         }
       }, 500);
 
-      // MediaRecorder の MIME タイプ判定（record-test から移植）
-      let mime = "";
-      if (typeof MediaRecorder !== "undefined") {
-        if (MediaRecorder.isTypeSupported("audio/webm;codecs=opus")) {
-          mime = "audio/webm;codecs=opus";
-        } else if (MediaRecorder.isTypeSupported("audio/webm")) {
-          mime = "audio/webm";
-        } else if (MediaRecorder.isTypeSupported("audio/ogg;codecs=opus")) {
-          mime = "audio/ogg;codecs=opus";
-        } else if (MediaRecorder.isTypeSupported("audio/mp4")) {
-          mime = "audio/mp4"; // Safari fallback
-        } else if (MediaRecorder.isTypeSupported("audio/aac")) {
-          mime = "audio/aac";
-        }
-      }
-      mimeTypeRef.current = mime || "audio/webm";
+      const mime = selectSupportedAudioMimeType();
+      mimeTypeRef.current = mime;
 
-      const recorder = new MediaRecorder(stream, {
-        mimeType: mimeTypeRef.current,
-      });
+      const recorder = createAudioRecorder(stream, mimeTypeRef.current);
       mediaRecorderRef.current = recorder;
       chunksRef.current = [];
 
@@ -125,7 +161,12 @@ const useVoiceRecorder = ({ onBlobReady }: UseVoiceRecorderOptions) => {
             ? performance.now() - startedAtRef.current
             : 0;
 
-        const blob = new Blob(chunksRef.current, { type: mimeTypeRef.current });
+        const recordedChunk = chunksRef.current.find(
+          (chunk): chunk is Blob =>
+            chunk instanceof Blob && chunk.type.startsWith("audio/")
+        );
+        const blobType = mimeTypeRef.current || recordedChunk?.type || "";
+        const blob = new Blob(chunksRef.current, { type: blobType });
 
         console.log("Debug: Recording stopped", {
           blobSize: blob.size,


### PR DESCRIPTION
## Summary

2026-06-21の家族UXテストで、スマホから音声入力がうまく動かない問題が見つかりました。
スマホブラウザでは、マイク権限取得前の enumerateDevices() や audio/webm の固定指定が失敗しやすい可能性があるため、getUserMedia() を先に呼び、MediaRecorder の MIME type は対応確認できた場合だけ指定するようにしました。

## Changes

- getUserMedia({ audio }) で先にマイク権限と初期ストリームを取得
- 権限取得後に enumerateDevices() を試し、失敗時は初期ストリームで継続
- 対応MIMEが見つからない場合は mimeType なしで MediaRecorder を作成
- MediaRecorder が空の file type を返す場合でも Next.js API Route で即400にしない
- useVoiceRecorder のJestテストを追加

## Tests

- npx jest __tests__/hooks/useVoiceRecorder.test.tsx __tests__/components/DreamEntryLauncher.test.tsx --runInBand

## Notes

- iPhone Safari / Android Chrome の実機確認は未実施です。
- backend API、認証処理、trial_audio_count 更新処理は変更していません。