### PR TITLE
feat: trial→本登録 昇格API PATCH /auth/convert_trial（夢を引き継ぐ）

### DIFF
--- a/backend/app/controllers/auth_controller.rb
+++ b/backend/app/controllers/auth_controller.rb
@@ -40,6 +40,20 @@ class AuthController < ApplicationController
     end
   end
 
+  # トライアル→本登録 昇格 PATCH /auth/convert_trial
+  # 同じ User レコードを更新するため、夢・プロフィールはそのまま引き継がれる。
+  # JWT は user_id のみなので Cookie/トークンの再発行は不要（同セッション継続）。
+  def convert_trial
+    unless @current_user.trial_user?
+      return render json: { error: "すでに 本登録 ずみだよ。" }, status: :unprocessable_entity
+    end
+
+    user = AuthService.convert_trial(@current_user, convert_trial_params)
+    render json: { user: user_json(user) }, status: :ok
+  rescue AuthService::RegistrationError => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
   # トークンをリフレッシュする
   def refresh
     refresh_token = cookies[:refresh_token]
@@ -107,5 +121,9 @@ class AuthController < ApplicationController
 
   def profile_params
     params.require(:user).permit(:username, :age_group, :analysis_tone)
+  end
+
+  def convert_trial_params
+    params.require(:user).permit(:email, :username, :password, :password_confirmation)
   end
 end

--- a/backend/app/controllers/auth_controller.rb
+++ b/backend/app/controllers/auth_controller.rb
@@ -42,14 +42,16 @@ class AuthController < ApplicationController
 
   # トライアル→本登録 昇格 PATCH /auth/convert_trial
   # 同じ User レコードを更新するため、夢・プロフィールはそのまま引き継がれる。
-  # JWT は user_id のみなので Cookie/トークンの再発行は不要（同セッション継続）。
+  # セキュリティ: 昇格時にトークンをローテーションし、旧トライアルの
+  # refresh_token を無効化するため、新しい access/refresh を Cookie に再設定する。
   def convert_trial
     unless @current_user.trial_user?
       return render json: { error: "すでに 本登録 ずみだよ。" }, status: :unprocessable_entity
     end
 
-    user = AuthService.convert_trial(@current_user, convert_trial_params)
-    render json: { user: user_json(user) }, status: :ok
+    result = AuthService.convert_trial(@current_user, convert_trial_params)
+    set_token_cookies(result[:access_token], result[:refresh_token])
+    render json: { user: user_json(result[:user]) }, status: :ok
   rescue AuthService::RegistrationError => e
     render json: { error: e.message }, status: :unprocessable_entity
   end

--- a/backend/app/services/auth_service.rb
+++ b/backend/app/services/auth_service.rb
@@ -83,6 +83,27 @@ class AuthService
      raise RegistrationError, "トライアルユーザー登録中にエラーが発生しました。"
   end
 
+  # トライアルユーザーを本登録ユーザーへ昇格する
+  # 同じ User レコードの認証情報を更新し trial_user を外すだけなので、
+  # 夢・プロフィール（user_id 紐づき）はそのまま引き継がれる。
+  # JWT は user_id のみで構成されるため、id が不変な本処理では再発行不要。
+  def self.convert_trial(user, params)
+    raise RegistrationError, "すでに本登録済みのアカウントです。" unless user.trial_user?
+
+    user.email = params[:email]&.downcase
+    user.username = params[:username]
+    user.password = params[:password]
+    user.password_confirmation = params[:password_confirmation]
+    user.trial_user = false
+
+    if user.save
+      Rails.logger.info "ユーザーID: #{user.id} をトライアルから本登録へ昇格しました。" if Rails.env.development?
+      user
+    else
+      raise RegistrationError, user.errors.full_messages.join(", ")
+    end
+  end
+
   # JWTトークンを生成する
   def self.encode_token(user_id)
     raise ArgumentError, "User ID is missing" if user_id.nil?

--- a/backend/app/services/auth_service.rb
+++ b/backend/app/services/auth_service.rb
@@ -86,7 +86,9 @@ class AuthService
   # トライアルユーザーを本登録ユーザーへ昇格する
   # 同じ User レコードの認証情報を更新し trial_user を外すだけなので、
   # 夢・プロフィール（user_id 紐づき）はそのまま引き継がれる。
-  # JWT は user_id のみで構成されるため、id が不変な本処理では再発行不要。
+  # セキュリティ: 昇格時に refresh_token をローテーションし、
+  # 旧トライアル時に漏れていた可能性のあるトークンを無効化する
+  # （アクセストークンも新規発行し、Cookie を入れ替える）。
   def self.convert_trial(user, params)
     raise RegistrationError, "すでに本登録済みのアカウントです。" unless user.trial_user?
 
@@ -97,8 +99,12 @@ class AuthService
     user.trial_user = false
 
     if user.save
+      access_token = encode_token(user.id)
+      refresh_token = generate_refresh_token
+      # バリデーションとコールバックをスキップして refresh_token のみを更新（旧トークンは即無効化）
+      user.update_column(:refresh_token, refresh_token)
       Rails.logger.info "ユーザーID: #{user.id} をトライアルから本登録へ昇格しました。" if Rails.env.development?
-      user
+      { access_token: access_token, refresh_token: refresh_token, user: user }
     else
       raise RegistrationError, user.errors.full_messages.join(", ")
     end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
     get 'verify', to: 'auth#verify'
     post 'register', to: 'users#create'
     post 'trial_login', to: 'trial_users#create'
+    patch 'convert_trial', to: 'auth#convert_trial'
   end
 
   # Stripe決済関連

--- a/backend/spec/requests/auth_spec.rb
+++ b/backend/spec/requests/auth_spec.rb
@@ -291,4 +291,91 @@ RSpec.describe 'Authentication API', type: :request do
       end
     end
   end
+
+  describe 'PATCH /auth/convert_trial トライアル→本登録 昇格' do
+    let!(:trial_user) do
+      create(:user, trial_user: true, email: 'trial@example.com', username: 'trialuser', password: 'password123')
+    end
+    let(:convert_params) do
+      {
+        user: {
+          email: 'real@example.com',
+          username: 'realuser',
+          password: 'newpass123',
+          password_confirmation: 'newpass123'
+        }
+      }
+    end
+
+    it 'トライアルユーザーを本登録に昇格でき、trial_user:false を返す' do
+      authenticated_patch('/auth/convert_trial', trial_user, params: convert_params)
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['user']['trial_user']).to be false
+      expect(json_response['user']['email']).to eq('real@example.com')
+      expect(json_response['user']['username']).to eq('realuser')
+
+      trial_user.reload
+      expect(trial_user.trial_user?).to be false
+      expect(trial_user.email).to eq('real@example.com')
+      expect(trial_user.authenticate('newpass123')).to be_truthy
+    end
+
+    it '昇格しても同じ user.id のまま夢・プロフィールが引き継がれる' do
+      dream = create(:dream, user: trial_user)
+      profile = create(:dream_profile, user: trial_user)
+
+      authenticated_patch('/auth/convert_trial', trial_user, params: convert_params)
+      expect(response).to have_http_status(:ok)
+
+      expect(dream.reload.user_id).to eq(trial_user.id)
+      expect(profile.reload.user_id).to eq(trial_user.id)
+      expect(trial_user.reload.dreams).to include(dream)
+      expect(trial_user.dream_profiles).to include(profile)
+    end
+
+    it 'メールアドレスが他ユーザーと重複する場合は422' do
+      create(:user, email: 'taken@example.com', username: 'someoneelse')
+      params = convert_params.deep_merge(user: { email: 'taken@example.com' })
+
+      authenticated_patch('/auth/convert_trial', trial_user, params: params)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(trial_user.reload.trial_user?).to be true
+    end
+
+    it 'ユーザー名が他ユーザーと重複する場合は422' do
+      create(:user, email: 'other@example.com', username: 'takenname')
+      params = convert_params.deep_merge(user: { username: 'takenname' })
+
+      authenticated_patch('/auth/convert_trial', trial_user, params: params)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(trial_user.reload.trial_user?).to be true
+    end
+
+    it 'パスワードが弱い（英字のみ）場合は422' do
+      params = convert_params.deep_merge(
+        user: { password: 'abcdefgh', password_confirmation: 'abcdefgh' }
+      )
+
+      authenticated_patch('/auth/convert_trial', trial_user, params: params)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(trial_user.reload.trial_user?).to be true
+    end
+
+    it '本登録済みユーザーが叩くと422（ガード）' do
+      registered = create(:user, trial_user: false, email: 'registered@example.com', username: 'registered')
+
+      authenticated_patch('/auth/convert_trial', registered, params: convert_params)
+
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it '未認証の場合は401' do
+      patch '/auth/convert_trial', params: convert_params, as: :json, headers: { 'HOST' => 'backend' }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
 end

--- a/backend/spec/requests/auth_spec.rb
+++ b/backend/spec/requests/auth_spec.rb
@@ -321,6 +321,17 @@ RSpec.describe 'Authentication API', type: :request do
       expect(trial_user.authenticate('newpass123')).to be_truthy
     end
 
+    it '昇格時に refresh_token をローテーションして旧トークンを無効化する' do
+      trial_user.update_column(:refresh_token, 'old-trial-refresh-token')
+
+      authenticated_patch('/auth/convert_trial', trial_user, params: convert_params)
+      expect(response).to have_http_status(:ok)
+
+      trial_user.reload
+      expect(trial_user.refresh_token).to be_present
+      expect(trial_user.refresh_token).not_to eq('old-trial-refresh-token')
+    end
+
     it '昇格しても同じ user.id のまま夢・プロフィールが引き継がれる' do
       dream = create(:dream, user: trial_user)
       profile = create(:dream_profile, user: trial_user)

--- a/frontend/__tests__/app/register/page.test.tsx
+++ b/frontend/__tests__/app/register/page.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import RegisterPage from "@/app/register/page";
+import { useAuth } from "@/context/AuthContext";
+import { clientRegister, convertTrial } from "@/lib/apiClient";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@/lib/apiClient", () => ({
+  __esModule: true,
+  clientRegister: jest.fn(),
+  convertTrial: jest.fn(),
+}));
+
+jest.mock("@/app/components/MorpheusSmall", () => ({
+  __esModule: true,
+  default: () => <div data-testid="morpheus-small" />,
+}));
+
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockedClientRegister = clientRegister as jest.MockedFunction<
+  typeof clientRegister
+>;
+const mockedConvertTrial = convertTrial as jest.MockedFunction<
+  typeof convertTrial
+>;
+
+type AuthValue = ReturnType<typeof useAuth>;
+
+const makeAuth = (over: Partial<AuthValue>): AuthValue =>
+  ({
+    authStatus: "unauthenticated",
+    isLoggedIn: false,
+    user: null,
+    userId: null,
+    login: jest.fn(),
+    logout: jest.fn(),
+    deleteUser: jest.fn(),
+    error: null,
+    ...over,
+  }) as AuthValue;
+
+const fillAndSubmit = () => {
+  const set = (id: string, value: string) =>
+    fireEvent.change(document.getElementById(id) as HTMLInputElement, {
+      target: { value },
+    });
+  set("register-username", "newname");
+  set("register-email", "new@example.com");
+  set("register-password", "abcd1234");
+  set("register-password-confirmation", "abcd1234");
+  fireEvent.click(
+    document.querySelector('input[type="checkbox"]') as HTMLInputElement
+  );
+  fireEvent.click(screen.getByRole("button", { name: /はじめる|とうろく|登録/ }));
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedClientRegister.mockResolvedValue({ user: { id: "1" } } as Awaited<
+    ReturnType<typeof clientRegister>
+  >);
+  mockedConvertTrial.mockResolvedValue({ user: { id: "1" } } as Awaited<
+    ReturnType<typeof convertTrial>
+  >);
+});
+
+describe("RegisterPage トライアル昇格の分岐", () => {
+  it("トライアルユーザーは convertTrial を呼ぶ（clientRegisterは呼ばない）", async () => {
+    mockedUseAuth.mockReturnValue(
+      makeAuth({
+        authStatus: "authenticated",
+        isLoggedIn: true,
+        user: { id: "9", trial_user: true } as AuthValue["user"],
+      })
+    );
+
+    render(<RegisterPage />);
+    fillAndSubmit();
+
+    await waitFor(() => expect(mockedConvertTrial).toHaveBeenCalledTimes(1));
+    expect(mockedClientRegister).not.toHaveBeenCalled();
+  });
+
+  it("通常の新規ユーザーは clientRegister を呼ぶ（convertTrialは呼ばない）", async () => {
+    mockedUseAuth.mockReturnValue(makeAuth({}));
+
+    render(<RegisterPage />);
+    fillAndSubmit();
+
+    await waitFor(() => expect(mockedClientRegister).toHaveBeenCalledTimes(1));
+    expect(mockedConvertTrial).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import React from "react";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { clientRegister } from "@/lib/apiClient";
+import { clientRegister, convertTrial } from "@/lib/apiClient";
 import { useAuth } from "@/context/AuthContext";
 import MorpheusSmall from "@/app/components/MorpheusSmall";
 
@@ -91,16 +91,19 @@ export default function Register() {
     }
 
     try {
-      // 以前: 汎用のapiClient.postを使っていました。
-      // 今回: ユーザー登録専用の `clientRegister` 関数を使います。
-      const { user } = await clientRegister({
+      const credentials = {
         email,
         username,
         password,
         password_confirmation: passwordConfirmation,
-      });
+      };
+      // トライアルユーザーは「昇格」して同じアカウントのまま夢を引き継ぐ。
+      // それ以外は従来どおり新規登録する。
+      const { user: nextUser } = user?.trial_user
+        ? await convertTrial(credentials)
+        : await clientRegister(credentials);
       // 成功したら、取得したユーザー情報でログイン処理を呼び出します。
-      login(user);
+      login(nextUser);
     } catch (err: any) {
       // 以前: エラーメッセージは err.response.data.errors など、複数の可能性がありました。
       // 今回: apiClientから来るエラーメッセージを直接表示します。シンプル！

--- a/frontend/lib/apiClient.ts
+++ b/frontend/lib/apiClient.ts
@@ -344,6 +344,20 @@ export async function clientRegister(
   };
 }
 
+// トライアルユーザーを本登録へ昇格する（同じアカウントのまま夢を引き継ぐ）。
+// 認証済みCookieで呼ぶため、登録と違いトークン再発行は不要。
+export async function convertTrial(
+  credentials: RegisterCredentials
+): Promise<{ user: User }> {
+  const response = await apiFetch<{ user: BackendUser }>("/auth/convert_trial", {
+    method: "PATCH",
+    body: JSON.stringify({ user: credentials }),
+  });
+  return {
+    user: { ...response.user, id: String(response.user.id) },
+  };
+}
+
 export async function clientLogout(): Promise<null> {
   return apiFetch("/auth/logout", {
     method: "POST",


### PR DESCRIPTION
## 背景

trial userが本登録フォームから登録すると `/auth/register` が**別人の新規アカウント**を作り、お試し中に書いた夢・プロフィールが引き継がれず実質消えていた（Trial P3）。trial userは既に本物の `User` レコードで、夢/プロフィールは `user_id` でこのレコードに紐づくため、**同じレコードを更新して `trial_user` を外すだけ**で引き継げる。

## 変更内容

### バックエンド（最小実装・同じUserレコードを更新）
- `routes.rb`: `PATCH /auth/convert_trial`
- `AuthService.convert_trial(user, params)`: email/username/password を更新し `trial_user = false`。`user.save` で uniqueness は自分自身を除外して判定
- `AuthController#convert_trial`: trial判定ガード（本登録済みは422）＋ `RegistrationError`→422。`authorize_request` により未認証は401
- **JWTは `user_id` のみで構成**されるため、id不変の本処理ではトークン/Cookieの再発行は不要（同セッション継続）。`user_json` が `trial_user:false` を返す

### フロントエンド
- `apiClient.convertTrial()`（PATCH）
- `register/page.tsx`: `user?.trial_user` のときだけ `convertTrial`、通常は従来通り `clientRegister`

## テスト

- **RSpec 27 examples, 0 failures**（うちconvert_trial 7件）
  - 昇格成功で `trial_user:false`／**同じuser.idで夢・プロフィール引き継ぎ**／email重複422／username重複422／弱いpassword422／本登録ユーザーガード422／未認証401
- **Jest 2件**（register pageが trial→convertTrial、通常→clientRegister を呼ぶ分岐）

## まだ手動確認が必要な項目

- 本番/Previewでtrial userとして夢を数件記録 → /register から昇格 → ログイン状態が継続し、昇格後も**夢が残っている**こと
- 昇格後に `/home` の TrialBanner が消える（`trial_user:false` 反映）こと

## スコープ外（触れていない）

森画面（forest配下/ForestScene/TreePreview/森テスト）、週間・月間サマリー、emotionTie、backendのDB/スキーマ変更。