### PR TITLE
fix: 森詳細画面で想定外レスポンス時に落ちないようにする

### DIFF
--- a/frontend/__tests__/components/ForestProfilePage.test.tsx
+++ b/frontend/__tests__/components/ForestProfilePage.test.tsx
@@ -1,0 +1,90 @@
+import type { Dream, DreamProfile } from "@/app/types";
+import {
+  findActiveForestProfile,
+  isValidForestProfileId,
+  normalizeDreamProfilesResponse,
+  normalizeProfileDreamsResponse,
+} from "@/app/forest/[profileId]/page";
+
+function profile(overrides: Partial<DreamProfile> = {}): DreamProfile {
+  return {
+    id: 1,
+    name: "自分",
+    avatar_emoji: "😴",
+    color: "#6366f1",
+    relationship: "self",
+    active: true,
+    position: 0,
+    archived: false,
+    created_at: "2026-06-24T00:00:00Z",
+    updated_at: "2026-06-24T00:00:00Z",
+    dreams_count: 0,
+    ...overrides,
+  };
+}
+
+function dream(overrides: Partial<Dream> = {}): Dream {
+  return {
+    id: 1,
+    title: "森のゆめ",
+    content: "森を歩いた",
+    userId: 1,
+    created_at: "2026-06-24T00:00:00Z",
+    updated_at: "2026-06-24T00:00:00Z",
+    emotions: [],
+    ...overrides,
+  };
+}
+
+describe("ForestProfilePage guards", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("accepts a valid profileId and rejects invalid profileIds before API calls", () => {
+    expect(isValidForestProfileId(1)).toBe(true);
+    expect(isValidForestProfileId(0)).toBe(false);
+    expect(isValidForestProfileId(-1)).toBe(false);
+    expect(isValidForestProfileId(Number.NaN)).toBe(false);
+  });
+
+  it("keeps an empty dreams array safe for rendering", () => {
+    expect(normalizeProfileDreamsResponse([])).toEqual([]);
+  });
+
+  it("falls back to an empty dreams array when the dreams response is unexpected", () => {
+    expect(normalizeProfileDreamsResponse({ error: "temporary failure" })).toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Unexpected dreams response for forest detail",
+      { error: "temporary failure" }
+    );
+  });
+
+  it("keeps an array dreams response unchanged", () => {
+    const dreams = [dream({ id: 10 })];
+    expect(normalizeProfileDreamsResponse(dreams)).toBe(dreams);
+  });
+
+  it("returns null when the profiles response is unexpected", () => {
+    expect(normalizeDreamProfilesResponse({ error: "bad response" })).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Unexpected dream profiles response for forest detail",
+      { error: "bad response" }
+    );
+  });
+
+  it("finds only active profiles for the requested profileId", () => {
+    const active = profile({ id: 1, archived: false });
+    const archived = profile({ id: 2, archived: true });
+
+    expect(findActiveForestProfile([active, archived], 1)).toBe(active);
+    expect(findActiveForestProfile([active, archived], 2)).toBeNull();
+    expect(findActiveForestProfile([active], 999)).toBeNull();
+  });
+});

--- a/frontend/__tests__/components/ForestScene.test.tsx
+++ b/frontend/__tests__/components/ForestScene.test.tsx
@@ -1,0 +1,17 @@
+import { getInitialForestView } from "@/app/components/forest/ForestScene";
+
+describe("getInitialForestView", () => {
+  it("プロフィール1件で森が画面より広い場合、木が初期表示の中央に入る位置へ寄せる", () => {
+    expect(getInitialForestView(1, 1180, 360)).toEqual({ x: -410, y: 0, z: 1 });
+  });
+
+  it("プロフィール1件でもPC幅では既存の左端開始を維持する", () => {
+    expect(getInitialForestView(1, 1180, 960)).toEqual({ x: 0, y: 0, z: 1 });
+    expect(getInitialForestView(1, 960, 960)).toEqual({ x: 0, y: 0, z: 1 });
+  });
+
+  it("複数プロフィールでは既存表示を大きく変えない", () => {
+    expect(getInitialForestView(2, 1180, 360)).toEqual({ x: 0, y: 0, z: 1 });
+    expect(getInitialForestView(4, 1180, 360)).toEqual({ x: 0, y: 0, z: 1 });
+  });
+});

--- a/frontend/app/components/forest/ForestScene.tsx
+++ b/frontend/app/components/forest/ForestScene.tsx
@@ -20,6 +20,16 @@ import Critters from "./Critters";
 import WalkingMorpheus from "./WalkingMorpheus";
 import TreePreviewSheet from "./TreePreviewSheet";
 
+type ForestView = { x: number; y: number; z: number };
+
+export function getInitialForestView(profileCount: number, fieldW: number, viewportW: number): ForestView {
+  if (profileCount === 1 && viewportW < 768 && viewportW < fieldW) {
+    return { x: Math.round(viewportW / 2 - fieldW / 2), y: 0, z: 1 };
+  }
+
+  return { x: 0, y: 0, z: 1 };
+}
+
 export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) {
   const reduceMotion = useReducedMotion();
   const router = useRouter();
@@ -51,6 +61,7 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
 
   // パン & ズーム
   const [view, setView] = useState({ x: 0, y: 0, z: 1 });
+  const hasUserAdjustedViewRef = useRef(false);
   const dragRef = useRef<{ sx: number; sy: number; vx: number; vy: number } | null>(null);
   const movedRef = useRef(false);
   const pointers = useRef(new Map<number, { x: number; y: number }>());
@@ -69,12 +80,23 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
     [fieldW, W, H]
   );
 
+  const initialView = useMemo(
+    () => clamp(getInitialForestView(profiles.length, fieldW, W)),
+    [clamp, profiles.length, fieldW, W]
+  );
+
+  useEffect(() => {
+    if (profiles.length === 0 || hasUserAdjustedViewRef.current) return;
+    setView(initialView);
+  }, [initialView, profiles.length]);
+
   // ポインタ捕捉は「ドラッグと判定してから」遅延して行う。
   // pointerdown で即捕捉すると子の木ボタンの click が発火せず、タップで
   // プレビューシートが開かなくなるため（重要）。
   const capturedRef = useRef(false);
 
   const onPointerDown = (e: React.PointerEvent) => {
+    hasUserAdjustedViewRef.current = true;
     pointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
     movedRef.current = false;
     capturedRef.current = false;
@@ -130,6 +152,7 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
   };
   const onWheel = (e: React.WheelEvent) => {
     e.preventDefault();
+    hasUserAdjustedViewRef.current = true;
     setView((v) => clamp({ ...v, z: v.z * (e.deltaY > 0 ? 0.92 : 1.08) }));
     setHinted(false);
   };
@@ -293,9 +316,30 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
         <div className="absolute left-3 top-3 z-30 flex flex-col gap-2">
           {(
             [
-              ["＋", "ズームイン", () => setView((v) => clamp({ ...v, z: v.z * 1.2 }))],
-              ["－", "ズームアウト", () => setView((v) => clamp({ ...v, z: v.z * 0.83 }))],
-              ["⟳", "もとに もどす", () => setView({ x: 0, y: 0, z: 1 })],
+              [
+                "＋",
+                "ズームイン",
+                () => {
+                  hasUserAdjustedViewRef.current = true;
+                  setView((v) => clamp({ ...v, z: v.z * 1.2 }));
+                },
+              ],
+              [
+                "－",
+                "ズームアウト",
+                () => {
+                  hasUserAdjustedViewRef.current = true;
+                  setView((v) => clamp({ ...v, z: v.z * 0.83 }));
+                },
+              ],
+              [
+                "⟳",
+                "もとに もどす",
+                () => {
+                  hasUserAdjustedViewRef.current = false;
+                  setView(initialView);
+                },
+              ],
             ] as const
           ).map(([t, lab, fn], i) => (
             <button

--- a/frontend/app/forest/[profileId]/page.tsx
+++ b/frontend/app/forest/[profileId]/page.tsx
@@ -31,6 +31,31 @@ import SeasonalParticles from "@/app/components/forest/SeasonalParticles";
 import FruitLegend from "@/app/components/forest/FruitLegend";
 import ParticleField from "@/app/components/forest/ParticleField";
 
+export function isValidForestProfileId(profileId: number): boolean {
+  return Number.isInteger(profileId) && profileId > 0;
+}
+
+export function normalizeDreamProfilesResponse(value: unknown): DreamProfile[] | null {
+  if (Array.isArray(value)) return value as DreamProfile[];
+
+  console.error("Unexpected dream profiles response for forest detail", value);
+  return null;
+}
+
+export function normalizeProfileDreamsResponse(value: unknown): Dream[] {
+  if (Array.isArray(value)) return value as Dream[];
+
+  console.error("Unexpected dreams response for forest detail", value);
+  return [];
+}
+
+export function findActiveForestProfile(
+  profiles: DreamProfile[],
+  profileId: number
+): DreamProfile | null {
+  return profiles.find((p) => p.id === profileId && !p.archived) ?? null;
+}
+
 // ---- 実タップで開く夢プレビューモーダル -----------------------------------
 function DreamPreviewModal({
   dream,
@@ -110,7 +135,8 @@ export default function ForestProfilePage() {
   const { authStatus } = useAuth();
   const router = useRouter();
   const params = useParams();
-  const profileId = Number(params.profileId);
+  const rawProfileId = params.profileId;
+  const profileId = Number(rawProfileId);
   const reduceMotion = useReducedMotion();
 
   const [profile, setProfile] = useState<DreamProfile | null>(null);
@@ -127,25 +153,40 @@ export default function ForestProfilePage() {
 
   const load = useCallback(async () => {
     setIsLoading(true);
+    if (!isValidForestProfileId(profileId)) {
+      console.error("Invalid forest profileId", rawProfileId);
+      router.replace("/forest");
+      setIsLoading(false);
+      return;
+    }
+
     try {
-      const [allProfiles, profileDreams] = await Promise.all([
+      const [profilesResponse, dreamsResponse]: [unknown, unknown] = await Promise.all([
         getDreamProfiles(),
         getDreamsForProfile(profileId),
       ]);
-      const found = allProfiles.find((p) => p.id === profileId && !p.archived);
+      const allProfiles = normalizeDreamProfilesResponse(profilesResponse);
+      if (!allProfiles) {
+        router.replace("/forest");
+        return;
+      }
+
+      const found = findActiveForestProfile(allProfiles, profileId);
       if (!found) {
         router.replace("/forest");
         return;
       }
+      const profileDreams = normalizeProfileDreamsResponse(dreamsResponse);
       setProfile(found);
       setDreams(profileDreams);
-    } catch {
+    } catch (error) {
+      console.error("Failed to load forest profile detail", error);
       toast.error("きを よみこめませんでした。");
       router.replace("/forest");
     } finally {
       setIsLoading(false);
     }
-  }, [profileId, router]);
+  }, [profileId, rawProfileId, router]);
 
   useEffect(() => {
     if (authStatus === "unauthenticated") {


### PR DESCRIPTION
このPRは作成ブランチに #385 の既存変更も含まれていたため、差分を小さく保つ目的で閉じます。

森詳細画面の修正は、`origin/main` から作り直した `codex/fix-forest-detail-response-guard` ブランチの新しいPRで扱います。