### PR TITLE
fix: trial登録時の通常登録フォールバックを防ぐ

### DIFF
--- a/frontend/__tests__/app/register/page.test.tsx
+++ b/frontend/__tests__/app/register/page.test.tsx
@@ -4,8 +4,10 @@ import RegisterPage from "@/app/register/page";
 import { useAuth } from "@/context/AuthContext";
 import { clientRegister, convertTrial } from "@/lib/apiClient";
 
+const mockPush = jest.fn();
+
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push: jest.fn() }),
+  useRouter: () => ({ push: mockPush }),
 }));
 
 jest.mock("@/context/AuthContext", () => ({
@@ -73,6 +75,34 @@ beforeEach(() => {
 });
 
 describe("RegisterPage トライアル昇格の分岐", () => {
+  it("認証確認中は submit ボタンが disabled になる", () => {
+    mockedUseAuth.mockReturnValue(
+      makeAuth({
+        authStatus: "checking",
+      })
+    );
+
+    render(<RegisterPage />);
+
+    expect(screen.getByRole("button", { name: /じゅんび/ })).toBeDisabled();
+  });
+
+  it("認証確認中に submit されても register / convert は呼ばない", async () => {
+    mockedUseAuth.mockReturnValue(
+      makeAuth({
+        authStatus: "checking",
+      })
+    );
+
+    render(<RegisterPage />);
+    fireEvent.submit(document.querySelector("form") as HTMLFormElement);
+
+    await waitFor(() => {
+      expect(mockedClientRegister).not.toHaveBeenCalled();
+      expect(mockedConvertTrial).not.toHaveBeenCalled();
+    });
+  });
+
   it("トライアルユーザーは convertTrial を呼ぶ（clientRegisterは呼ばない）", async () => {
     mockedUseAuth.mockReturnValue(
       makeAuth({
@@ -96,6 +126,40 @@ describe("RegisterPage トライアル昇格の分岐", () => {
     fillAndSubmit();
 
     await waitFor(() => expect(mockedClientRegister).toHaveBeenCalledTimes(1));
+    expect(mockedConvertTrial).not.toHaveBeenCalled();
+  });
+
+  it("認証済みだが user が null の場合は clientRegister にフォールバックしない", async () => {
+    mockedUseAuth.mockReturnValue(
+      makeAuth({
+        authStatus: "authenticated",
+        isLoggedIn: true,
+        user: null,
+      })
+    );
+
+    render(<RegisterPage />);
+    fillAndSubmit();
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/home"));
+    expect(mockedClientRegister).not.toHaveBeenCalled();
+    expect(mockedConvertTrial).not.toHaveBeenCalled();
+  });
+
+  it("認証済み通常ユーザーは clientRegister を呼ばず /home に戻す", async () => {
+    mockedUseAuth.mockReturnValue(
+      makeAuth({
+        authStatus: "authenticated",
+        isLoggedIn: true,
+        user: { id: "2", trial_user: false } as AuthValue["user"],
+      })
+    );
+
+    render(<RegisterPage />);
+    fillAndSubmit();
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/home"));
+    expect(mockedClientRegister).not.toHaveBeenCalled();
     expect(mockedConvertTrial).not.toHaveBeenCalled();
   });
 });

--- a/frontend/__tests__/context/AuthContext.test.tsx
+++ b/frontend/__tests__/context/AuthContext.test.tsx
@@ -112,6 +112,38 @@ beforeEach(() => {
   mockedUseRouter.mockReturnValue({ push: jest.fn() } as never);
 });
 
+describe("/register の認証確認", () => {
+  it("authHint がなくても /register では verify を実行する", async () => {
+    mockedUsePathname.mockReturnValue("/register");
+    mockedGet.mockResolvedValue({
+      user: { id: 9, trial_user: true },
+    } as never);
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(mockedGet).toHaveBeenCalledWith("/auth/verify");
+      expect(captured.authStatus).toBe("authenticated");
+    });
+    expect(captured.user).toEqual({ id: "9", trial_user: true });
+    expect(localStorage.getItem(AUTH_HINT_KEY)).toBe("1");
+  });
+
+  it("未認証の新規ユーザーが /register を開くと verify 後に unauthenticated になる", async () => {
+    mockedUsePathname.mockReturnValue("/register");
+    mockedGet.mockRejectedValue(makeApiError(401));
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(mockedGet).toHaveBeenCalledWith("/auth/verify");
+      expect(captured.authStatus).toBe("unauthenticated");
+    });
+    expect(captured.user).toBeNull();
+    expect(localStorage.getItem(AUTH_HINT_KEY)).toBeNull();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // 1. 非一時障害エラー → 恒久的障害としてログアウト扱い
 //    対象: 401 / 403 / 404 / 500 （TRANSIENT_STATUSES 外のすべて）

--- a/frontend/__tests__/proxy.test.ts
+++ b/frontend/__tests__/proxy.test.ts
@@ -1,0 +1,19 @@
+import { shouldAllowAuthPageForUser } from "@/lib/authPageRedirect";
+
+describe("shouldAllowAuthPageForUser", () => {
+  it("trial user は /register を通過できる", () => {
+    expect(shouldAllowAuthPageForUser("/register", { trial_user: true })).toBe(true);
+  });
+
+  it("trial user でも /login は従来どおり通過対象にしない", () => {
+    expect(shouldAllowAuthPageForUser("/login", { trial_user: true })).toBe(false);
+  });
+
+  it("通常ユーザーは /register を通過対象にしない", () => {
+    expect(shouldAllowAuthPageForUser("/register", { trial_user: false })).toBe(false);
+  });
+
+  it("ユーザー情報が読めない場合は /register を通過対象にしない", () => {
+    expect(shouldAllowAuthPageForUser("/register", null)).toBe(false);
+  });
+});

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -43,6 +43,7 @@ export default function Register() {
   const [isLoading, setIsLoading] = useState(false);
   const { login, authStatus, user } = useAuth();
   const router = useRouter();
+  const isAuthChecking = authStatus === "checking";
 
   // 認証済みでも trial_user は本登録フォームに進めるため除外する
   useEffect(() => {
@@ -54,6 +55,12 @@ export default function Register() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
+
+    if (isAuthChecking) {
+      setError("ログインじょうたいを かくにんしているよ。すこし まってね。");
+      return;
+    }
+
     setIsLoading(true);
 
     // 2. 入力内容のチェックを強化
@@ -97,9 +104,14 @@ export default function Register() {
         password,
         password_confirmation: passwordConfirmation,
       };
-      // トライアルユーザーは「昇格」して同じアカウントのまま夢を引き継ぐ。
-      // それ以外は従来どおり新規登録する。
-      const { user: nextUser } = user?.trial_user
+      // トライアル判定が不明な状態では通常登録にフォールバックしない。
+      // 認証済み通常ユーザーは既存アカウントを保護するため /home へ戻す。
+      if (authStatus === "authenticated" && user?.trial_user !== true) {
+        router.push("/home");
+        return;
+      }
+
+      const { user: nextUser } = authStatus === "authenticated"
         ? await convertTrial(credentials)
         : await clientRegister(credentials);
       // 成功したら、取得したユーザー情報でログイン処理を呼び出します。
@@ -330,10 +342,10 @@ export default function Register() {
 
           <button
             type="submit"
-            disabled={isLoading}
+            disabled={isLoading || isAuthChecking}
             className="w-full py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring active:bg-primary/80 transition-colors duration-200 ease-in-out disabled:opacity-50"
           >
-            {isLoading ? "じゅんび しているよ..." : "はじめる"}
+            {isLoading || isAuthChecking ? "じゅんび しているよ..." : "はじめる"}
           </button>
         </div>
         {error && (

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -28,7 +28,14 @@ type AuthContextType = {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 const AUTH_HINT_KEY = "dreamjournal_auth_hint";
-const PROTECTED_PATH_PREFIXES = ["/home", "/dream", "/forest", "/settings", "/subscription"];
+const AUTH_VERIFY_PATH_PREFIXES = [
+  "/home",
+  "/dream",
+  "/forest",
+  "/settings",
+  "/subscription",
+  "/register",
+];
 
 function hasAuthHint(): boolean {
   if (typeof window === "undefined") return false;
@@ -44,15 +51,15 @@ function setAuthHint(enabled: boolean): void {
   }
 }
 
-function isProtectedPath(pathname: string | null): boolean {
+function shouldVerifyPath(pathname: string | null): boolean {
   if (!pathname) return false;
-  return PROTECTED_PATH_PREFIXES.some(
+  return AUTH_VERIFY_PATH_PREFIXES.some(
     (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
   );
 }
 
 function getInitialAuthStatus(pathname: string | null): AuthStatus {
-  return isProtectedPath(pathname) ? "checking" : "unauthenticated";
+  return shouldVerifyPath(pathname) ? "checking" : "unauthenticated";
 }
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
@@ -79,7 +86,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     let mounted = true;
     retryCountRef.current = 0;
 
-    const shouldVerify = hasAuthHint() || isProtectedPath(pathname);
+    const shouldVerify = hasAuthHint() || shouldVerifyPath(pathname);
 
     if (!shouldVerify) {
       setAuthStatus("unauthenticated");

--- a/frontend/e2e/registration-flow.spec.ts
+++ b/frontend/e2e/registration-flow.spec.ts
@@ -135,7 +135,10 @@ test.describe("ユーザー登録フロー", () => {
   });
 
   test("登録成功でホームページに遷移する", async ({ page }) => {
+    let registered = false;
+
     await page.route("**/auth/register", async (route) => {
+      registered = true;
       await route.fulfill({
         status: 201,
         contentType: "application/json",
@@ -147,6 +150,15 @@ test.describe("ユーザー登録フロー", () => {
 
     // 登録後の認証検証（登録直後のリダイレクト先 /home で verify が呼ばれる）
     await page.route("**/auth/verify", async (route) => {
+      if (!registered) {
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Unauthorized" }),
+        });
+        return;
+      }
+
       await route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/frontend/e2e/registration-flow.spec.ts
+++ b/frontend/e2e/registration-flow.spec.ts
@@ -10,6 +10,13 @@ test.describe("ユーザー登録フロー", () => {
         body: JSON.stringify({ error: "Unauthorized" }),
       });
     });
+    await page.route("**/auth/refresh", async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Unauthorized" }),
+      });
+    });
   });
 
   test("登録フォームが表示される", async ({ page }) => {

--- a/frontend/lib/authPageRedirect.ts
+++ b/frontend/lib/authPageRedirect.ts
@@ -1,0 +1,6 @@
+export function shouldAllowAuthPageForUser(
+  pathname: string,
+  user: { trial_user?: boolean } | null | undefined
+): boolean {
+  return pathname.startsWith("/register") && user?.trial_user === true;
+}

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { shouldAllowAuthPageForUser } from "./lib/authPageRedirect";
 
 const API_PREFIX_PATTERN = /\/api\/v1\/?$/;
 
@@ -70,7 +71,13 @@ export async function proxy(request: NextRequest) {
       });
 
       if (response.ok && isAuthPage) {
-        // Logged in, and on an auth page -> redirect to home
+        const data = await response.json().catch(() => null);
+        if (shouldAllowAuthPageForUser(pathname, data?.user)) {
+          return NextResponse.next();
+        }
+
+        // Logged in, and on an auth page -> redirect to home.
+        // Trial users are allowed through /register so they can convert in-place.
         return NextResponse.redirect(new URL("/home", request.url));
       } else if (!response.ok && isProtectedPage) {
         // Invalid token on a protected page: clear the stale cookie, then let


### PR DESCRIPTION
## Summary

Trialユーザーが `/register` から本登録する際、認証確認前または user 不明状態で通常の新規登録にフォールバックし、旧trial userの夢が見えなくなる可能性を防ぎました。

`/register` でも `/auth/verify` が走るようにし、trial user かどうかを確認してから登録処理を分岐します。

## Changes

- `AuthContext`
  - `PROTECTED_PATH_PREFIXES` を `AUTH_VERIFY_PATH_PREFIXES` にリネーム
  - `/register` を認証確認対象に追加
  - auth hint がなくても `/register` では `/auth/verify` を実行

- `Register`
  - `authStatus === "checking"` 中は送信不可
  - handleSubmit 内でも checking 中は早期 return
  - `authenticated && user?.trial_user === true` の場合だけ `convertTrial()`
  - `authenticated` だが trial user でない/不明な場合は `clientRegister()` に落とさず `/home` へ戻す
  - `unauthenticated` の場合だけ通常登録

- Tests
  - `/register` で auth hint なしでも verify することを確認
  - 未認証の新規ユーザーが `/register` を開いた場合は 401 後に unauthenticated になることを確認
  - checking / trial昇格 / 通常登録 / authenticated user null / 通常ユーザーの分岐を確認

## Tests

```bash
cd frontend
npx jest __tests__/context/AuthContext.test.tsx __tests__/app/register/page.test.tsx
# 2 suites / 36 tests passed

npm run build
# production build succeeded
```

## Scope

以下には触れていません。

- backend/API/DB
- Trial P3 の backend 実装
- Stripe
- 森画面
- Sentry

## Manual QA

マージ後、本番で以下を確認します。

```txt
1. お試しユーザーでログイン
2. 夢を1つ作る
3. /register へ行く
4. 本登録する
5. 登録後もログイン状態が続く
6. 作った夢が残っている
7. プロフィールが残っている
8. TrialBanner が消える
9. /home と /forest で確認
```
