### PR TITLE
fix: 森アニメーション操作時の未捕捉エラーを防ぐ

### DIFF
--- a/frontend/__tests__/components/ForestScene.test.tsx
+++ b/frontend/__tests__/components/ForestScene.test.tsx
@@ -1,4 +1,8 @@
-import { getInitialForestView } from "@/app/components/forest/ForestScene";
+import {
+  clampForestView,
+  getInitialForestView,
+  getSafePinchZoom,
+} from "@/app/components/forest/ForestScene";
 
 describe("getInitialForestView", () => {
   it("プロフィール1件で森が画面より広い場合、木が初期表示の中央に入る位置へ寄せる", () => {
@@ -13,5 +17,39 @@ describe("getInitialForestView", () => {
   it("複数プロフィールでは既存表示を大きく変えない", () => {
     expect(getInitialForestView(2, 1180, 360)).toEqual({ x: 0, y: 0, z: 1 });
     expect(getInitialForestView(4, 1180, 360)).toEqual({ x: 0, y: 0, z: 1 });
+  });
+});
+
+describe("clampForestView", () => {
+  it("NaN や Infinity が来ても安全な view に戻す", () => {
+    expect(clampForestView({ x: Number.NaN, y: Infinity, z: -Infinity }, 1180, 360, 560)).toEqual({
+      x: 0,
+      y: 0,
+      z: 1,
+    });
+  });
+
+  it("通常の view は既存の範囲制限を維持する", () => {
+    expect(clampForestView({ x: 100, y: 100, z: 3 }, 1180, 960, 560)).toEqual({
+      x: 40,
+      y: 60,
+      z: 2.2,
+    });
+  });
+});
+
+describe("getSafePinchZoom", () => {
+  it("ピンチ開始距離が 0 の場合はズーム計算をスキップする", () => {
+    expect(getSafePinchZoom(1, 120, 0)).toBeNull();
+  });
+
+  it("NaN や Infinity が混ざる場合はズーム計算をスキップする", () => {
+    expect(getSafePinchZoom(1, Number.NaN, 120)).toBeNull();
+    expect(getSafePinchZoom(1, 120, Infinity)).toBeNull();
+    expect(getSafePinchZoom(Number.NaN, 120, 100)).toBeNull();
+  });
+
+  it("正常なピンチ距離では次のズーム値を返す", () => {
+    expect(getSafePinchZoom(1, 150, 100)).toBe(1.5);
   });
 });

--- a/frontend/__tests__/components/ParticleField.test.tsx
+++ b/frontend/__tests__/components/ParticleField.test.tsx
@@ -1,0 +1,37 @@
+import { render } from "@testing-library/react";
+import ParticleField from "@/app/components/forest/ParticleField";
+
+describe("ParticleField", () => {
+  const originalResizeObserver = global.ResizeObserver;
+  const originalGetContext = HTMLCanvasElement.prototype.getContext;
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    global.ResizeObserver = originalResizeObserver;
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+    consoleErrorSpy.mockRestore();
+    jest.restoreAllMocks();
+  });
+
+  it("does not crash when ResizeObserver is unavailable", () => {
+    global.ResizeObserver = undefined as any;
+
+    expect(() => {
+      render(<ParticleField phase="day" season="summer" />);
+    }).not.toThrow();
+  });
+
+  it("does not crash when canvas 2d context is unavailable", () => {
+    HTMLCanvasElement.prototype.getContext = jest.fn(() => null) as any;
+
+    expect(() => {
+      render(<ParticleField phase="day" season="summer" />);
+    }).not.toThrow();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith("ParticleField canvas 2d context is unavailable");
+  });
+});

--- a/frontend/__tests__/components/TreePreviewSheet.test.tsx
+++ b/frontend/__tests__/components/TreePreviewSheet.test.tsx
@@ -42,8 +42,15 @@ function dream(overrides: Partial<Dream>): Dream {
 }
 
 describe("TreePreviewSheet", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
+    consoleErrorSpy.mockRestore();
   });
 
   it("clears the previous recent dream when loading another profile fails", async () => {
@@ -75,6 +82,69 @@ describe("TreePreviewSheet", () => {
 
     await waitFor(() => {
       expect(screen.queryByText(/前の木のゆめ/)).not.toBeInTheDocument();
+      expect(screen.queryByText("さいきんの ゆめ：")).not.toBeInTheDocument();
+    });
+  });
+
+  it("ignores a non-array dreams response without crashing", async () => {
+    mockedGetDreamsForProfile.mockResolvedValueOnce({ error: "bad response" } as any);
+
+    render(
+      <TreePreviewSheet
+        profile={profile({ id: 1, name: "自分" })}
+        onOpen={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockedGetDreamsForProfile).toHaveBeenCalledWith(1);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("さいきんの ゆめ：")).not.toBeInTheDocument();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Unexpected dreams response for tree preview sheet",
+        { error: "bad response" }
+      );
+    });
+  });
+
+  it("treats malformed recent dream emotions as empty", async () => {
+    mockedGetDreamsForProfile.mockResolvedValueOnce([
+      dream({ title: "ふしぎな森", emotions: "bad" as any }),
+    ]);
+
+    render(
+      <TreePreviewSheet
+        profile={profile({ id: 1, name: "自分" })}
+        onOpen={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(await screen.findByText(/ふしぎな森/)).toBeInTheDocument();
+    expect(screen.queryByText("喜び")).not.toBeInTheDocument();
+  });
+
+  it("does not render malformed recent dream titles", async () => {
+    mockedGetDreamsForProfile.mockResolvedValueOnce([
+      dream({ title: null as any }),
+    ]);
+
+    render(
+      <TreePreviewSheet
+        profile={profile({ id: 1, name: "自分" })}
+        onOpen={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockedGetDreamsForProfile).toHaveBeenCalledWith(1);
+    });
+
+    await waitFor(() => {
       expect(screen.queryByText("さいきんの ゆめ：")).not.toBeInTheDocument();
     });
   });

--- a/frontend/app/components/forest/Critters.tsx
+++ b/frontend/app/components/forest/Critters.tsx
@@ -28,8 +28,12 @@ function Critter({ data, fieldW, motion }: CritterProps) {
       el.style.transform = `translateX(-50%) scaleX(${st.current.dir})`;
       return;
     }
-    let raf: number;
+    let raf = 0;
+    let disposed = false;
     const tick = () => {
+      if (disposed) return;
+      const el = elRef.current;
+      if (!el) return;
       const s = st.current;
       s.ph += 0.016;
       s.x += s.dir * data.speed;
@@ -48,7 +52,10 @@ function Critter({ data, fieldW, motion }: CritterProps) {
       raf = requestAnimationFrame(tick);
     };
     raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(raf);
+    };
   }, [motion, fieldW, data]);
 
   return (

--- a/frontend/app/components/forest/ForestScene.tsx
+++ b/frontend/app/components/forest/ForestScene.tsx
@@ -30,6 +30,29 @@ export function getInitialForestView(profileCount: number, fieldW: number, viewp
   return { x: 0, y: 0, z: 1 };
 }
 
+export function clampForestView(v: ForestView, fieldW: number, viewportW: number, viewportH: number): ForestView {
+  const safeZ = Number.isFinite(v.z) ? v.z : 1;
+  const safeX = Number.isFinite(v.x) ? v.x : 0;
+  const safeY = Number.isFinite(v.y) ? v.y : 0;
+  const z = Math.max(0.7, Math.min(2.2, safeZ));
+
+  return {
+    z,
+    x: Math.max(Math.min(safeX, 40), Math.min(-(fieldW * z - viewportW) - 40, 40)),
+    y: Math.max(Math.min(safeY, 60), Math.min(-(viewportH * z - viewportH) - 40, 60)),
+  };
+}
+
+export function getSafePinchZoom(startZoom: number, currentDistance: number, startDistance: number): number | null {
+  if (!Number.isFinite(startZoom) || !Number.isFinite(currentDistance) || !Number.isFinite(startDistance)) {
+    return null;
+  }
+  if (startDistance <= 0) return null;
+
+  const nextZoom = startZoom * (currentDistance / startDistance);
+  return Number.isFinite(nextZoom) ? nextZoom : null;
+}
+
 export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) {
   const reduceMotion = useReducedMotion();
   const router = useRouter();
@@ -69,14 +92,7 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
   const [hinted, setHinted] = useState(true);
 
   const clamp = useCallback(
-    (v: { x: number; y: number; z: number }) => {
-      const z = Math.max(0.7, Math.min(2.2, v.z));
-      return {
-        z,
-        x: Math.max(Math.min(v.x, 40), Math.min(-(fieldW * z - W) - 40, 40)),
-        y: Math.max(Math.min(v.y, 60), Math.min(-(H * z - H) - 40, 60)),
-      };
-    },
+    (v: ForestView) => clampForestView(v, fieldW, W, H),
     [fieldW, W, H]
   );
 
@@ -105,7 +121,8 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
       dragRef.current = { sx: e.clientX, sy: e.clientY, vx: view.x, vy: view.y };
     } else if (pointers.current.size === 2) {
       const pts = [...pointers.current.values()];
-      pinch.current = { dist: Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y), z: view.z };
+      const dist = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+      pinch.current = Number.isFinite(dist) && dist > 0 ? { dist, z: view.z } : null;
       dragRef.current = null;
     }
   };
@@ -123,7 +140,9 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
       }
       const pts = [...pointers.current.values()];
       const dist = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
-      setView((v) => clamp({ ...v, z: pinch.current!.z * (dist / pinch.current!.dist) }));
+      const nextZoom = getSafePinchZoom(pinch.current.z, dist, pinch.current.dist);
+      if (nextZoom === null) return;
+      setView((v) => clamp({ ...v, z: nextZoom }));
     } else if (dragRef.current) {
       const dx = e.clientX - dragRef.current.sx;
       const dy = e.clientY - dragRef.current.sy;

--- a/frontend/app/components/forest/ParticleField.tsx
+++ b/frontend/app/components/forest/ParticleField.tsx
@@ -18,7 +18,8 @@ interface ParticleFieldProps {
 function makeGlow(size: number, inner: string, outer: string): HTMLCanvasElement {
   const c = document.createElement("canvas");
   c.width = c.height = size;
-  const x = c.getContext("2d")!;
+  const x = c.getContext("2d");
+  if (!x) return c;
   const g = x.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
   g.addColorStop(0, inner); g.addColorStop(0.45, outer); g.addColorStop(1, "rgba(0,0,0,0)");
   x.fillStyle = g; x.beginPath(); x.arc(size / 2, size / 2, size / 2, 0, 7); x.fill();
@@ -37,9 +38,15 @@ export default function ParticleField({ phase, season, weather = "firefly", star
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext("2d")!;
+    const maybeContext = canvas.getContext("2d");
+    if (!maybeContext) {
+      console.error("ParticleField canvas 2d context is unavailable");
+      return;
+    }
+    const ctx: CanvasRenderingContext2D = maybeContext;
     const dpr = Math.min(1.5, window.devicePixelRatio || 1);
     let W = 0, H = 0;
+    let disposed = false;
 
     const fireGlow = makeGlow(40, "rgba(253,230,138,1)", "rgba(251,191,36,0.55)");
     const moteGlow = makeGlow(28, "rgba(199,210,254,0.85)", "rgba(199,210,254,0.18)");
@@ -70,11 +77,12 @@ export default function ParticleField({ phase, season, weather = "firefly", star
     }
 
     function resize() {
-      if (!canvas) return;
-      const r = canvas.getBoundingClientRect();
+      const currentCanvas = canvasRef.current;
+      if (disposed || !currentCanvas) return;
+      const r = currentCanvas.getBoundingClientRect();
       W = r.width; H = r.height;
-      canvas.width  = Math.max(1, W * dpr);
-      canvas.height = Math.max(1, H * dpr);
+      currentCanvas.width  = Math.max(1, W * dpr);
+      currentCanvas.height = Math.max(1, H * dpr);
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       seed();
       if (!propsRef.current.motion) frame(performance.now());
@@ -85,6 +93,7 @@ export default function ParticleField({ phase, season, weather = "firefly", star
     let raf = 0, lastT = 0;
 
     function frame(now: number) {
+      if (disposed || !canvasRef.current) return;
       const P = propsRef.current;
       const moving = P.motion;
       if (moving && now - lastT < FRAME_MS) {
@@ -180,9 +189,13 @@ export default function ParticleField({ phase, season, weather = "firefly", star
 
     resize();
     if (propsRef.current.motion) raf = requestAnimationFrame(frame);
-    const ro = new ResizeObserver(resize);
-    ro.observe(canvas);
-    return () => { cancelAnimationFrame(raf); ro.disconnect(); };
+    const ro = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(resize);
+    ro?.observe(canvas);
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(raf);
+      ro?.disconnect();
+    };
   }, [reduceMotion]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (

--- a/frontend/app/components/forest/TreePreviewSheet.tsx
+++ b/frontend/app/components/forest/TreePreviewSheet.tsx
@@ -14,6 +14,21 @@ interface TreePreviewSheetProps {
   onClose: () => void;
 }
 
+function normalizeRecentDreamsResponse(value: unknown): Dream[] {
+  if (Array.isArray(value)) return value as Dream[];
+
+  console.error("Unexpected dreams response for tree preview sheet", value);
+  return [];
+}
+
+function dreamTitle(dream: Dream): string | null {
+  return typeof dream.title === "string" ? dream.title : null;
+}
+
+function dreamEmotions(dream: Dream): NonNullable<Dream["emotions"]> {
+  return Array.isArray(dream.emotions) ? dream.emotions : [];
+}
+
 /**
  * 木をタップしたときに下からスライドアップするプレビューシート。
  * プロフィール・直近の夢・感情タグを表示し、「この きを 見る ›」で詳細へ遷移。
@@ -33,13 +48,17 @@ export default function TreePreviewSheet({ profile, onOpen, onClose }: TreePrevi
     setLoading(true);
     setRecentDream(null);
     getDreamsForProfile(profile.id)
-      .then((dreams) => { if (!cancelled) setRecentDream(dreams[0] ?? null); })
+      .then((dreams) => {
+        if (!cancelled) setRecentDream(normalizeRecentDreamsResponse(dreams)[0] ?? null);
+      })
       .catch(() => {/* silently ignore — sheet still useful without recent dream */})
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
   }, [profile?.id]);
 
   const lvl = profile ? getGrowthLevel(profile.dreams_count ?? 0) : null;
+  const recentDreamTitle = recentDream ? dreamTitle(recentDream) : null;
+  const recentDreamEmotions = recentDream ? dreamEmotions(recentDream) : [];
 
   return (
     <AnimatePresence>
@@ -79,13 +98,13 @@ export default function TreePreviewSheet({ profile, onOpen, onClose }: TreePrevi
           </div>
 
           {/* recent dream */}
-          {!loading && recentDream && (
+          {!loading && recentDream && recentDreamTitle && (
             <div className="mb-3 text-[13px] leading-relaxed text-white/80">
               <span className="text-white/50">さいきんの ゆめ：</span>
-              「{recentDream.title}」
-              {(recentDream.emotions?.length ?? 0) > 0 && (
+              「{recentDreamTitle}」
+              {recentDreamEmotions.length > 0 && (
                 <div className="mt-1.5 flex flex-wrap gap-1.5">
-                  {recentDream.emotions!.map((e) => (
+                  {recentDreamEmotions.map((e) => (
                     <span
                       key={e.id}
                       className="rounded-full px-2 py-0.5 text-[11.5px] font-bold"

--- a/frontend/app/components/forest/WalkingMorpheus.tsx
+++ b/frontend/app/components/forest/WalkingMorpheus.tsx
@@ -59,15 +59,18 @@ export default function WalkingMorpheus({ fieldW, baseY = 0 }: WalkingMorpheusPr
 
   // walk animation (DOM writes, no React state per frame)
   useEffect(() => {
-    const outer = outerRef.current;
-    const photo = photoRef.current;
-    if (!outer) return;
+    if (!outerRef.current) return;
     if (!motion) {
-      outer.style.left = st.current.x + "px";
+      outerRef.current.style.left = st.current.x + "px";
       return;
     }
-    let raf: number, t0 = performance.now();
+    let raf = 0, t0 = performance.now();
+    let disposed = false;
     const step = (now: number) => {
+      if (disposed) return;
+      const outer = outerRef.current;
+      if (!outer) return;
+      const photo = photoRef.current;
       const dt = Math.min(48, now - t0); t0 = now;
       const s = st.current;
       const diff = s.target - s.x;
@@ -80,7 +83,10 @@ export default function WalkingMorpheus({ fieldW, baseY = 0 }: WalkingMorpheusPr
       raf = requestAnimationFrame(step);
     };
     raf = requestAnimationFrame(step);
-    return () => cancelAnimationFrame(raf);
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(raf);
+    };
   }, [motion]);
 
   return (


### PR DESCRIPTION
## Summary

スマホ本番環境で `/forest` のアニメーション領域をタップ・ドラッグ・ピンチ操作した際に、まれに `frontend/app/error.tsx` のグローバルエラー画面が表示される問題への防御を追加しました。

森画面内のアニメーション部品・プレビューシート・ピンチ操作時の view 計算に対して、想定外値や unmount 後処理で落ちないように最小ガードを追加しています。

## Changes

- `ParticleField`
  - `canvas.getContext("2d")` が `null` の場合は描画 effect を終了
  - `ResizeObserver` が `undefined` の場合でも初回 resize のみで継続
  - RAF と `ResizeObserver` の cleanup を強化

- `WalkingMorpheus` / `Critters`
  - RAF ループ内で毎回 `ref.current` を確認
  - unmount 後の DOM write を防止

- `TreePreviewSheet`
  - `getDreamsForProfile()` が配列以外を返しても `[]` にフォールバック
  - `recentDream.emotions` が配列でない場合は空配列扱い
  - `recentDream.title` が文字列でない場合も落ちないようにする

- `ForestScene`
  - `clampForestView()` を切り出し
  - `x / y / z` に `NaN` や `Infinity` が来た場合、安全な値に戻す
  - `getSafePinchZoom()` を追加し、ピンチ距離が `0` / 非有限値の場合は `setView` しない

## Tests

```bash
cd frontend
npx jest __tests__/components/ForestScene.test.tsx
```

- 1 suite / 8 tests passed

```bash
cd frontend
npx jest __tests__/components/ParticleField.test.tsx __tests__/components/TreePreviewSheet.test.tsx __tests__/components/ForestScene.test.tsx __tests__/components/ForestProfilePage.test.tsx
```

- 4 suites / 20 tests passed

```bash
npm run build
```

- production build succeeded

## Scope

以下には触れていません。

- backend/API/DB
- `/forest/[profileId]`
- ForestScene の初期表示補正
- summary / emotionTie 系
- Trial 系
- framer-motion 依存更新
- 未追跡の `docs/`、`outputs/`、`frontend/public/images/morpheus/generated/`

## Preview / 実機確認項目

- `/forest` を開いて30秒待つ
- 背景を軽くタップ
- 背景を1本指でドラッグ
- 2本指ピンチをゆっくり試す
- 2本指ピンチを速めに試す
- `＋ / － / ⟳` ボタンを押す
- 木をタップしてプレビューシートが出る
- 「この きを見る」を押して詳細へ移動できる
- 森へ戻れる
- `うまく ひらけなかったよ` が出ない