### PR TITLE
fix: 森画面の少数プロフィール初期表示を改善

### DIFF
--- a/frontend/__tests__/components/ForestScene.test.tsx
+++ b/frontend/__tests__/components/ForestScene.test.tsx
@@ -1,0 +1,17 @@
+import { getInitialForestView } from "@/app/components/forest/ForestScene";
+
+describe("getInitialForestView", () => {
+  it("プロフィール1件で森が画面より広い場合、木が初期表示の中央に入る位置へ寄せる", () => {
+    expect(getInitialForestView(1, 1180, 360)).toEqual({ x: -410, y: 0, z: 1 });
+  });
+
+  it("プロフィール1件でもPC幅では既存の左端開始を維持する", () => {
+    expect(getInitialForestView(1, 1180, 960)).toEqual({ x: 0, y: 0, z: 1 });
+    expect(getInitialForestView(1, 960, 960)).toEqual({ x: 0, y: 0, z: 1 });
+  });
+
+  it("複数プロフィールでは既存表示を大きく変えない", () => {
+    expect(getInitialForestView(2, 1180, 360)).toEqual({ x: 0, y: 0, z: 1 });
+    expect(getInitialForestView(4, 1180, 360)).toEqual({ x: 0, y: 0, z: 1 });
+  });
+});

--- a/frontend/app/components/forest/ForestScene.tsx
+++ b/frontend/app/components/forest/ForestScene.tsx
@@ -20,6 +20,16 @@ import Critters from "./Critters";
 import WalkingMorpheus from "./WalkingMorpheus";
 import TreePreviewSheet from "./TreePreviewSheet";
 
+type ForestView = { x: number; y: number; z: number };
+
+export function getInitialForestView(profileCount: number, fieldW: number, viewportW: number): ForestView {
+  if (profileCount === 1 && viewportW < 768 && viewportW < fieldW) {
+    return { x: Math.round(viewportW / 2 - fieldW / 2), y: 0, z: 1 };
+  }
+
+  return { x: 0, y: 0, z: 1 };
+}
+
 export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) {
   const reduceMotion = useReducedMotion();
   const router = useRouter();
@@ -51,6 +61,7 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
 
   // パン & ズーム
   const [view, setView] = useState({ x: 0, y: 0, z: 1 });
+  const hasUserAdjustedViewRef = useRef(false);
   const dragRef = useRef<{ sx: number; sy: number; vx: number; vy: number } | null>(null);
   const movedRef = useRef(false);
   const pointers = useRef(new Map<number, { x: number; y: number }>());
@@ -69,12 +80,23 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
     [fieldW, W, H]
   );
 
+  const initialView = useMemo(
+    () => clamp(getInitialForestView(profiles.length, fieldW, W)),
+    [clamp, profiles.length, fieldW, W]
+  );
+
+  useEffect(() => {
+    if (profiles.length === 0 || hasUserAdjustedViewRef.current) return;
+    setView(initialView);
+  }, [initialView, profiles.length]);
+
   // ポインタ捕捉は「ドラッグと判定してから」遅延して行う。
   // pointerdown で即捕捉すると子の木ボタンの click が発火せず、タップで
   // プレビューシートが開かなくなるため（重要）。
   const capturedRef = useRef(false);
 
   const onPointerDown = (e: React.PointerEvent) => {
+    hasUserAdjustedViewRef.current = true;
     pointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
     movedRef.current = false;
     capturedRef.current = false;
@@ -130,6 +152,7 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
   };
   const onWheel = (e: React.WheelEvent) => {
     e.preventDefault();
+    hasUserAdjustedViewRef.current = true;
     setView((v) => clamp({ ...v, z: v.z * (e.deltaY > 0 ? 0.92 : 1.08) }));
     setHinted(false);
   };
@@ -293,9 +316,30 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
         <div className="absolute left-3 top-3 z-30 flex flex-col gap-2">
           {(
             [
-              ["＋", "ズームイン", () => setView((v) => clamp({ ...v, z: v.z * 1.2 }))],
-              ["－", "ズームアウト", () => setView((v) => clamp({ ...v, z: v.z * 0.83 }))],
-              ["⟳", "もとに もどす", () => setView({ x: 0, y: 0, z: 1 })],
+              [
+                "＋",
+                "ズームイン",
+                () => {
+                  hasUserAdjustedViewRef.current = true;
+                  setView((v) => clamp({ ...v, z: v.z * 1.2 }));
+                },
+              ],
+              [
+                "－",
+                "ズームアウト",
+                () => {
+                  hasUserAdjustedViewRef.current = true;
+                  setView((v) => clamp({ ...v, z: v.z * 0.83 }));
+                },
+              ],
+              [
+                "⟳",
+                "もとに もどす",
+                () => {
+                  hasUserAdjustedViewRef.current = false;
+                  setView(initialView);
+                },
+              ],
             ] as const
           ).map(([t, lab, fn], i) => (
             <button


### PR DESCRIPTION
## 背景

2026-06-21の家族UXテストで、trial userがスマホから森画面を見ると木が見えず、森がうまく表示できない可能性が見つかりました。

trial userは通常プロフィールが1件のため、森画面の初期表示位置によって1本目の木が画面外に隠れると、ユーザーには「木がない」「画面が表示できていない」ように見える可能性があります。

## 原因

`ForestScene` は森の横幅を最低 `1180px` にしており、プロフィール1件の場合は木が森の中央付近に配置されます。

一方でスマホ幅が360px前後の場合、初期 `view.x = 0` では森の左端だけが表示されるため、中央付近の木が初期表示範囲外になる可能性がありました。

## 変更内容

- `ForestScene` に `getInitialForestView()` を追加
- プロフィール1件かつスマホ相当幅の場合のみ、初期 `view.x` を森の中央寄せに補正
- PC幅や複数プロフィールでは従来の左端開始を維持
- ユーザーがパン/ズームした後は自動補正で位置を戻さないように調整
- 「もとに もどす」ボタンは補正後の初期位置に戻るように変更
- 初期表示座標のJestテストを追加

## なぜスマホで改善する可能性があるか

スマホ幅では表示できる横幅が狭いため、森の左端から表示すると1本だけの木が右側に隠れる可能性がありました。

今回、プロフィール1件のスマホ相当幅だけ初期視点を中央へ寄せることで、trial userの最初の木が画面内に入りやすくなります。

## テスト結果

```bash
cd frontend
npx jest __tests__/components/ForestScene.test.tsx
```

- Test Suites: 1 passed
- Tests: 3 passed

## スコープ外

- APIエラー表示の分離
- `/forest/[profileId]` のredirect設計変更
- trial userのselfプロフィールbackfill
- backend変更
- DB変更
- 週間サマリー同率表示
- 月間サマリー同率表示
- `emotionTie` 共通ヘルパー

## 実機確認が必要な項目

- Vercel Previewをスマホ幅で開き、trial userの `/forest` で木が最初から見えること
- 1本表示時のパン/ズーム操作が壊れていないこと
- 「もとに もどす」ボタンで木が見える初期位置へ戻ること
- 複数プロフィールの森表示が大きく変わっていないこと
