### PR TITLE
feat: Morpheusヒーロー基盤(#1) — トークン駆動化と全消費先掛け替え

### DIFF
--- a/docs/superpowers/plans/2026-06-28-morpheus-hero-foundation.md
+++ b/docs/superpowers/plans/2026-06-28-morpheus-hero-foundation.md
@@ -1,0 +1,52 @@
+# Morpheusヒーロー基盤(#1) Implementation Plan
+
+> **For agentic workers:** Implement this plan with TDD. Keep the change visual-only and do not touch auth, DB, Stripe, routing logic, or forest-specific Morpheus work.
+
+**Goal:** Upgrade `MorpheusHero` into the token-driven hero primitive for the full-screen redesign path, using #0 tokens for responsive size, glow, and float.
+
+**Architecture:** Add `cssSize` to `MorpheusImage` for CSS-driven square rendering while preserving numeric intrinsic dimensions for `next/image`. Make `MorpheusHero` default to `var(--morpheus-hero)`, add a decorative `animate-moon-pulse` glow ring, and add `animate-morpheus-float` to the image wrapper. Remove fixed hero sizes from current MorpheusHero consumers.
+
+**Tech Stack:** Next.js 16 App Router, Tailwind CSS v4, Jest, Testing Library, framer-motion.
+
+## Global Constraints
+
+- Presentation-only change. Do not alter authentication, data fetching, Stripe, DB, migrations, rake tasks, or forest screen behavior.
+- Preserve backward compatibility: explicit numeric `size` on `MorpheusHero` / `MorpheusImage` must still render fixed-size images.
+- Do not convert small inline `MorpheusImage` usages to hero behavior. This pass is only for `MorpheusHero` and its current full-screen consumers.
+- Do not touch `frontend/public/images/morpheus/generated/`.
+
+## Tasks
+
+- [ ] Add failing tests for `MorpheusImage`.
+  - `cssSize` uses intrinsic `320` by default and renders via CSS width/height.
+  - numeric `size` without `cssSize` preserves existing fixed rendering.
+
+- [ ] Add failing tests for `MorpheusHero`.
+  - renders title/message.
+  - renders a decorative `animate-moon-pulse` glow ring.
+  - defaults to `var(--morpheus-hero)`.
+  - explicit numeric `size` remains a fixed-size escape hatch.
+
+- [ ] Implement `MorpheusImage.cssSize`.
+  - Add `cssSize?: string`.
+  - Use `size ?? 320` as intrinsic size when `cssSize` exists.
+  - Apply `style={{ width: cssSize, height: cssSize }}` and `sizes={cssSize}`.
+  - Preserve fallback SVG behavior.
+
+- [ ] Upgrade `MorpheusHero`.
+  - Remove the internal default fixed `size`.
+  - Pass `cssSize="var(--morpheus-hero)"` when no numeric `size` override is supplied.
+  - Add `animate-moon-pulse` decorative ring.
+  - Add `motion-safe:animate-morpheus-float` to the image wrapper.
+
+- [ ] Remove fixed hero sizes from current consumers.
+  - `frontend/app/home/page.tsx`
+  - `frontend/app/subscription/page.tsx`
+  - `frontend/app/login/page.tsx`
+  - `frontend/app/components/MorpheusLoginRequired.tsx`
+  - `frontend/app/components/MorpheusGuide.tsx`
+
+- [ ] Validate.
+  - `npx jest __tests__/components/MorpheusImage.test.tsx __tests__/components/MorpheusHero.test.tsx --runInBand`
+  - `npx jest --runInBand`
+  - Build or equivalent check. If build is blocked by a pre-existing Next page export/type issue, document the exact failure.

--- a/docs/superpowers/specs/2026-06-28-morpheus-hero-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-28-morpheus-hero-foundation-design.md
@@ -1,7 +1,7 @@
 # Morpheusヒーロー基盤（サブPJ #1）設計仕様
 
 - 日付: 2026-06-28
-- 対象: YumeTree フロントエンド（Next.js 15 App Router + Tailwind v4 + framer-motion）
+- 対象: YumeTree フロントエンド（Next.js 16 App Router + Tailwind v4 + framer-motion）
 - 前提: #0 デザインシステム基盤（PR #394, main `51432e9`）がマージ済み。`--morpheus-hero`(clamp 120–160) / `--glow-active`(明=紫/夜=琥珀, `moon-pulse`連動) / `animate-morpheus-float` が利用可能。
 - 位置づけ: 全画面リデザインの#1。既存 `MorpheusHero` を**#0トークン駆動の正準ヒーロープリミティブ**へ格上げし、全消費先を掛け替える。
 - スコープ判断: ユーザーが「広め（全画面掛け替え）」を選択。

--- a/docs/superpowers/specs/2026-06-28-morpheus-hero-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-28-morpheus-hero-foundation-design.md
@@ -1,0 +1,87 @@
+# Morpheusヒーロー基盤（サブPJ #1）設計仕様
+
+- 日付: 2026-06-28
+- 対象: YumeTree フロントエンド（Next.js 15 App Router + Tailwind v4 + framer-motion）
+- 前提: #0 デザインシステム基盤（PR #394, main `51432e9`）がマージ済み。`--morpheus-hero`(clamp 120–160) / `--glow-active`(明=紫/夜=琥珀, `moon-pulse`連動) / `animate-morpheus-float` が利用可能。
+- 位置づけ: 全画面リデザインの#1。既存 `MorpheusHero` を**#0トークン駆動の正準ヒーロープリミティブ**へ格上げし、全消費先を掛け替える。
+- スコープ判断: ユーザーが「広め（全画面掛け替え）」を選択。
+
+## 0. 背景
+
+`MorpheusHero` は既に存在するが、サイズ150–220を全消費先が固定指定し、`--morpheus-hero` clamp も `animate-moon-pulse` 後光も `animate-morpheus-float` も未使用。#1でこれを#0トークン駆動に統一し、レスポンシブ化・後光・浮遊を与える。森画面はMorpheusHero非消費（MorpheusImage直利用）のため**#1では触れない**（#4で扱う）。
+
+## 1. 設計原則
+
+1. **後方互換**: `MorpheusHero` / `MorpheusImage` の既存propは壊さない。新挙動はデフォルト、旧挙動はprop上書きで温存。
+2. **トークン駆動**: ヒーロー描画サイズは `var(--morpheus-hero)`、後光は `animate-moon-pulse`（#0でテーマ連動済み）、浮遊は `animate-morpheus-float`。新規の色・サイズのハードコードを足さない。
+3. **提示的変更のみ**: 認証・Stripe・DB・ルーティングのロジックには触れない。変更はビジュアル（サイズ/後光/浮遊）に限定。
+
+## 2. コンポーネント仕様
+
+### 2.1 `MorpheusImage`（`app/components/MorpheusImage.tsx`）— 加算
+正方形画像（1254×1254）。レスポンシブ描画のため任意prop `cssSize` を追加する。
+
+- 追加prop: `cssSize?: string`（例 `"var(--morpheus-hero)"`）
+- 挙動:
+  - `cssSize` 指定時: `next/image` の intrinsic `width`/`height` は数値 `size`（最適化用。`cssSize`使用時の既定intrinsicは320=Retina想定）に保ちつつ、描画サイズを `style={{ width: cssSize, height: cssSize }}` で可変にする。`sizes` も `cssSize` を反映。
+  - `cssSize` 未指定時: 現状どおり `width=height=size`（数値）でレンダリング（既存挙動・後方互換）。
+  - フォールバック `MorpheusSVG` も `cssSize` 指定時は同じCSSサイズで描画する（数値`size`しか持たない場合との整合）。
+- 既存の `variant` / `priority` / `className` / framer-motion entry / drop-shadow / onErrorフォールバックは不変更。
+
+### 2.2 `MorpheusHero`（`app/components/MorpheusHero.tsx`）— 格上げ
+- 描画サイズ: 既定で `MorpheusImage` に `cssSize="var(--morpheus-hero)"` を渡す。`size`(数値)propが渡された場合のみ従来の固定サイズに上書き（後方互換）。
+- 後光: Morpheus画像の背後に `rounded-full` + `animate-moon-pulse` のグローリング要素を1つ追加（早見表「後光あり」）。色は `--glow-active` 連動（明=紫/夜=琥珀）。`pointer-events-none`・`aria-hidden`。
+- 浮遊: 画像ラッパに `motion-safe:animate-morpheus-float` を付与（既存framer-motion entryと併用可）。
+- 既存API（`title` / `message` / `expression` / `imageVariant` / `variant`(home/compose/detail/voice) / `className` / `action`）は不変更。既存の装飾（blur blob・✦/⋆）は維持。
+
+### 2.3 消費先の固定size掃き出し（全画面掛け替え）
+以下から `size={...}` を除去し、`MorpheusHero` のレスポンシブ既定に委ねる:
+
+| ファイル | 現状size | 対応 |
+|---|---|---|
+| `app/home/page.tsx` | 164 | `size`除去 |
+| `app/subscription/page.tsx`（2箇所） | 160, 160 | `size`除去 |
+| `app/components/MorpheusLoginRequired.tsx` | 168 | `size`除去 |
+| `app/components/MorpheusGuide.tsx`（2箇所） | 220, 既定 | `size`除去 |
+| `app/login/page.tsx` | 150 | `size`除去 |
+
+> `MorpheusGuide` / `MorpheusLoginRequired` は共有ラッパなので、これらの掃き出しで詳細/設定/サブスク等の画面にも自動反映される。これは意図どおり。
+
+## 3. テスト方針（TDD・component render）
+
+既存パターン（`@testing-library/react` + jest, `__tests__/app/...`）に従う。
+
+- **MorpheusImage**:
+  - `cssSize` 指定時、`<img>` が `style` の width/height に `cssSize` を反映する。
+  - `cssSize` 未指定時、従来どおり数値`size`でレンダリングする（後方互換）。
+- **MorpheusHero**:
+  - 後光リング（`animate-moon-pulse` を持つ `aria-hidden` 要素）が描画される。
+  - 既定で `MorpheusImage` にトークンサイズ（`var(--morpheus-hero)`）が渡る。
+  - `title` / `message` が描画される（既存表示の回帰防止）。
+- 既存スイート（304件）が緑のまま。
+
+## 4. 検証方針
+
+- 完了ゲート: `yarn jest` 全緑 + `yarn build` 成功。
+- **preview目視（公開ページ）**: `/login`（MorpheusHero消費・未認証で表示可）を preview で起動し、
+  - light: 後光が**紫**で視認できる
+  - dark: 後光が**琥珀**
+  - スマホ幅（~390px）でヒーローが `--morpheus-hero` の下限~120pxに収まる
+  をスクリーンショットで確認。これにより#0で持ち越した「公開ページでの後光発色目視」も消化する。
+
+## 5. 成果物と境界
+
+**#1で触る**: `MorpheusImage.tsx`（`cssSize`加算）/ `MorpheusHero.tsx`（格上げ）/ 上表の6ファイルのsize掃き出し / 新規テスト。
+
+**#1で触らない（後続へ）**:
+- 詳細/インサイト用の小円クロップ `MorpheusAvatar` プリミティブ → 消費先が出る#3まで保留（YAGNI）
+- 森画面（MorpheusHero非消費）→ #4
+- 認証/DB/Stripe/ルーティングのロジック
+
+**ドキュメント**: 本仕様書 + 実装プラン。
+
+## 6. リスクと注意
+
+- 後光/浮遊は共有 `MorpheusHero` 由来のため、home/subscription（認証ページ）にも自動反映される。提示的変更のみで、Stripe/認証ロジックは不変更。
+- `cssSize` 導入で `next/image` の最適化が崩れないこと（intrinsic 320を保持、`sizes`整合）をビルドで確認。
+- 既存の数値`size`上書き経路を残すため、想定外の回帰時はprop指定で即旧挙動に戻せる。

--- a/frontend/__tests__/components/MorpheusHero.test.tsx
+++ b/frontend/__tests__/components/MorpheusHero.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import MorpheusHero from "@/app/components/MorpheusHero";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({
+    alt,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement>) => <img alt={alt} {...props} />,
+}));
+
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      initial: _initial,
+      animate: _animate,
+      transition: _transition,
+      ...props
+    }: React.HTMLAttributes<HTMLDivElement> & {
+      initial?: unknown;
+      animate?: unknown;
+      transition?: unknown;
+    }) => <div {...props}>{children}</div>,
+  },
+}));
+
+describe("MorpheusHero", () => {
+  it("title/messageとテーマ連動の後光リングを描画する", () => {
+    const { container } = render(
+      <MorpheusHero title="おかえり！" message="今日の夢を聞かせてね。" />
+    );
+
+    expect(screen.getByText("おかえり！")).toBeInTheDocument();
+    expect(screen.getByText("今日の夢を聞かせてね。")).toBeInTheDocument();
+    expect(
+      container.querySelector('[aria-hidden="true"].animate-moon-pulse')
+    ).toBeTruthy();
+  });
+
+  it("既定ではMorpheusImageをトークンサイズでレスポンシブ描画する", () => {
+    render(<MorpheusHero title="おかえり！" message="今日の夢を聞かせてね。" />);
+
+    const image = screen.getByAltText("ホーム画面で見守るモルペウス");
+    expect(image).toHaveAttribute("width", "320");
+    expect(image).toHaveAttribute("height", "320");
+    expect(image).toHaveStyle({
+      width: "var(--morpheus-hero)",
+      height: "var(--morpheus-hero)",
+    });
+  });
+
+  it("size指定時は後方互換として固定サイズ描画に戻せる", () => {
+    render(
+      <MorpheusHero
+        title="おかえり！"
+        message="今日の夢を聞かせてね。"
+        size={150}
+      />
+    );
+
+    const image = screen.getByAltText("ホーム画面で見守るモルペウス");
+    expect(image).toHaveAttribute("width", "150");
+    expect(image).toHaveAttribute("height", "150");
+    expect(image).not.toHaveStyle({ width: "var(--morpheus-hero)" });
+  });
+});

--- a/frontend/__tests__/components/MorpheusImage.test.tsx
+++ b/frontend/__tests__/components/MorpheusImage.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import MorpheusImage from "@/app/components/MorpheusImage";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({
+    alt,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement>) => <img alt={alt} {...props} />,
+}));
+
+jest.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      initial: _initial,
+      animate: _animate,
+      transition: _transition,
+      ...props
+    }: React.HTMLAttributes<HTMLDivElement> & {
+      initial?: unknown;
+      animate?: unknown;
+      transition?: unknown;
+    }) => <div {...props}>{children}</div>,
+  },
+}));
+
+describe("MorpheusImage", () => {
+  it("cssSize指定時はintrinsic sizeを保ち、描画サイズだけCSSで可変にする", () => {
+    render(<MorpheusImage variant="home" cssSize="var(--morpheus-hero)" />);
+
+    const image = screen.getByAltText("ホーム画面で見守るモルペウス");
+    expect(image).toHaveAttribute("width", "320");
+    expect(image).toHaveAttribute("height", "320");
+    expect(image).toHaveAttribute("sizes", "var(--morpheus-hero)");
+    expect(image).toHaveStyle({
+      width: "var(--morpheus-hero)",
+      height: "var(--morpheus-hero)",
+    });
+  });
+
+  it("cssSize未指定時は従来どおり数値sizeで描画する", () => {
+    render(<MorpheusImage variant="home" size={88} />);
+
+    const image = screen.getByAltText("ホーム画面で見守るモルペウス");
+    expect(image).toHaveAttribute("width", "88");
+    expect(image).toHaveAttribute("height", "88");
+    expect(image).toHaveAttribute("sizes", "88px");
+    expect(image).not.toHaveStyle({ width: "var(--morpheus-hero)" });
+  });
+});

--- a/frontend/app/components/MorpheusGuide.tsx
+++ b/frontend/app/components/MorpheusGuide.tsx
@@ -184,7 +184,6 @@ export function MorpheusGuideEmpty({ ageGroup }: { ageGroup?: string }) {
           ? "ねたら でてくるよ 🌙　おきたら モルペウスに おしえてね。"
           : "今夜みた夢を、起きたらすぐ記録してみてください。モルペウスがそばで待っています。"
       }
-      size={210}
       className="w-full"
     />
   );
@@ -199,7 +198,6 @@ export function MorpheusGuideCompose() {
       variant="compose"
       title="モルペウスに ゆめを おしえてね"
       message="さいしょは ひとことでも だいじょうぶ。おもいだせる ぶんだけ、ゆっくり かいてみよう。"
-      size={220}
       className="w-full"
     />
   );

--- a/frontend/app/components/MorpheusHero.tsx
+++ b/frontend/app/components/MorpheusHero.tsx
@@ -41,11 +41,13 @@ export default function MorpheusHero({
   message,
   expression = "cheerful",
   imageVariant,
-  size = 190,
+  size,
   variant = "home",
   className = "",
   action,
 }: MorpheusHeroProps) {
+  const heroCssSize = size === undefined ? "var(--morpheus-hero)" : undefined;
+
   return (
     <section
       className={`relative overflow-hidden rounded-[2rem] border bg-gradient-to-br p-5 shadow-xl ${variantStyles[variant]} ${className}`}
@@ -79,11 +81,16 @@ export default function MorpheusHero({
           initial={{ opacity: 0, scale: 0.86, y: 12 }}
           animate={{ opacity: 1, scale: 1, y: 0 }}
           transition={{ type: "spring", stiffness: 210, damping: 18 }}
-          className="mx-auto grid place-items-center sm:mx-0"
+          className="relative mx-auto grid place-items-center motion-safe:animate-morpheus-float sm:mx-0"
         >
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-[14%] rounded-full animate-moon-pulse"
+          />
           <MorpheusImage
             variant={imageVariant ?? expressionToImageVariant[expression]}
             size={size}
+            cssSize={heroCssSize}
             priority={variant === "home"}
             className="relative"
           />

--- a/frontend/app/components/MorpheusImage.tsx
+++ b/frontend/app/components/MorpheusImage.tsx
@@ -67,27 +67,45 @@ const FALLBACK_EXPRESSION: Record<MorpheusImageVariant, MorpheusExpression> = {
 type MorpheusImageProps = {
   variant?: MorpheusImageVariant;
   size?: number;
+  cssSize?: string;
   className?: string;
   priority?: boolean;
 };
 
 export default function MorpheusImage({
   variant = "home",
-  size = 180,
+  size,
+  cssSize,
   className = "",
   priority = false,
 }: MorpheusImageProps) {
   const [hasImageError, setHasImageError] = useState(false);
+  const intrinsicSize = cssSize ? size ?? 320 : size ?? 180;
+  const responsiveStyle = cssSize
+    ? { width: cssSize, height: cssSize }
+    : undefined;
 
   useEffect(() => {
     setHasImageError(false);
   }, [variant]);
 
   if (hasImageError) {
+    if (cssSize) {
+      return (
+        <div style={responsiveStyle} className={className}>
+          <MorpheusSVG
+            expression={FALLBACK_EXPRESSION[variant]}
+            size={intrinsicSize}
+            className="h-full w-full"
+          />
+        </div>
+      );
+    }
+
     return (
       <MorpheusSVG
         expression={FALLBACK_EXPRESSION[variant]}
-        size={size}
+        size={intrinsicSize}
         className={className}
       />
     );
@@ -103,12 +121,13 @@ export default function MorpheusImage({
       <Image
         src={MORPHEUS_IMAGE_SRC[variant]}
         alt={ALT_BY_VARIANT[variant]}
-        width={size}
-        height={size}
+        width={intrinsicSize}
+        height={intrinsicSize}
         priority={priority}
         onError={() => setHasImageError(true)}
         className="object-contain block"
-        sizes={`${size}px`}
+        style={responsiveStyle}
+        sizes={cssSize ?? `${intrinsicSize}px`}
       />
     </motion.div>
   );

--- a/frontend/app/components/MorpheusLoginRequired.tsx
+++ b/frontend/app/components/MorpheusLoginRequired.tsx
@@ -21,7 +21,6 @@ export default function MorpheusLoginRequired({
           expression="cheerful"
           imageVariant="login"
           variant="detail"
-          size={168}
           title={title}
           message={message}
           action={

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -325,7 +325,6 @@ export default function HomePage() {
           variant="home"
           title={user ? `${user.username}さん、おはよう！` : "おはよう！"}
           message={`${copy.heading} ${copy.sub}`}
-          size={164}
           className="w-full mb-4"
           action={
             <div className="max-w-md">

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -91,7 +91,6 @@ export default function Login() {
           message="今日も来てくれてうれしいよ。つづきから、ゆめの世界へ入ろう。"
           imageVariant="login"
           variant="compose"
-          size={150}
           className="mb-5"
         />
       <form

--- a/frontend/app/subscription/page.tsx
+++ b/frontend/app/subscription/page.tsx
@@ -126,7 +126,6 @@ export default function SubscriptionPage() {
             expression="proud"
             imageVariant="praise"
             variant="home"
-            size={160}
             title="プレミアム会員です ✨"
             message="すべての機能をご利用いただけます。毎日の夢を存分に記録・分析してください！"
             className="mb-8"
@@ -168,7 +167,6 @@ export default function SubscriptionPage() {
           expression="cheerful"
           imageVariant="reward"
           variant="home"
-          size={160}
           title="YumeTree プレミアム"
           message="AI分析をたっぷり使える。夢の画像生成と月次サマリーで、毎日の夢がもっと深く楽しめる。"
         />


### PR DESCRIPTION
## 概要

サブPJ #1「Morpheusヒーロー基盤」です。

`MorpheusHero` を #0 デザイントークン駆動の正準ヒーロープリミティブに格上げし、全画面リデザインの入口になる home / subscription / login / loginRequired / guide 系の固定サイズ指定を掃き出しました。

## 変更内容

- `MorpheusImage` に `cssSize?: string` を追加
  - `cssSize` 指定時は intrinsic `width/height` を `size ?? 320` に維持
  - 描画サイズだけ `style={{ width: cssSize, height: cssSize }}` で可変化
  - `cssSize` 未指定時は従来どおり数値 `size` 描画
- `MorpheusHero` をトークン駆動化
  - 既定サイズを `var(--morpheus-hero)` に変更
  - 後光リング `animate-moon-pulse` を追加
  - 画像ラッパに `motion-safe:animate-morpheus-float` を追加
  - 明示的な `size={...}` は後方互換の固定サイズ上書きとして維持
- 固定 `size` 掃き出し
  - `frontend/app/home/page.tsx`
  - `frontend/app/subscription/page.tsx`
  - `frontend/app/login/page.tsx`
  - `frontend/app/components/MorpheusLoginRequired.tsx`
  - `frontend/app/components/MorpheusGuide.tsx`
- #1 実装計画を追加
  - `docs/superpowers/plans/2026-06-28-morpheus-hero-foundation.md`
- #1 仕様書の前提を現行 Next.js 16 に補正

## 追加したテスト

- `frontend/__tests__/components/MorpheusImage.test.tsx`
  - `cssSize` 指定時の intrinsic 320 + CSS描画サイズ
  - `cssSize` 未指定時の従来固定サイズ
- `frontend/__tests__/components/MorpheusHero.test.tsx`
  - title / message 表示
  - `animate-moon-pulse` 後光リング
  - 既定 `var(--morpheus-hero)` 描画
  - `size` 指定時の固定サイズ上書き

## 検証結果

- Targeted:
  - `npx jest __tests__/components/MorpheusImage.test.tsx __tests__/components/MorpheusHero.test.tsx --runInBand`
  - 2 suites / 5 tests green
- Full Jest:
  - `npx jest --runInBand`
  - 37 suites / 311 tests green
- Build:
  - `npm run build -- --webpack`
  - webpack compile は成功
  - TypeScript step で既存の Next Page export 型エラーにより失敗:
    - `app/forest/[profileId]/page.tsx`
    - `"isValidForestProfileId" is not a valid Page export field`
  - 今回変更した #1 ファイル起因のエラーではありません

## 触っていない領域

- 認証ロジック
- DB
- Stripe
- migration
- rake
- 森画面のMorpheus実装
- `frontend/public/images/morpheus/generated/`
- 小型インライン `MorpheusImage` 利用箇所

## 補足

このPRはMorpheusHero消費先の「広め掛け替え」までを対象にしています。詳細/インサイト向けの小円クロップ `MorpheusAvatar` は、仕様どおり後続 #3 に残しています。
