### PR TITLE
feat: 既存の夢をselfプロフィールへ割り当てるバックフィルrakeを追加

### DIFF
--- a/backend/lib/tasks/dream_profiles.rake
+++ b/backend/lib/tasks/dream_profiles.rake
@@ -25,4 +25,29 @@ namespace :dream_profiles do
 
     puts "完了: 対象 #{total} ユーザー | 作成 #{created} 件 | スキップ #{skipped} 件"
   end
+
+  desc "dream_profile_id が未設定の既存の夢を、各ユーザーの「自分」プロフィールへ割り当てる（冪等・バッチ）"
+  task backfill_dream_profile_id: :environment do
+    assigned      = 0
+    skipped_users = 0
+
+    User.find_each do |user|
+      self_profile = user.dream_profiles.find_by(relationship: "self")
+      # self プロフィールが無いユーザーは先に ensure_self_profiles が必要。ここでは落とさず飛ばす。
+      unless self_profile
+        skipped_users += 1
+        next
+      end
+
+      # 未設定（NULL）の夢だけをバッチで埋める。既に割り当て済みの夢は触らない（＝冪等）。
+      # update_column でバリデーション/コールバックをスキップし、古いレコードでも安全に FK だけ設定する。
+      user.dreams.where(dream_profile_id: nil).find_each do |dream|
+        dream.update_column(:dream_profile_id, self_profile.id)
+        assigned += 1
+      end
+    end
+
+    remaining = Dream.where(dream_profile_id: nil).count
+    puts "完了: 割当 #{assigned} 件 | selfなしスキップ #{skipped_users} ユーザー | 残NULL #{remaining} 件"
+  end
 end

--- a/backend/spec/tasks/dream_profiles_rake_spec.rb
+++ b/backend/spec/tasks/dream_profiles_rake_spec.rb
@@ -127,3 +127,67 @@ RSpec.describe 'rake dream_profiles:ensure_self_profiles' do
     end
   end
 end
+
+RSpec.describe 'rake dream_profiles:backfill_dream_profile_id' do
+  before(:all) do
+    Rails.application.load_tasks
+  end
+
+  def invoke_task
+    Rake::Task['dream_profiles:backfill_dream_profile_id'].reenable
+    original = $stdout
+    $stdout = StringIO.new
+    Rake::Task['dream_profiles:backfill_dream_profile_id'].invoke
+  ensure
+    $stdout = original
+  end
+
+  context 'dream_profile_id が未設定の夢があるユーザー' do
+    let!(:user) { create(:user) }
+    let!(:self_profile) { create(:dream_profile, :self_profile, user: user) }
+    let!(:legacy_dream) { create(:dream, user: user, dream_profile_id: nil) }
+
+    it '未設定の夢を self プロフィールに割り当てる' do
+      invoke_task
+      expect(legacy_dream.reload.dream_profile_id).to eq(self_profile.id)
+    end
+
+    it '実行後は未設定の夢が残らない' do
+      invoke_task
+      expect(Dream.where(dream_profile_id: nil).count).to eq(0)
+    end
+  end
+
+  context 'すでに別プロフィールが割り当て済みの夢' do
+    let!(:user) { create(:user) }
+    let!(:self_profile) { create(:dream_profile, :self_profile, user: user) }
+    let!(:other_profile) { create(:dream_profile, user: user) }
+    let!(:assigned_dream) { create(:dream, user: user, dream_profile_id: other_profile.id) }
+
+    it '割り当て済みの夢は変更しない（冪等）' do
+      expect { invoke_task }.not_to change { assigned_dream.reload.dream_profile_id }
+      expect(assigned_dream.dream_profile_id).to eq(other_profile.id)
+    end
+  end
+
+  context 'self プロフィールが無いユーザー' do
+    let!(:user) { create(:user) }
+    let!(:orphan_dream) { create(:dream, user: user, dream_profile_id: nil) }
+
+    it 'スキップして落ちず、その夢は未設定のまま残る' do
+      expect { invoke_task }.not_to raise_error
+      expect(orphan_dream.reload.dream_profile_id).to be_nil
+    end
+  end
+
+  context '2回実行した場合' do
+    let!(:user) { create(:user) }
+    let!(:self_profile) { create(:dream_profile, :self_profile, user: user) }
+    let!(:legacy_dream) { create(:dream, user: user, dream_profile_id: nil) }
+
+    it '2回目で割り当て先が変わらない' do
+      invoke_task
+      expect { invoke_task }.not_to change { legacy_dream.reload.dream_profile_id }
+    end
+  end
+end


### PR DESCRIPTION
## 背景

Phase 5 の `dreams.dream_profile_id` を最終的に **NOT NULL** にしたい。新規の夢は `DreamsController` が自動でプロフィールを設定するが、**列追加より前に作られた古い夢**は `dream_profile_id = NULL` のまま残っている可能性がある。NOT NULL化の前に、この空欄を埋めるバックフィルが必要。

既存の `dream_profiles:ensure_self_profiles` は「自分プロフィールを作る」だけで、**夢への割り当ては行わない**ため、本タスクを追加する。

## 変更内容（rake + spec の2ファイルのみ）

- `dream_profiles:backfill_dream_profile_id` を追加
  - `dream_profile_id = NULL` の夢だけを `find_each` バッチで各ユーザーの「自分」プロフィールへ割り当て
  - **冪等**（再実行しても割り当て済みは触らない）
  - `update_column` でバリデーション/コールバックをスキップし、古いレコードでも安全に FK のみ設定
  - selfプロフィール未作成ユーザーは落とさずスキップ＋件数報告
  - 実行後の残NULL件数を出力（NOT NULL化前のゲート確認用）
- RSpec 4件追加（NULL割当 / 別プロフィールは不変 / selfなしスキップで非クラッシュ / 冪等）

## テスト

RSpec **14 examples, 0 failures**（既存ensure_self_profiles 10 ＋ backfill 4）

## 運用手順（このPRマージ後・本番は別判断）

```
1. Render console: Dream.where(dream_profile_id: nil).count で空欄数を確認
2. rake dream_profiles:ensure_self_profiles   # selfプロフィールを全員に用意
3. rake dream_profiles:backfill_dream_profile_id  # 空欄を埋める
4. Dream.where(dream_profile_id: nil).count == 0 を確認
5. （別PR）change_column_null :dreams, :dream_profile_id, false を適用
```

## スコープ外

- 本番DBでの実行（Renderでの判断）
- NOT NULL migration 本体（バックフィル実行・残NULL=0確認の後の別PR）
- trial convert 系（別途調査中のため非干渉）