### PR TITLE
fix: 認証ページのクロール除外とSEO設定を整理

### DIFF
--- a/frontend/__tests__/app/seo.test.ts
+++ b/frontend/__tests__/app/seo.test.ts
@@ -1,0 +1,55 @@
+import robots from "@/app/robots";
+import sitemap from "@/app/sitemap";
+import { SITE_URL, NON_INDEXABLE_PATH_PREFIXES } from "@/lib/site";
+
+// ---------------------------------------------------------------------------
+// robots.txt
+// ---------------------------------------------------------------------------
+describe("robots", () => {
+  const result = robots();
+  const rule = Array.isArray(result.rules) ? result.rules[0] : result.rules;
+  const disallow = ([] as string[]).concat(rule?.disallow ?? []);
+
+  it("公開トップを許可する", () => {
+    expect(rule?.allow).toBe("/");
+  });
+
+  it.each(NON_INDEXABLE_PATH_PREFIXES)(
+    "認証・裏方パス %s をクロール除外する",
+    (path) => {
+      expect(disallow).toContain(path);
+    }
+  );
+
+  it("sitemap を絶対URLで指す", () => {
+    expect(result.sitemap).toBe(`${SITE_URL}/sitemap.xml`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sitemap.xml
+// ---------------------------------------------------------------------------
+describe("sitemap", () => {
+  const entries = sitemap();
+  const urls = entries.map((e) => e.url);
+
+  it("公開ページのみを含み、認証ページを含まない", () => {
+    for (const url of urls) {
+      const path = url.replace(SITE_URL, "") || "/";
+      const isNonIndexable = NON_INDEXABLE_PATH_PREFIXES.some((prefix) =>
+        path.startsWith(prefix)
+      );
+      expect(isNonIndexable).toBe(false);
+    }
+  });
+
+  it("全URLが本番ベースURLで始まる", () => {
+    for (const url of urls) {
+      expect(url.startsWith(SITE_URL)).toBe(true);
+    }
+  });
+
+  it("トップページを含む", () => {
+    expect(urls).toContain(SITE_URL);
+  });
+});

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -9,6 +9,7 @@ import { Suspense } from "react";
 import Loading from "./loading";
 import { Providers } from "./providers";
 import PendingDreamsMonitor from "./components/PendingDreamsMonitor";
+import { SITE_URL, GOOGLE_SITE_VERIFICATION } from "@/lib/site";
 
 const notoSansJP = Noto_Sans_JP({ subsets: ["latin"] });
 // Hydration前にテーマを合わせて、ライト→ダークのちらつきを防ぐ。
@@ -21,7 +22,7 @@ const themeInitScript = `
   }
 `;
 
-const siteUrl = "https://dreamjournal-app.vercel.app";
+const siteUrl = SITE_URL;
 
 export const metadata: Metadata = {
   title: "YumeTree | モルペウスと育てるAI夢ノート",
@@ -48,6 +49,10 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
+  // Search Console の HTMLタグ検証。環境変数が無ければ verification 自体を省略する。
+  ...(GOOGLE_SITE_VERIFICATION
+    ? { verification: { google: GOOGLE_SITE_VERIFICATION } }
+    : {}),
 };
 
 export default function RootLayout({

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,10 +1,12 @@
 import type { MetadataRoute } from "next";
-
-const siteUrl = "https://dreamjournal-app.vercel.app";
+import { SITE_URL, NON_INDEXABLE_PATH_PREFIXES } from "@/lib/site";
 
 /**
  * robots.txt を自動生成する
  * Google への案内板：「ここは見ていいよ、ここは裏方だから見ないでね」
+ *
+ * クロール除外パスは lib/site.ts の NON_INDEXABLE_PATH_PREFIXES に一元管理し、
+ * 認証ページを追加したときに robots と sitemap の両方で取りこぼさないようにする。
  */
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -12,14 +14,9 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: "/",
-        disallow: [
-          "/api/",      // API エンドポイントはクロールさせない
-          "/home",      // ログイン後のページはクロールさせない
-          "/dream",     // ユーザーの夢データはクロールさせない
-          "/settings",  // 設定ページはクロールさせない
-        ],
+        disallow: [...NON_INDEXABLE_PATH_PREFIXES],
       },
     ],
-    sitemap: `${siteUrl}/sitemap.xml`,
+    sitemap: `${SITE_URL}/sitemap.xml`,
   };
 }

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,6 +1,5 @@
 import type { MetadataRoute } from "next";
-
-const siteUrl = "https://dreamjournal-app.vercel.app";
+import { SITE_URL as siteUrl } from "@/lib/site";
 
 /**
  * sitemap.xml を自動生成する

--- a/frontend/lib/site.ts
+++ b/frontend/lib/site.ts
@@ -1,0 +1,33 @@
+/**
+ * サイト全体で共有する公開URL・SEO関連の定数。
+ *
+ * これまで layout / sitemap / robots に本番URLが個別ハードコードされていたため、
+ * 独自ドメイン移行時の取りこぼしや canonical 不整合を防ぐ目的で一元化する。
+ * 環境変数 NEXT_PUBLIC_SITE_URL があればそれを優先し、無ければ本番Vercel URLにフォールバックする。
+ */
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://dreamjournal-app.vercel.app"
+).replace(/\/$/, "");
+
+/**
+ * 認証が必要・裏方・決済リダイレクトなど、検索エンジンにクロール/インデックスさせたくないパス接頭辞。
+ * robots.txt の disallow と整合させ、新しい認証ページを追加したらここに足す。
+ */
+export const NON_INDEXABLE_PATH_PREFIXES = [
+  "/api/", // APIエンドポイント
+  "/home", // ログイン後トップ
+  "/dream", // 夢の詳細・新規・月別（ユーザーデータ）
+  "/my-dreams", // 夢一覧（ユーザーデータ）
+  "/forest", // 夢の森（認証）
+  "/profiles", // プロフィール（認証）
+  "/settings", // 設定（認証）
+  "/subscription", // サブスク管理・決済リダイレクト（認証）
+  "/debug", // 開発用デバッグページ
+] as const;
+
+/**
+ * Google Search Console の HTMLタグ検証用トークン（任意）。
+ * Search Console で発行された値を環境変数に設定すると <meta name="google-site-verification"> が出力される。
+ */
+export const GOOGLE_SITE_VERIFICATION =
+  process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION;


### PR DESCRIPTION
## 変更内容

- 認証必須ページと裏方ページのクロール除外設定を `robots.ts` に追加しました。
- 本番URLと非インデックス対象パスを `frontend/lib/site.ts` に一元化しました。
- `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` による Google Search Console の HTMLタグ検証に対応しました。
- `robots.ts` / `sitemap.ts` のSEO回帰防止テストを追加しました。

## robots.ts で追加除外したパス

- `/my-dreams`
- `/forest`
- `/profiles`
- `/subscription`
- `/debug`

既存の `/api/`, `/home`, `/dream`, `/settings` は維持しています。

## SITE_URL 一元化の理由

`layout.tsx`, `sitemap.ts`, `robots.ts` に本番URLが個別に存在していたため、独自ドメイン移行やURL変更時に canonical / sitemap / robots の不整合が起きる余地がありました。

`frontend/lib/site.ts` の `SITE_URL` に集約し、`NEXT_PUBLIC_SITE_URL` で上書き可能にしています。

## Search Console検証タグ対応

`NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` を設定すると、Next.js metadata の `verification.google` 経由で Search Console のHTMLタグ検証メタタグを出力します。

未設定時は `verification` 自体を出さないため、既存環境には影響しません。

## 追加したテスト

- `frontend/__tests__/app/seo.test.ts`
  - robots が非インデックス対象パスを除外すること
  - robots の sitemap URL が絶対URLであること
  - sitemap が認証ページを含まないこと
  - sitemap のURLが `SITE_URL` で始まること
  - sitemap がトップページを含むこと

## 検証結果

- SEOテスト: `14/14 green`
  - `npx jest __tests__/app/seo.test.ts --runInBand`
- Jest全体: `34 suites / 278 tests green`
  - `npx jest --runInBand`
- TypeScript:
  - `npx tsc --noEmit` は既存のテスト型エラーで失敗
  - エラーは `__tests__/app/login/page.test.tsx`, `__tests__/app/register/page.test.tsx`, `__tests__/context/AuthContext.test.tsx`, `__tests__/hooks/useVoiceRecorder.test.tsx`, `__tests__/lib/apiClient.test.ts` など未変更ファイル由来
  - 今回変更したSEOファイルには `tsc` エラーなし

## 触っていない領域

- 認証
- DB
- 森画面
- Stripe
- migration
- rake
- `morpheus/generated` 画像
