### PR TITLE
fix: 森詳細画面で想定外レスポンス時に落ちないようにする

### DIFF
--- a/frontend/__tests__/components/ForestProfilePage.test.tsx
+++ b/frontend/__tests__/components/ForestProfilePage.test.tsx
@@ -1,0 +1,90 @@
+import type { Dream, DreamProfile } from "@/app/types";
+import {
+  findActiveForestProfile,
+  isValidForestProfileId,
+  normalizeDreamProfilesResponse,
+  normalizeProfileDreamsResponse,
+} from "@/app/forest/[profileId]/page";
+
+function profile(overrides: Partial<DreamProfile> = {}): DreamProfile {
+  return {
+    id: 1,
+    name: "自分",
+    avatar_emoji: "😴",
+    color: "#6366f1",
+    relationship: "self",
+    active: true,
+    position: 0,
+    archived: false,
+    created_at: "2026-06-24T00:00:00Z",
+    updated_at: "2026-06-24T00:00:00Z",
+    dreams_count: 0,
+    ...overrides,
+  };
+}
+
+function dream(overrides: Partial<Dream> = {}): Dream {
+  return {
+    id: 1,
+    title: "森のゆめ",
+    content: "森を歩いた",
+    userId: 1,
+    created_at: "2026-06-24T00:00:00Z",
+    updated_at: "2026-06-24T00:00:00Z",
+    emotions: [],
+    ...overrides,
+  };
+}
+
+describe("ForestProfilePage guards", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("accepts a valid profileId and rejects invalid profileIds before API calls", () => {
+    expect(isValidForestProfileId(1)).toBe(true);
+    expect(isValidForestProfileId(0)).toBe(false);
+    expect(isValidForestProfileId(-1)).toBe(false);
+    expect(isValidForestProfileId(Number.NaN)).toBe(false);
+  });
+
+  it("keeps an empty dreams array safe for rendering", () => {
+    expect(normalizeProfileDreamsResponse([])).toEqual([]);
+  });
+
+  it("falls back to an empty dreams array when the dreams response is unexpected", () => {
+    expect(normalizeProfileDreamsResponse({ error: "temporary failure" })).toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Unexpected dreams response for forest detail",
+      { error: "temporary failure" }
+    );
+  });
+
+  it("keeps an array dreams response unchanged", () => {
+    const dreams = [dream({ id: 10 })];
+    expect(normalizeProfileDreamsResponse(dreams)).toBe(dreams);
+  });
+
+  it("returns null when the profiles response is unexpected", () => {
+    expect(normalizeDreamProfilesResponse({ error: "bad response" })).toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Unexpected dream profiles response for forest detail",
+      { error: "bad response" }
+    );
+  });
+
+  it("finds only active profiles for the requested profileId", () => {
+    const active = profile({ id: 1, archived: false });
+    const archived = profile({ id: 2, archived: true });
+
+    expect(findActiveForestProfile([active, archived], 1)).toBe(active);
+    expect(findActiveForestProfile([active, archived], 2)).toBeNull();
+    expect(findActiveForestProfile([active], 999)).toBeNull();
+  });
+});

--- a/frontend/app/forest/[profileId]/page.tsx
+++ b/frontend/app/forest/[profileId]/page.tsx
@@ -31,6 +31,31 @@ import SeasonalParticles from "@/app/components/forest/SeasonalParticles";
 import FruitLegend from "@/app/components/forest/FruitLegend";
 import ParticleField from "@/app/components/forest/ParticleField";
 
+export function isValidForestProfileId(profileId: number): boolean {
+  return Number.isInteger(profileId) && profileId > 0;
+}
+
+export function normalizeDreamProfilesResponse(value: unknown): DreamProfile[] | null {
+  if (Array.isArray(value)) return value as DreamProfile[];
+
+  console.error("Unexpected dream profiles response for forest detail", value);
+  return null;
+}
+
+export function normalizeProfileDreamsResponse(value: unknown): Dream[] {
+  if (Array.isArray(value)) return value as Dream[];
+
+  console.error("Unexpected dreams response for forest detail", value);
+  return [];
+}
+
+export function findActiveForestProfile(
+  profiles: DreamProfile[],
+  profileId: number
+): DreamProfile | null {
+  return profiles.find((p) => p.id === profileId && !p.archived) ?? null;
+}
+
 // ---- 実タップで開く夢プレビューモーダル -----------------------------------
 function DreamPreviewModal({
   dream,
@@ -110,7 +135,8 @@ export default function ForestProfilePage() {
   const { authStatus } = useAuth();
   const router = useRouter();
   const params = useParams();
-  const profileId = Number(params.profileId);
+  const rawProfileId = params.profileId;
+  const profileId = Number(rawProfileId);
   const reduceMotion = useReducedMotion();
 
   const [profile, setProfile] = useState<DreamProfile | null>(null);
@@ -127,25 +153,40 @@ export default function ForestProfilePage() {
 
   const load = useCallback(async () => {
     setIsLoading(true);
+    if (!isValidForestProfileId(profileId)) {
+      console.error("Invalid forest profileId", rawProfileId);
+      router.replace("/forest");
+      setIsLoading(false);
+      return;
+    }
+
     try {
-      const [allProfiles, profileDreams] = await Promise.all([
+      const [profilesResponse, dreamsResponse]: [unknown, unknown] = await Promise.all([
         getDreamProfiles(),
         getDreamsForProfile(profileId),
       ]);
-      const found = allProfiles.find((p) => p.id === profileId && !p.archived);
+      const allProfiles = normalizeDreamProfilesResponse(profilesResponse);
+      if (!allProfiles) {
+        router.replace("/forest");
+        return;
+      }
+
+      const found = findActiveForestProfile(allProfiles, profileId);
       if (!found) {
         router.replace("/forest");
         return;
       }
+      const profileDreams = normalizeProfileDreamsResponse(dreamsResponse);
       setProfile(found);
       setDreams(profileDreams);
-    } catch {
+    } catch (error) {
+      console.error("Failed to load forest profile detail", error);
       toast.error("きを よみこめませんでした。");
       router.replace("/forest");
     } finally {
       setIsLoading(false);
     }
-  }, [profileId, router]);
+  }, [profileId, rawProfileId, router]);
 
   useEffect(() => {
     if (authStatus === "unauthenticated") {


### PR DESCRIPTION
## Summary

スマホ本番環境で、trial user が `/forest` から木をタップし「この きを 見る」を押すと、`frontend/app/error.tsx` のグローバルエラー画面が表示される問題を修正しました。

`/forest/[profileId]` で `profileId` や APIレスポンスの形を検証し、配列前提の処理に想定外データが流れ込まないようにしました。

## Changes

- `profileId` が `NaN` / `0` / 負数など不正な場合、APIを呼ばず `/forest` に戻す
- `getDreamProfiles()` の結果が配列でない場合は `console.error` に残して `/forest` に戻す
- `getDreamsForProfile()` の結果が配列でない場合は `console.error` に残しつつ `[]` にフォールバック
- `dreams.slice(...)` など配列前提の処理へ、配列でない値が流れ込まないようにする
- profile が見つからない / archived の場合は従来どおり `/forest` に戻す
- `ForestProfilePage` のテストを追加

## Tests

```bash
cd frontend
npx jest __tests__/components/ForestProfilePage.test.tsx
```

- 6 passed

```bash
cd frontend
npx jest __tests__/components/ForestProfilePage.test.tsx __tests__/components/ForestScene.test.tsx
```

- 9 passed

## Scope

以下には触れていません。

- backend/API/DB
- `ForestScene` の初期表示補正
- summary / emotionTie 系
- trial user 作成処理
- Sentry本格対応

## Preview / 実機確認項目

- `/forest` を開く
- 木が見える
- 木をタップする
- プレビューシートが出る
- 「この きを 見る」を押す
- グローバルエラーが出ない
- 夢0件でも落ちない
- 森へ戻れる
