### PR TITLE
fix: 今週サマリーで同率1位の感情を複数表示し、月間と共通化

### DIFF
--- a/frontend/__tests__/lib/emotionTie.test.ts
+++ b/frontend/__tests__/lib/emotionTie.test.ts
@@ -1,0 +1,42 @@
+import { pickTopEmotionLabels, formatTopEmotionLabels } from "@/lib/emotionTie";
+
+describe("pickTopEmotionLabels", () => {
+  it("単独1位なら1つだけ返す", () => {
+    expect(pickTopEmotionLabels({ うれしい: 3, こわい: 1 })).toEqual([
+      "うれしい",
+    ]);
+  });
+
+  it("同率1位はすべて返す", () => {
+    expect(pickTopEmotionLabels({ うれしい: 2, こわい: 2, かなしい: 1 })).toEqual([
+      "うれしい",
+      "こわい",
+    ]);
+  });
+
+  it("感情が無いときは空配列を返す", () => {
+    expect(pickTopEmotionLabels({})).toEqual([]);
+  });
+});
+
+describe("formatTopEmotionLabels", () => {
+  it("1つは「A」だけ", () => {
+    expect(formatTopEmotionLabels(["うれしい"])).toBe("「うれしい」");
+  });
+
+  it("2つは「A」と「B」でつなぐ", () => {
+    expect(formatTopEmotionLabels(["うれしい", "こわい"])).toBe(
+      "「うれしい」と「こわい」"
+    );
+  });
+
+  it("3つを超えると3つまで＋「など」", () => {
+    expect(formatTopEmotionLabels(["A", "B", "C", "D"])).toBe(
+      "「A」と「B」と「C」など"
+    );
+  });
+
+  it("空配列は空文字", () => {
+    expect(formatTopEmotionLabels([])).toBe("");
+  });
+});

--- a/frontend/app/components/DreamStatsWidget.tsx
+++ b/frontend/app/components/DreamStatsWidget.tsx
@@ -3,6 +3,7 @@
 import { Dream } from "@/app/types";
 import { getChildFriendlyEmotionLabel } from "./EmotionTag";
 import { getJSTYearMonthKey } from "@/lib/date";
+import { formatTopEmotionLabels, pickTopEmotionLabels } from "@/lib/emotionTie";
 import MorpheusImage from "./MorpheusImage";
 
 interface DreamStatsWidgetProps {
@@ -59,9 +60,8 @@ export default function DreamStatsWidget({ dreams }: DreamStatsWidgetProps) {
       weekEmotionCounts[label] = (weekEmotionCounts[label] ?? 0) + 1;
     });
   });
-  const weekTop = Object.entries(weekEmotionCounts).sort(
-    ([, a], [, b]) => b - a
-  )[0];
+  // 同率1位もすべて表示する（月間ふりかえりと同じ共通ヘルパーを使用）
+  const weekTopLabels = pickTopEmotionLabels(weekEmotionCounts);
 
   if (sortedEmotions.length === 0) return null;
 
@@ -95,7 +95,7 @@ export default function DreamStatsWidget({ dreams }: DreamStatsWidgetProps) {
       </div>
 
       {/* モルペウスの今週サマリー */}
-      {weekTop && (
+      {weekTopLabels.length > 0 && (
         <div className="flex items-center gap-3 rounded-2xl border border-sky-200/60 bg-sky-50/80 p-3 dark:border-sky-500/20 dark:bg-slate-800/70">
           <div className="shrink-0 rounded-xl bg-white/80 p-1 shadow-sm ring-1 ring-sky-100 dark:bg-white/10 dark:ring-white/10">
             <MorpheusImage variant="analysis" size={54} />
@@ -103,7 +103,7 @@ export default function DreamStatsWidget({ dreams }: DreamStatsWidgetProps) {
           <p className="text-xs leading-relaxed text-slate-700 dark:text-slate-200">
             今週いちばん多い きもちは{" "}
             <span className="font-bold text-sky-600 dark:text-sky-300">
-              「{weekTop[0]}」
+              {formatTopEmotionLabels(weekTopLabels)}
             </span>{" "}
             だったよ！
           </p>

--- a/frontend/lib/emotionTie.ts
+++ b/frontend/lib/emotionTie.ts
@@ -1,0 +1,35 @@
+// 感情タグの集計から「同率1位」を扱う共通ヘルパー。
+// 月間ふりかえり(monthlySummary)と今週サマリー(DreamStatsWidget)で共有する。
+
+const TIE_DISPLAY_LIMIT = 3;
+
+/**
+ * 件数マップから最も多い感情ラベルをすべて返す（同率1位を取りこぼさない）。
+ * 感情が1つも無いときは空配列を返す。
+ */
+export function pickTopEmotionLabels(
+  counts: Record<string, number>
+): string[] {
+  const maxCount = Math.max(0, ...Object.values(counts));
+  if (maxCount <= 0) return [];
+  return Object.entries(counts)
+    .filter(([, count]) => count === maxCount)
+    .map(([label]) => label);
+}
+
+/**
+ * 同率1位ラベルを「「A」と「B」」の形に整形する。
+ * 読みやすさのため既定で3つまで表示し、超過分は「など」でまとめる。
+ */
+export function formatTopEmotionLabels(
+  labels: string[],
+  limit: number = TIE_DISPLAY_LIMIT
+): string {
+  if (labels.length === 0) return "";
+  const joined = labels
+    .slice(0, limit)
+    .map((label) => `「${label}」`)
+    .join("と");
+  const suffix = labels.length > limit ? "など" : "";
+  return `${joined}${suffix}`;
+}

--- a/frontend/lib/monthlySummary.ts
+++ b/frontend/lib/monthlySummary.ts
@@ -1,6 +1,7 @@
 import { Dream } from "@/app/types";
 import { getChildFriendlyEmotionLabel } from "@/app/components/EmotionTag";
 import { getJSTDateStr } from "@/lib/date";
+import { formatTopEmotionLabels, pickTopEmotionLabels } from "@/lib/emotionTie";
 
 export type MonthlySummary = {
   dreamCount: number;
@@ -45,11 +46,8 @@ export function buildMonthlySummary(
     .slice(0, 3)
     .map(([label, count]) => ({ label, count }));
 
-  // 同率1位をすべて拾う（メッセージで「と」つなぎにするため）
-  const maxCount = Math.max(0, ...Object.values(emotionCounts));
-  const topTiedLabels = Object.entries(emotionCounts)
-    .filter(([, count]) => count === maxCount)
-    .map(([label]) => label);
+  // 同率1位をすべて拾い、共通ヘルパーで「「A」と「B」」に整形する
+  const topTiedLabels = pickTopEmotionLabels(emotionCounts);
 
   const highlights = [
     `${dreamCount}この ゆめ`,
@@ -59,12 +57,7 @@ export function buildMonthlySummary(
 
   let message = `${fallbackMonthLabel}は ${dreamCount}この ゆめを きろくしたよ。`;
   if (topTiedLabels.length > 0) {
-    // 多すぎると読みにくいので3つまで表示し、残りは「など」でまとめる
-    const TIE_DISPLAY_LIMIT = 3;
-    const shown = topTiedLabels.slice(0, TIE_DISPLAY_LIMIT);
-    const joined = shown.map((label) => `「${label}」`).join("と");
-    const suffix = topTiedLabels.length > TIE_DISPLAY_LIMIT ? "など" : "";
-    message += ` いちばん多かった きもちは${joined}${suffix}だったよ。`;
+    message += ` いちばん多かった きもちは${formatTopEmotionLabels(topTiedLabels)}だったよ。`;
   } else if (dreamCount > 0) {
     message += " これから きもちタグが ふえると、もっと たのしく ふりかえれるよ。";
   }


### PR DESCRIPTION
## 背景

[PR #377](https://github.com/isekaisaru/dreamjournal-app/pull/377) で月間ふりかえり(`monthlySummary.ts`)の同率1位表示は直したが、ホームの今週サマリー(`DreamStatsWidget.tsx`)の「今週いちばん多い きもちは『X』」は `weekTop[0]` で1位を1つしか取っておらず、同率1位が潰れていた（#377の週間版）。

## 変更内容（frontend）

- 同率1位ロジックを `frontend/lib/emotionTie.ts` に共通化
  - `pickTopEmotionLabels(counts)`: 最大件数と同数の感情ラベルを全部返す
  - `formatTopEmotionLabels(labels)`: 「「A」と「B」」に整形（3つまで＋超過は「など」）
- `DreamStatsWidget.tsx`: `weekTop[0]` → `pickTopEmotionLabels` ＋ `formatTopEmotionLabels` に置換し、同率1位を複数表示
- `monthlySummary.ts`: 同じ共通ヘルパーを使うようリファクタし、重複ロジックを解消・挙動を統一

## なぜ共通化したか

月間と週間は「同率トップをどう出すか」が全く同じ仕様。コピーすると片方だけ直す/挙動がズレる事故が起きやすいので、1箇所(`emotionTie.ts`)に集約して一貫性を担保した。

## テスト

Jest（**11 passed**）:
- 新規 `emotionTie` 7件（単独/同率/空、整形1〜3つ＋など/空）
- 既存 `monthlySummary` 4件もグリーンのまま（リファクタ後も挙動不変）

## スコープ外

backend/API/DB変更、月間ふりかえりの表示文言変更、Trial P3。

🤖 Generated with [Claude Code](https://claude.com/claude-code)