### PR TITLE
feat: ボトムタブナビ(#2) — モバイル用BottomTabBar＋中央FAB

### DIFF
--- a/docs/superpowers/plans/2026-06-28-bottom-tab-navigation.md
+++ b/docs/superpowers/plans/2026-06-28-bottom-tab-navigation.md
@@ -1,0 +1,283 @@
+# ボトムタブ・ナビゲーション(#2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** モバイル専用の認証連動ボトムタブバー（おうち/もり/[＋きろくFAB]/マイ夢/設定）を新設し、`layout.tsx` にマウントする。
+
+**Architecture:** 新規 client コンポーネント `BottomTabBar` を作り、`useAuth` でログイン時のみ描画。FABは既存 `DreamEntryLauncher` を円形に整形して再利用。コンテンツがバーに隠れないよう、バー自身が「ログイン時・モバイルのみ」のスペーサーを描画する（`layout.tsx` 本体のpaddingは変えず、デスクトップをピクセル不変に保つ）。
+
+**Tech Stack:** Next.js 16 App Router, Tailwind v4, lucide-react, framer-motion(既存), Jest + @testing-library/react.
+
+## Global Constraints
+
+- **提示層のみ**: 認証・ルーティング・Stripe・DBのロジックには触れない。既存リンク/既存 `DreamEntryLauncher` への導線のみ。
+- **デスクトップ不変**: バーは `md:hidden`。`layout.tsx` の既存クラス・padding は変更しない（スペーサーは `BottomTabBar` 内に閉じる）。
+- **認証連動**: `authStatus === "checking"` または `!isLoggedIn` のとき `return null`。`useAuth()` は `{ authStatus, isLoggedIn, logout }` を返す（既存 `AuthNav` と同型）。
+- **アクティブ判定**: `pathname === href || (href !== "/" && pathname?.startsWith(href))`（`AuthNav` と同一）。
+- **FAB再利用**: 中央は `DreamEntryLauncher`（`buttonLabel`/`buttonClassName`/`showSparkles` で整形）。新規モーダルは作らない。
+- **navに backdrop-filter / transform を付けない**: `DreamEntryLauncher` のモーダルは `fixed inset-0 z-[100]`。祖先に `backdrop-filter`(=`backdrop-blur`) や `transform` があると包含ブロック化してモーダルが全画面化できない。nav はソリッド `bg-background` にする。
+- **タブ確定**: `/home`=おうち(House) / `/forest`=もり(Trees) / 中央FAB=きろく / `/my-dreams`=マイ夢(Moon) / `/settings`=設定(Settings)。子ども向けのやさしい語彙を踏襲。
+- 完了ゲート: `yarn jest` 全緑（既存311 + 新規）+ `yarn build` 成功。
+- 作業ディレクトリ: `frontend/`。
+
+---
+
+### Task 1: BottomTabBar コンポーネント
+
+**Files:**
+- Create: `frontend/app/components/BottomTabBar.tsx`
+- Test: `frontend/__tests__/components/BottomTabBar.test.tsx`
+
+**Interfaces:**
+- Consumes: `useAuth()`→`{ authStatus: string; isLoggedIn: boolean }`（`@/context/AuthContext`）, `usePathname()`（`next/navigation`）, `DreamEntryLauncher`（`./DreamEntryLauncher`、props `buttonLabel`/`buttonClassName`/`showSparkles`）。
+- Produces: `export default function BottomTabBar(): JSX.Element | null`（props無し）。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`frontend/__tests__/components/BottomTabBar.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import BottomTabBar from "@/app/components/BottomTabBar";
+
+const mockUsePathname = jest.fn();
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("@/app/components/DreamEntryLauncher", () => ({
+  __esModule: true,
+  default: ({ buttonLabel }: { buttonLabel: string }) => (
+    <button>{buttonLabel}</button>
+  ),
+}));
+
+beforeEach(() => {
+  mockUsePathname.mockReturnValue("/home");
+  mockUseAuth.mockReturnValue({ authStatus: "authenticated", isLoggedIn: true });
+});
+
+describe("BottomTabBar", () => {
+  it("未ログインでは何も描画しない", () => {
+    mockUseAuth.mockReturnValue({ authStatus: "unauthenticated", isLoggedIn: false });
+    const { container } = render(<BottomTabBar />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("認証確認中は何も描画しない", () => {
+    mockUseAuth.mockReturnValue({ authStatus: "checking", isLoggedIn: false });
+    const { container } = render(<BottomTabBar />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("ログイン時に4タブと記録FABを描画する", () => {
+    render(<BottomTabBar />);
+    expect(screen.getByRole("link", { name: "おうち" })).toHaveAttribute("href", "/home");
+    expect(screen.getByRole("link", { name: "もり" })).toHaveAttribute("href", "/forest");
+    expect(screen.getByRole("link", { name: "マイ夢" })).toHaveAttribute("href", "/my-dreams");
+    expect(screen.getByRole("link", { name: "設定" })).toHaveAttribute("href", "/settings");
+    expect(screen.getByRole("button", { name: "夢をきろくする" })).toBeInTheDocument();
+  });
+
+  it("現在地のタブをアクティブ表示する", () => {
+    mockUsePathname.mockReturnValue("/forest");
+    render(<BottomTabBar />);
+    expect(screen.getByRole("link", { name: "もり" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: "おうち" })).not.toHaveAttribute("aria-current");
+  });
+});
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `cd frontend && yarn jest __tests__/components/BottomTabBar.test.tsx`
+Expected: FAIL（`BottomTabBar` が存在しない / モジュール未解決）
+
+- [ ] **Step 3: コンポーネントを実装**
+
+`frontend/app/components/BottomTabBar.tsx`:
+
+```tsx
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { House, Trees, Moon, Settings, type LucideIcon } from "lucide-react";
+
+import { useAuth } from "@/context/AuthContext";
+import DreamEntryLauncher from "./DreamEntryLauncher";
+
+type Tab = { href: string; label: string; icon: LucideIcon };
+
+const LEFT_TABS: Tab[] = [
+  { href: "/home", label: "おうち", icon: House },
+  { href: "/forest", label: "もり", icon: Trees },
+];
+const RIGHT_TABS: Tab[] = [
+  { href: "/my-dreams", label: "マイ夢", icon: Moon },
+  { href: "/settings", label: "設定", icon: Settings },
+];
+
+/**
+ * モバイル専用のボトムタブバー。ログイン時だけ表示し、中央に記録FAB（DreamEntryLauncher）を置く。
+ * デスクトップ（md以上）は現行Headerに任せるため md:hidden。
+ * nav には backdrop-filter / transform を付けない（DreamEntryLauncherの fixed モーダルを壊さないため）。
+ */
+export default function BottomTabBar(): React.JSX.Element | null {
+  const pathname = usePathname();
+  const { authStatus, isLoggedIn } = useAuth();
+
+  if (authStatus === "checking" || !isLoggedIn) return null;
+
+  const renderTab = ({ href, label, icon: Icon }: Tab) => {
+    const active =
+      pathname === href || (href !== "/" && (pathname?.startsWith(href) ?? false));
+    return (
+      <Link
+        key={href}
+        href={href}
+        aria-current={active ? "page" : undefined}
+        className={`flex flex-1 flex-col items-center justify-center gap-0.5 py-1.5 text-[11px] font-semibold transition-colors ${
+          active ? "text-primary" : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        <Icon size={22} aria-hidden />
+        <span>{label}</span>
+      </Link>
+    );
+  };
+
+  return (
+    <>
+      {/* コンテンツがバーに隠れないようにする下スペーサー（ログイン時・モバイルのみ） */}
+      <div
+        aria-hidden
+        className="h-[calc(env(safe-area-inset-bottom)+4.5rem)] md:hidden"
+      />
+      <nav
+        aria-label="メインナビゲーション"
+        className="fixed inset-x-0 bottom-0 z-40 flex items-stretch justify-around border-t border-border bg-background px-2 pb-[env(safe-area-inset-bottom)] md:hidden"
+      >
+        {LEFT_TABS.map(renderTab)}
+
+        <div className="flex flex-1 items-start justify-center">
+          <DreamEntryLauncher
+            buttonLabel="夢をきろくする"
+            buttonClassName="-mt-6 h-14 w-14 justify-center rounded-full bg-primary text-primary-foreground shadow-lg [&>span]:sr-only"
+            showSparkles
+          />
+        </div>
+
+        {RIGHT_TABS.map(renderTab)}
+      </nav>
+    </>
+  );
+}
+```
+
+- [ ] **Step 4: テストを実行して成功を確認**
+
+Run: `cd frontend && yarn jest __tests__/components/BottomTabBar.test.tsx`
+Expected: PASS（4テスト緑）
+
+- [ ] **Step 5: コミット**
+
+```bash
+cd frontend && git add app/components/BottomTabBar.tsx __tests__/components/BottomTabBar.test.tsx
+git commit -m "feat: モバイル用ボトムタブバーを追加
+
+おうち/もり/[＋きろくFAB]/マイ夢/設定。認証時のみ表示・md:hidden。
+FABは既存DreamEntryLauncherを再利用。
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: layout.tsx へのマウントと検証
+
+**Files:**
+- Modify: `frontend/app/layout.tsx`（`BottomTabBar` を import し `<Providers>` 内・`<PendingDreamsMonitor />` の後に追加）
+
+**Interfaces:**
+- Consumes: `BottomTabBar`（Task 1、`./components/BottomTabBar`、default export、props無し）
+
+- [ ] **Step 1: `layout.tsx` に import を追加**
+
+`frontend/app/layout.tsx` の import 群（`import PendingDreamsMonitor from "./components/PendingDreamsMonitor";` の直後）に追加:
+
+```tsx
+import BottomTabBar from "./components/BottomTabBar";
+```
+
+- [ ] **Step 2: `<BottomTabBar />` をマウント**
+
+`frontend/app/layout.tsx` の既存:
+
+```tsx
+          <PendingDreamsMonitor />
+        </Providers>
+```
+
+を以下に変更（`<PendingDreamsMonitor />` の直後に1行追加。他は不変更）:
+
+```tsx
+          <PendingDreamsMonitor />
+          <BottomTabBar />
+        </Providers>
+```
+
+- [ ] **Step 3: 完了ゲート（全テスト＋ビルド）**
+
+```bash
+cd frontend && yarn jest && yarn build
+```
+Expected: Jest 全緑（既存311 + 新規4）、`yarn build` 成功。
+
+> 注: このリポジトリには `app/forest/[profileId]/page.tsx` の named export 起因の既存tsc型エラーが別途あり得る（#2変更とは無関係）。`yarn build` が当該既存エラーで止まる場合は、webpackコンパイルが通り、かつ #2 で触れた `BottomTabBar.tsx` / `layout.tsx` に新規型エラーが無いことを確認すれば本タスクのゲートは満たす（既存エラーは別タスクで対応）。
+
+- [ ] **Step 4: preview目視（公開ページで検証可能な範囲）**
+
+preview を起動し:
+- `/login`（未認証）で**ボトムバーが表示されない**こと。
+- モバイル幅（~390px）で `/login` のレイアウトが崩れないこと。
+- デスクトップ幅で `Header` が従来どおりで、ボトムバーが出ないこと（`md:hidden`）。
+
+> 認証済み画面でのバー表示・FAB・アクティブ状態は `isLoggedIn` 依存のため component test で担保済み。実機タップ感は手動QAに委ねる（spec §4の限界）。
+
+- [ ] **Step 5: コミット**
+
+```bash
+cd frontend && git add app/layout.tsx
+git commit -m "feat: ボトムタブバーをlayoutにマウント
+
+認証時のみモバイルで表示。デスクトップは現行Header維持。
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage（仕様→タスク対応）:**
+- §2.1 BottomTabBar（表示条件/レイアウト/タブ/アクティブ/FAB/a11y）→ Task 1 ✓
+- §2.2 layout.tsx 組み込み → Task 2 ✓（spec §2.2の「wrapperへ下padding」は、認証連動性とデスクトップ不変のため**BottomTabBar内スペーサー**に改善。意図＝「コンテンツがバーに隠れない／デスクトップ不変」は満たす）
+- §3 テスト（null×2 / 4タブ＋FAB / アクティブ）→ Task 1 のテスト ✓
+- §4 検証（build/jest/公開ページpreview）→ Task 2 Step 3-4 ✓
+- §6 リスク①md:pb-0/desktop不変 → スペーサーmd:hidden＋layout padding不変更で担保 ✓
+- §6 リスク②FABモーダルのstacking → navに backdrop-filter/transform を付けない（Global Constraints）で回避 ✓
+- §6 リスク③ログアウト即時消滅 → `useAuth` の `isLoggedIn` 依存で自動 ✓
+- §6 リスク④home記録導線の重複増加 → 新モーダルを作らず既存ランチャー再利用、home個別調整は#3 ✓（本PRで重複を増やさない）
+
+**2. Placeholder scan:** TBD/TODO・曖昧指示なし。全コードブロックに実コードを記載 ✓
+
+**3. Type consistency:** `BottomTabBar` は props無し default export（Task 1 Produces ＝ Task 2 Consumes 一致）。`useAuth()` 形は `{ authStatus, isLoggedIn }`、`DreamEntryLauncher` props（`buttonLabel`/`buttonClassName`/`showSparkles`）は実コードと一致 ✓
+
+**注記（spec deviation）:** spec §2.2 は「本文ラッパにモバイル下padding」だったが、本プランでは **`BottomTabBar` 内の `md:hidden` スペーサー**に変更した。理由＝(1)ログイン時だけ余白が要る（公開ページに余白を残さない）、(2)`layout.tsx` 本体を不変更にしデスクトップをピクセル不変に保てる。実装後に spec §2.2 を同主旨へ追記してよい。

--- a/docs/superpowers/specs/2026-06-28-bottom-tab-navigation-design.md
+++ b/docs/superpowers/specs/2026-06-28-bottom-tab-navigation-design.md
@@ -1,0 +1,83 @@
+# ボトムタブ・ナビゲーション（サブPJ #2）設計仕様
+
+- 日付: 2026-06-28
+- 対象: YumeTree フロントエンド（Next.js 16 App Router + Tailwind v4 + framer-motion）
+- 前提: #0（PR #394）/ #1（PR #395）マージ済み。`--morpheus-hero` / `--glow-active` / `animate-moon-pulse` / `animate-morpheus-float` 利用可能。
+- 位置づけ: 全画面リデザインの#2。アプリのシェル（ナビ）をモバイル先行で整え、#3で各画面を流し込む土台にする。
+- スコープ判断: タブ＝**おうち/もり/[＋きろくFAB]/マイ夢/設定**、デスクトップは**現行Header維持・ボトムバーはモバイルのみ**（ユーザー選択）。
+
+## 0. 背景と現状
+
+現行ナビは上部 `Header`（`HeaderLogo` + `AuthNav` + `ThemeToggle`）。`AuthNav`（認証時）は左[おうち/home・もり/forest・きろくする(`DreamEntryLauncher`)]＋右[保護者メニュー/settings・ログアウト]で、モバイルでは縦積みになり背が高い。`my-dreams` 等はトップナビに無い。子ども向けのやさしい語彙（おうち/もり/きろく）を踏襲する。
+
+`DreamEntryLauncher`（記録モーダル：マイク/手書き、`buttonClassName` で見た目差し替え可）が既にあり、これを**中央FABの中身として再利用**する。
+
+## 1. 設計原則
+
+1. **提示層のみ**: 認証・ルーティング・Stripe・DBのロジックには触れない。新規ナビは表示と既存リンク/既存ランチャーへの導線のみ。
+2. **デスクトップ不変**: `md` 以上は現行Headerのまま。ボトムバーは `md:hidden` でモバイル専用。デスクトップの見た目はピクセル等価を保つ。
+3. **認証連動**: ボトムバーは `isLoggedIn` の時だけ表示。`authStatus==="checking"` および未ログインでは描画しない（公開ページ landing/login/trial に出さない）。
+4. **再利用**: FABは既存 `DreamEntryLauncher`、アクティブ判定は `AuthNav` と同じ `usePathname` ロジックを踏襲。トークン（色/グロー）は#0準拠で新規ハードコードを足さない。
+
+## 2. コンポーネント仕様
+
+### 2.1 新規 `BottomTabBar`（`app/components/BottomTabBar.tsx`、client）
+
+- 表示条件: `useAuth()` の `isLoggedIn` が真のときのみ。`authStatus==="checking"` / 未ログインは `return null`。
+- レイアウト: `fixed inset-x-0 bottom-0 z-40 md:hidden`、`bg-background/95 backdrop-blur border-t border-border`、iOSセーフエリア対応 `pb-[env(safe-area-inset-bottom)]`。横並び5スロット（中央FABを浮かせる）。
+- タブ（左2・右2、中央FAB）:
+
+  | スロット | href | ラベル | アイコン(lucide) |
+  |---|---|---|---|
+  | 1 | `/home` | おうち | `House` |
+  | 2 | `/forest` | もり | `Trees` |
+  | 中央 | （FAB） | きろく | `DreamEntryLauncher`（円形・`Plus`/`Mic`） |
+  | 3 | `/my-dreams` | マイ夢 | `Moon` |
+  | 4 | `/settings` | 設定 | `Settings` |
+
+- アクティブ判定: `pathname === href || (href !== "/" && pathname?.startsWith(href))`（`AuthNav` と同一）。アクティブ時は `text-primary`、非アクティブは `text-muted-foreground`。各タブは `Link` でアイコン＋極小ラベル（縦並び）。
+- 中央FAB: `DreamEntryLauncher` を `buttonClassName` で円形（`h-14 w-14 rounded-full bg-primary text-primary-foreground shadow-lg -mt-6`）に整形し、バー上端から少し浮かせる。`buttonLabel` は視覚的に隠し（`sr-only`）、アイコンのみ表示。アクセシブルラベルは「夢をきろくする」。
+- アクセシビリティ: `<nav aria-label="メインナビゲーション">`。各リンクにラベルテキスト同梱。
+
+### 2.2 `layout.tsx` への組み込み（`app/layout.tsx`）
+
+- `<Footer />` / `<PendingDreamsMonitor />` と並べて `<BottomTabBar />` を追加。
+- モバイルでコンテンツがバーに隠れないよう、本文ラッパに**モバイル限定の下パディング**を付与: 例 `main` を包む要素へ `pb-[calc(env(safe-area-inset-bottom)+4.5rem)] md:pb-0`。`md` 以上は `pb-0` でデスクトップ不変。
+- `Header` / `AuthNav` は**今回変更しない**（モバイルの縦積みスリム化は将来#3/別PRの任意改善として残す）。
+
+## 3. テスト方針（TDD・component render）
+
+既存パターン（`@testing-library/react` + jest、`useAuth`/`usePathname` をモック）に従う。
+
+- **BottomTabBar**:
+  - 未ログイン（`isLoggedIn=false`）で `null`（何も描画しない）。
+  - `authStatus==="checking"` で `null`。
+  - ログイン時、`/home`・`/forest`・`/my-dreams`・`/settings` への4リンクと中央の記録FAB（`DreamEntryLauncher` 由来のボタン）が描画される。
+  - `usePathname` が `/forest` のとき「もり」タブがアクティブ表示（`text-primary` 等の活性クラス）になる。
+- 既存スイート（311件）が緑のまま。
+
+## 4. 検証方針
+
+- 完了ゲート: `yarn jest` 全緑 + `yarn build` 成功。
+- **preview目視**:
+  - 公開ページ `/login`（未認証）でボトムバーが**出ない**こと、モバイル幅でレイアウトが崩れないこと、デスクトップ幅でHeaderが従来どおりであることを確認（公開ページで検証可能な範囲）。
+  - 認証済み画面でのバー表示・FAB・アクティブ状態は `isLoggedIn` 依存のため、**component testで担保**し、実機での発色/タップ感は認証済みpreview or 手動QAに委ねる（限界として明記）。
+
+## 5. 成果物と境界
+
+**#2で触る**: 新規 `BottomTabBar.tsx` / `app/layout.tsx`（マウント＋モバイル下パディング）/ 新規テスト。
+
+**#2で触らない（後続へ）**:
+- `Header` / `AuthNav` のリファクタ（モバイル縦積みスリム化）→ 任意・後続
+- 各画面の中身 → #3
+- 森画面 → #4
+- 認証/ルーティング/Stripe/DBのロジック
+
+**ドキュメント**: 本仕様書 + 実装プラン。
+
+## 6. リスクと注意
+
+1. `layout.tsx` は全画面共通。下パディングは**必ず `md:pb-0`** にしてデスクトップをピクセル不変に保つ。
+2. 中央FABの `DreamEntryLauncher` はモーダルを開く。`fixed` バー内に置くと **stacking context / overlay のクリップ**が起きないか要確認（モーダルが `z-index`・portal で最前面に出ること）。問題があればFABはランチャーのトリガーのみをバーに置き、モーダル本体はバー外で描画する。
+3. `isLoggedIn` 連動のため、ログアウト直後やトークン失効時にバーが即座に消えること（`AuthContext` 状態に追従）を確認。
+4. 既存 `DreamRecorderFloating`（別の浮遊録音UI）との**役割・表示重複**に注意。重複して画面に2つ録音導線が出る場合は、#2では現状維持（重複解消は別途判断）とし、本PRで新たな重複を増やさない。

--- a/frontend/__tests__/components/BottomTabBar.test.tsx
+++ b/frontend/__tests__/components/BottomTabBar.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import BottomTabBar from "@/app/components/BottomTabBar";
+
+const mockUsePathname = jest.fn();
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("@/app/components/DreamEntryLauncher", () => ({
+  __esModule: true,
+  default: ({ buttonLabel }: { buttonLabel: string }) => (
+    <button>{buttonLabel}</button>
+  ),
+}));
+
+beforeEach(() => {
+  mockUsePathname.mockReturnValue("/home");
+  mockUseAuth.mockReturnValue({ authStatus: "authenticated", isLoggedIn: true });
+});
+
+describe("BottomTabBar", () => {
+  it("未ログインでは何も描画しない", () => {
+    mockUseAuth.mockReturnValue({ authStatus: "unauthenticated", isLoggedIn: false });
+    const { container } = render(<BottomTabBar />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("認証確認中は何も描画しない", () => {
+    mockUseAuth.mockReturnValue({ authStatus: "checking", isLoggedIn: false });
+    const { container } = render(<BottomTabBar />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("ログイン時に4タブと記録FABを描画する", () => {
+    render(<BottomTabBar />);
+    expect(screen.getByRole("link", { name: "おうち" })).toHaveAttribute("href", "/home");
+    expect(screen.getByRole("link", { name: "もり" })).toHaveAttribute("href", "/forest");
+    expect(screen.getByRole("link", { name: "マイ夢" })).toHaveAttribute("href", "/my-dreams");
+    expect(screen.getByRole("link", { name: "設定" })).toHaveAttribute("href", "/settings");
+    expect(screen.getByRole("button", { name: "夢をきろくする" })).toBeInTheDocument();
+  });
+
+  it("現在地のタブをアクティブ表示する", () => {
+    mockUsePathname.mockReturnValue("/forest");
+    render(<BottomTabBar />);
+    expect(screen.getByRole("link", { name: "もり" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: "おうち" })).not.toHaveAttribute("aria-current");
+  });
+});

--- a/frontend/app/components/BottomTabBar.tsx
+++ b/frontend/app/components/BottomTabBar.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { House, Trees, Moon, Settings, type LucideIcon } from "lucide-react";
+
+import { useAuth } from "@/context/AuthContext";
+import DreamEntryLauncher from "./DreamEntryLauncher";
+
+type Tab = { href: string; label: string; icon: LucideIcon };
+
+const LEFT_TABS: Tab[] = [
+  { href: "/home", label: "おうち", icon: House },
+  { href: "/forest", label: "もり", icon: Trees },
+];
+const RIGHT_TABS: Tab[] = [
+  { href: "/my-dreams", label: "マイ夢", icon: Moon },
+  { href: "/settings", label: "設定", icon: Settings },
+];
+
+/**
+ * モバイル専用のボトムタブバー。ログイン時だけ表示し、中央に記録FAB（DreamEntryLauncher）を置く。
+ * デスクトップ（md以上）は現行Headerに任せるため md:hidden。
+ * nav には backdrop-filter / transform を付けない（DreamEntryLauncherの fixed モーダルを壊さないため）。
+ */
+export default function BottomTabBar(): React.JSX.Element | null {
+  const pathname = usePathname();
+  const { authStatus, isLoggedIn } = useAuth();
+
+  if (authStatus === "checking" || !isLoggedIn) return null;
+
+  const renderTab = ({ href, label, icon: Icon }: Tab) => {
+    const active =
+      pathname === href || (href !== "/" && (pathname?.startsWith(href) ?? false));
+    return (
+      <Link
+        key={href}
+        href={href}
+        aria-current={active ? "page" : undefined}
+        className={`flex flex-1 flex-col items-center justify-center gap-0.5 py-1.5 text-[11px] font-semibold transition-colors ${
+          active ? "text-primary" : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        <Icon size={22} aria-hidden />
+        <span>{label}</span>
+      </Link>
+    );
+  };
+
+  return (
+    <>
+      {/* コンテンツがバーに隠れないようにする下スペーサー（ログイン時・モバイルのみ） */}
+      <div
+        aria-hidden
+        className="h-[calc(env(safe-area-inset-bottom)+4.5rem)] md:hidden"
+      />
+      <nav
+        aria-label="メインナビゲーション"
+        className="fixed inset-x-0 bottom-0 z-40 flex items-stretch justify-around border-t border-border bg-background px-2 pb-[env(safe-area-inset-bottom)] md:hidden"
+      >
+        {LEFT_TABS.map(renderTab)}
+
+        <div className="flex flex-1 items-start justify-center">
+          <DreamEntryLauncher
+            buttonLabel="夢をきろくする"
+            buttonClassName="-mt-6 h-14 w-14 justify-center rounded-full bg-primary text-primary-foreground shadow-lg [&>span]:sr-only"
+            showSparkles
+          />
+        </div>
+
+        {RIGHT_TABS.map(renderTab)}
+      </nav>
+    </>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -9,6 +9,7 @@ import { Suspense } from "react";
 import Loading from "./loading";
 import { Providers } from "./providers";
 import PendingDreamsMonitor from "./components/PendingDreamsMonitor";
+import BottomTabBar from "./components/BottomTabBar";
 import { SITE_URL, GOOGLE_SITE_VERIFICATION } from "@/lib/site";
 
 const notoSansJP = Noto_Sans_JP({ subsets: ["latin"] });
@@ -78,6 +79,7 @@ export default function RootLayout({
             {/* 全体で1つのインスタンスとしてマウント */}
           </div>
           <PendingDreamsMonitor />
+          <BottomTabBar />
         </Providers>
       </body>
     </html>


### PR DESCRIPTION
## 概要

サブPJ **#2「ボトムタブ・ナビゲーション」**。モバイル先行で **BottomTabBar＋中央FAB** を導入し、#3で各画面を流し込むシェルを整える。

世界観リデザインの土台づくりで、**提示層のみ・認証/ルーティング/Stripe/DBロジックは非タッチ**。

仕様・プラン:
- 📄 `docs/superpowers/specs/2026-06-28-bottom-tab-navigation-design.md`
- 📄 `docs/superpowers/plans/2026-06-28-bottom-tab-navigation.md`

## 変更内容

### 1. 新規 `BottomTabBar`（`frontend/app/components/BottomTabBar.tsx`）
- モバイル専用（`md:hidden`）・**認証時のみ表示**（`authStatus==="checking"` / `!isLoggedIn` で `null`）
- タブ: **おうち**(/home) / **もり**(/forest) / **[＋きろくFAB]** / **マイ夢**(/my-dreams) / **設定**(/settings)（子ども向けのやさしい語彙を踏襲）
- 中央FAB = 既存 `DreamEntryLauncher` を円形化して再利用（新規モーダルを作らない）
- アクティブ判定は `AuthNav` と同一ロジック、`aria-current="page"` 付与、iOSセーフエリア対応
- コンテンツがバーに隠れない下スペーサーを**コンポーネント内に内包**（layout本体は不変更）

### 2. `layout.tsx` にマウント（2行）
- import 追加＋ `<PendingDreamsMonitor />` 直後に `<BottomTabBar />` 1つ。既存クラス/padding は不変更でデスクトップはピクセル不変。

## 設計上の要点
- **nav はソリッド `bg-background`（backdrop-filter/transform なし）**。`DreamEntryLauncher` のモーダル（`fixed inset-0 z-[100]`）の包含ブロック化を構造的に回避（レビューで祖先チェーンを辿って実証済み）。
- spacer を `BottomTabBar` 内に閉じることで、ログイン時だけ余白が出て、公開ページとデスクトップに影響を残さない（spec §2.2 の padding 方式からの改善）。

## 検証結果
- **Jest: 315/315 green**（既存311 + 新規 BottomTabBar 4）
- **`yarn build`: webpack compile 成功**、#2変更ファイル由来の新規型エラーなし（既存の `app/forest/[profileId]/page.tsx` の named export 型エラーは無関係・別タスクで対応）
- **preview目視（公開 `/login`）**: ボトムバー非表示・Header健在・レイアウト正常を確認
- サブエージェント駆動：タスクごとに spec＋quality レビュー → 最終ブランチ全体レビューも **Ready to merge = Yes**（Critical/Important ゼロ）

### 認証済み表示の限界
ボトムバーは `isLoggedIn` 依存のため、公開ページpreviewでは「非表示・非破壊」までを確認。ログイン時のバー表示・FAB・アクティブ状態は **component test で担保**し、実機タップ感は手動QAに委ねる。

## 触っていない領域
認証ロジック / ルーティング / Stripe / DB / migration / 森画面のMorpheus実装 / `Header`・`AuthNav` のリファクタ / `frontend/public/images/morpheus/generated/`。

## #3 へ繰越（このPRでは対象外）
- `/home` の記録導線が複数（新FAB・`DreamRecorderFloating`(`z-[9999]`)・in-page `DreamEntryLauncher`）。**#3で整理**し、`z-[9999]` と FABモーダル `z-[100]` の重なりも解消する。
- `MorpheusAvatar`（詳細/インサイト用の小円クロップ）は #3。
