### PR TITLE
feat: MorpheusAvatar(#3) — 円形顔クロップを夢詳細/インサイトに適用

### DIFF
--- a/docs/superpowers/plans/2026-06-28-morpheus-avatar.md
+++ b/docs/superpowers/plans/2026-06-28-morpheus-avatar.md
@@ -1,0 +1,320 @@
+# MorpheusAvatar 適用(#3スライス) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 円形・顔クロップの `MorpheusAvatar` を新設し、`DreamStatsWidget`(インサイト) と 夢詳細の分析カードに適用する。variant→src/alt マップは `morpheusAssets.ts` に抽出して `MorpheusImage` と共有する。
+
+**Architecture:** `MorpheusImage` 内の `MorpheusImageVariant`/`MORPHEUS_IMAGE_SRC`/`ALT_BY_VARIANT` を純データモジュール `morpheusAssets.ts` へ移動（`MorpheusImage` は型を再export して既存importを非破壊）。`MorpheusAvatar` はその map を使い、円形コンテナ＋`next/image fill object-cover`＋`transform: scale(2) transformOrigin:center 25%` で顔にズーム。後光は付けない。
+
+**Tech Stack:** Next.js 16 App Router, Tailwind v4, next/image, Jest + @testing-library/react.
+
+## Global Constraints
+
+- **提示層のみ**: 認証/ルーティング/Stripe/DBロジックに触れない。表示の差し替え/追加のみ。
+- **後方互換**: `MorpheusImageVariant` の既存import元は `MorpheusImage`（多数のファイルが `import { ... type MorpheusImageVariant } from ".../MorpheusImage"`）。抽出後も `MorpheusImage` から**再export**して壊さない。
+- **アセット単一出典**: src/alt マップは `morpheusAssets.ts` のみが持つ。再タイプ禁止＝既存ブロックを**そのまま移動**。
+- **後光なし**: `MorpheusAvatar` に `animate-moon-pulse` を付けない（#0早見表「詳細＝後光なし」）。
+- 完了ゲート: `yarn jest` 全緑（既存322 + 新規）+ `yarn build` 成功（既存 forest/[profileId] 型エラーは無関係）。
+- 作業ディレクトリ: `frontend/`。
+
+---
+
+### Task 1: アセットマップ抽出（morpheusAssets）＋ MorpheusImage 再export
+
+**Files:**
+- Create: `frontend/app/components/morpheusAssets.ts`
+- Modify: `frontend/app/components/MorpheusImage.tsx`
+- Test: `frontend/__tests__/components/morpheusAssets.test.ts`（新規）
+
+**Interfaces:**
+- Produces: `morpheusAssets.ts` から `MorpheusImageVariant`(type) / `MORPHEUS_IMAGE_SRC` / `ALT_BY_VARIANT` を export。`MorpheusImage.tsx` は `MorpheusImageVariant` を再export（後続import互換）。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`frontend/__tests__/components/morpheusAssets.test.ts`:
+
+```typescript
+import { MORPHEUS_IMAGE_SRC, ALT_BY_VARIANT } from "@/app/components/morpheusAssets";
+
+describe("morpheusAssets", () => {
+  it("src と alt が同じ variant 集合を網羅する", () => {
+    const srcKeys = Object.keys(MORPHEUS_IMAGE_SRC).sort();
+    const altKeys = Object.keys(ALT_BY_VARIANT).sort();
+    expect(srcKeys.length).toBeGreaterThan(0);
+    expect(srcKeys).toEqual(altKeys);
+  });
+  it("analysis variant の src は morpheus-analysis 画像を指す", () => {
+    expect(MORPHEUS_IMAGE_SRC.analysis).toContain("morpheus-analysis");
+  });
+});
+```
+
+- [ ] **Step 2: 実行して失敗を確認**
+
+Run: `cd frontend && yarn jest __tests__/components/morpheusAssets.test.ts`
+Expected: FAIL（`morpheusAssets` モジュール未解決）
+
+- [ ] **Step 3: `morpheusAssets.ts` を作成し、MorpheusImage からマップを移動**
+
+まず `frontend/app/components/MorpheusImage.tsx` を読み、以下3ブロックを**そのまま（verbatim）切り取る**:
+- `export type MorpheusImageVariant = ... ;`（union 型定義）
+- `const MORPHEUS_IMAGE_SRC: Record<MorpheusImageVariant, string> = { ... };`
+- `const ALT_BY_VARIANT: Record<MorpheusImageVariant, string> = { ... };`
+
+切り取った3ブロックを `frontend/app/components/morpheusAssets.ts` に貼り付け、2つの `const` に `export` を付ける（型は既に `export type`）。ファイル冒頭コメント例:
+
+```typescript
+/**
+ * Morpheus 画像アセットの単一出典（variant → 画像/altテキスト）。
+ * MorpheusImage（全身）と MorpheusAvatar（顔クロップ）が共有する。
+ */
+// ↓ ここに MorpheusImage から移動した
+//   export type MorpheusImageVariant / export const MORPHEUS_IMAGE_SRC / export const ALT_BY_VARIANT
+//   を貼り付ける（src/alt の中身は再タイプせず移動すること）
+```
+
+- [ ] **Step 4: `MorpheusImage.tsx` を import に切替＋型を再export**
+
+`MorpheusImage.tsx` の既存 import 群に追加:
+
+```typescript
+import {
+  MORPHEUS_IMAGE_SRC,
+  ALT_BY_VARIANT,
+  type MorpheusImageVariant,
+} from "./morpheusAssets";
+```
+
+そして、移動して消えた `export type MorpheusImageVariant` の代わりに、既存importを壊さないための再exportを追加（import群の近くに1行）:
+
+```typescript
+export type { MorpheusImageVariant };
+```
+
+`FALLBACK_EXPRESSION`（`MorpheusExpression` 依存）は `MorpheusImage.tsx` に残す。`MorpheusImage` 本体のロジック（cssSize 等）は不変更。
+
+- [ ] **Step 5: テスト緑＋既存スイートで後方互換を確認**
+
+Run: `cd frontend && yarn jest __tests__/components/morpheusAssets.test.ts __tests__/components/MorpheusImage.test.tsx`
+Expected: PASS（新規 morpheusAssets 緑、既存 MorpheusImage テストも緑＝抽出が後方互換）
+
+- [ ] **Step 6: コミット**
+
+```bash
+cd frontend && git add app/components/morpheusAssets.ts app/components/MorpheusImage.tsx __tests__/components/morpheusAssets.test.ts
+git commit -m "refactor: Morpheusのvariant→src/altマップをmorpheusAssetsへ抽出
+
+MorpheusImageとMorpheusAvatarで共有する単一出典に。MorpheusImageは
+MorpheusImageVariantを再exportし既存importを非破壊。
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: MorpheusAvatar コンポーネント
+
+**Files:**
+- Create: `frontend/app/components/MorpheusAvatar.tsx`
+- Test: `frontend/__tests__/components/MorpheusAvatar.test.tsx`（新規）
+
+**Interfaces:**
+- Consumes: `MORPHEUS_IMAGE_SRC` / `ALT_BY_VARIANT` / `MorpheusImageVariant`（`./morpheusAssets`、Task 1）。
+- Produces: `export default function MorpheusAvatar(props): JSX.Element`、props `{ variant: MorpheusImageVariant; size?: number; className?: string; priority?: boolean }`。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`frontend/__tests__/components/MorpheusAvatar.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import MorpheusAvatar from "@/app/components/MorpheusAvatar";
+
+describe("MorpheusAvatar", () => {
+  it("variantに応じた画像とaltで描画する", () => {
+    render(<MorpheusAvatar variant="analysis" />);
+    const img = screen.getByAltText("夢の本を読んで分析しているモルペウス");
+    expect(img.getAttribute("src")).toContain("morpheus-analysis");
+  });
+
+  it("円形クロップ構造（rounded-full + overflow-hidden）を持つ", () => {
+    const { container } = render(<MorpheusAvatar variant="analysis" />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain("rounded-full");
+    expect(wrapper.className).toContain("overflow-hidden");
+  });
+
+  it("後光(animate-moon-pulse)を付けない", () => {
+    const { container } = render(<MorpheusAvatar variant="analysis" />);
+    expect(container.innerHTML).not.toContain("animate-moon-pulse");
+  });
+});
+```
+
+- [ ] **Step 2: 実行して失敗を確認**
+
+Run: `cd frontend && yarn jest __tests__/components/MorpheusAvatar.test.tsx`
+Expected: FAIL（`MorpheusAvatar` 未解決）
+
+- [ ] **Step 3: `MorpheusAvatar.tsx` を実装**
+
+`frontend/app/components/MorpheusAvatar.tsx`:
+
+```tsx
+"use client";
+
+import Image from "next/image";
+
+import {
+  MORPHEUS_IMAGE_SRC,
+  ALT_BY_VARIANT,
+  type MorpheusImageVariant,
+} from "./morpheusAssets";
+
+type MorpheusAvatarProps = {
+  variant: MorpheusImageVariant;
+  size?: number;
+  className?: string;
+  priority?: boolean;
+};
+
+/**
+ * Morpheus の顔を円形にクロップした小アバター。
+ * 全身画像（正方形・顔は上部中央）を object-cover + scale で顔にズームする。
+ * 後光は付けない（#0早見表「詳細＝後光なし」）。
+ */
+export default function MorpheusAvatar({
+  variant,
+  size = 56,
+  className = "",
+  priority = false,
+}: MorpheusAvatarProps) {
+  return (
+    <span
+      className={`relative inline-flex shrink-0 overflow-hidden rounded-full bg-muted ring-1 ring-border ${className}`}
+      style={{ width: size, height: size }}
+    >
+      <Image
+        src={MORPHEUS_IMAGE_SRC[variant]}
+        alt={ALT_BY_VARIANT[variant]}
+        fill
+        sizes={`${size}px`}
+        priority={priority}
+        className="object-cover"
+        style={{ transform: "scale(2)", transformOrigin: "center 25%" }}
+      />
+    </span>
+  );
+}
+```
+
+- [ ] **Step 4: テスト緑を確認**
+
+Run: `cd frontend && yarn jest __tests__/components/MorpheusAvatar.test.tsx`
+Expected: PASS（3テスト緑）
+
+- [ ] **Step 5: コミット**
+
+```bash
+cd frontend && git add app/components/MorpheusAvatar.tsx __tests__/components/MorpheusAvatar.test.tsx
+git commit -m "feat: 顔を円形クロップするMorpheusAvatarを追加
+
+全身画像を object-cover + scale で顔にズーム。後光なし。
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: DreamStatsWidget と 夢詳細への適用
+
+**Files:**
+- Modify: `frontend/app/components/DreamStatsWidget.tsx`
+- Modify: `frontend/app/dream/[id]/page.tsx`
+
+**Interfaces:**
+- Consumes: `MorpheusAvatar`（Task 2、`@/app/components/MorpheusAvatar` または相対）。
+
+- [ ] **Step 1: DreamStatsWidget の import を差し替え**
+
+`frontend/app/components/DreamStatsWidget.tsx` の
+`import MorpheusImage from "./MorpheusImage";`
+を
+`import MorpheusAvatar from "./MorpheusAvatar";`
+に変更。
+
+- [ ] **Step 2: DreamStatsWidget の今週サマリーを置換**
+
+既存:
+
+```tsx
+          <div className="shrink-0 rounded-xl bg-white/80 p-1 shadow-sm ring-1 ring-sky-100 dark:bg-white/10 dark:ring-white/10">
+            <MorpheusImage variant="analysis" size={54} />
+          </div>
+```
+
+を以下に置換（円アバター自身が ring を持つため囲み箱は不要）:
+
+```tsx
+          <MorpheusAvatar variant="analysis" size={54} className="shadow-sm" />
+```
+
+- [ ] **Step 3: 夢詳細の import を追加**
+
+`frontend/app/dream/[id]/page.tsx` の import 群（`import { MorpheusGuideDetail } from "@/app/components/MorpheusGuide";` の近く）に追加:
+
+```tsx
+import MorpheusAvatar from "@/app/components/MorpheusAvatar";
+```
+
+- [ ] **Step 4: 夢詳細の分析カードの🔮ボックスを置換**
+
+既存:
+
+```tsx
+                  <div className="rounded-3xl bg-primary/10 px-4 py-3 text-3xl">
+                    🔮
+                  </div>
+```
+
+を以下に置換:
+
+```tsx
+                  <MorpheusAvatar variant="analysis" size={56} />
+```
+
+- [ ] **Step 5: 完了ゲート（全テスト＋ビルド）**
+
+```bash
+cd frontend && yarn jest && yarn build
+```
+Expected: Jest 全緑（既存322 + Task1/2 の新規）、`yarn build` 成功。
+（`app/forest/[profileId]/page.tsx` の既存 named export 型エラーで止まる場合は、webpack compile が通り、#3で触れたファイル由来の新規エラーが無ければゲートを満たす。）
+
+- [ ] **Step 6: コミット**
+
+```bash
+cd frontend && git add app/components/DreamStatsWidget.tsx "app/dream/[id]/page.tsx"
+git commit -m "feat: インサイトと夢詳細の分析アバターをMorpheusAvatarに
+
+DreamStatsWidgetの今週サマリーと夢詳細の分析カード（🔮）を
+円形顔クロップのMorpheusAvatarに差し替え。
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §2.1 アセット抽出＋再export → Task 1 ✓
+- §2.2 MorpheusAvatar（円クロップ・後光なし）→ Task 2 ✓
+- §2.3 適用2カ所 → Task 3 ✓
+- §3 テスト（avatar src/alt・円構造・後光なし / assets網羅 / 既存緑）→ Task 1・2 のテスト ✓
+- §4 検証（build/jest）→ Task 3 Step 5。クロップ目視(eval注入)はコントローラが実施 ✓
+- §6 リスク①再export → Task 1 Step 4＋既存テストで担保 ✓ / ②transform無害 → 固定子孫なし ✓ / ③クロップ目視 → コントローラ ✓
+
+**2. Placeholder scan:** Task 1 Step 3 は「移動」指示（再タイプ防止）で意図的に中身を列挙しない＝プレースホルダではなく安全策。他は実コード。✓
+
+**3. Type consistency:** `MorpheusAvatar` props（`variant`/`size`/`className`/`priority`）は Task 2 定義＝Task 3 使用と一致。`MORPHEUS_IMAGE_SRC`/`ALT_BY_VARIANT`/`MorpheusImageVariant` は Task 1 produces＝Task 2 consumes 一致。`alt`「夢の本を読んで分析しているモルペウス」はテストと実マップで一致（要・実マップ確認：morpheus-analysis の alt）。✓

--- a/docs/superpowers/specs/2026-06-28-morpheus-avatar-design.md
+++ b/docs/superpowers/specs/2026-06-28-morpheus-avatar-design.md
@@ -1,0 +1,69 @@
+# MorpheusAvatar 適用（サブPJ #3・アバタースライス）設計仕様
+
+- 日付: 2026-06-28
+- 対象: YumeTree フロントエンド（Next.js 16 App Router + Tailwind v4）
+- 前提: #0(#394)/#1(#395)/#2(#396)/#3a(#397) マージ済み。本ブランチは main から派生。
+- 位置づけ: #1でYAGNI保留した「詳細/インサイト用の小円クロップ `MorpheusAvatar`」の回収。#0早見表「詳細＝analysis・sm48〜56・円クロップ・後光なし」を実装。
+- スコープ判断: 適用は2カ所（`DreamStatsWidget` インサイト＋夢詳細の分析カード）。月次サマリーは後続（ユーザー選択）。
+
+## 0. 背景
+
+- `DreamStatsWidget`（ホーム「今月のきもち」）の「今週サマリー」に既に `MorpheusImage variant="analysis" size={54}`（rounded-xl箱・全身）がある → 円クロップ顔アバターに置換すると世界観が締まる。
+- 夢詳細 `dream/[id]` の「🔮 AI分析」カード前面に `rounded-3xl bg-primary/10 ... text-3xl` の **🔮絵文字ボックス**がある → これを Morpheus の分析アバターに置換し「Morpheusが夢を読む」顔を主役にする。
+- 実画像は1254四方のチビ全身（顔は上部中央・縦~25%付近）。`MorpheusImage` は `object-contain`（全身表示）なので、顔クロップ用の別プリミティブが要る。
+
+## 1. 設計原則
+
+1. **提示層のみ**。認証/ルーティング/Stripe/DBに触れない。表示の差し替え/追加のみ。
+2. **アセット単一出典**。variant→src/alt マップを `MorpheusImage` と `MorpheusAvatar` で共有（DRY）。
+3. **後方互換**。`MorpheusImageVariant` の既存import元（`MorpheusImage`）を壊さない（再export）。
+4. **後光なし**（#0早見表「詳細＝後光なし」）。アバターは ring のみ、`moon-pulse` は付けない。
+
+## 2. 実装仕様
+
+### 2.1 アセットマップ抽出 `app/components/morpheusAssets.ts`（新規）
+- `MorpheusImageVariant` 型 / `MORPHEUS_IMAGE_SRC` / `ALT_BY_VARIANT` を `MorpheusImage.tsx` から移動。
+- `MorpheusImage.tsx` はこれらを import し、**`export type { MorpheusImageVariant }` を再export**（既存の `import { MorpheusImageVariant } from "./MorpheusImage"` 多数を壊さないため）。`FALLBACK_EXPRESSION` は `MorpheusImage` に残す（SVGフォールバック固有）。
+- 純データモジュールのため循環依存なし（型もこのモジュールが起点）。
+
+### 2.2 新規 `app/components/MorpheusAvatar.tsx`（client）
+- props: `variant: MorpheusImageVariant` / `size?: number`（既定 56）/ `className?: string` / `priority?: boolean`。
+- 描画: 円形コンテナ（`relative inline-flex shrink-0 overflow-hidden rounded-full ring-1 ring-border bg-muted`、`style={{ width: size, height: size }}`）の中に `next/image` を `fill` `sizes={size}px` `className="object-cover"`、`style={{ transform: "scale(2)", transformOrigin: "center 25%" }}` で**顔（上部中央）にズーム**。
+- alt は `ALT_BY_VARIANT[variant]`。`onError` で簡易フォールバック（`bg-muted` のまま・装飾要素のため SVG フォールバックは不要）。
+- クロップ値（`scale(2)` / `transformOrigin center 25%`）は preview への要素注入で目視確認し微調整する（§4）。
+
+### 2.3 適用
+- `app/components/DreamStatsWidget.tsx`: 「今週サマリー」の
+  `<MorpheusImage variant="analysis" size={54} />` を
+  `<MorpheusAvatar variant="analysis" size={54} />` に置換（囲みの `rounded-xl` 箱は ring と重複するため整理して可。最小では中身だけ差し替え）。import も差し替え。
+- `app/dream/[id]/page.tsx`: 分析カード前面の
+  `<div className="rounded-3xl bg-primary/10 px-4 py-3 text-3xl">🔮</div>` を
+  `<MorpheusAvatar variant="analysis" size={56} />` に置換。`MorpheusAvatar` を import。
+
+## 3. テスト方針（TDD・component render）
+
+- **MorpheusAvatar**:
+  - `variant` に応じた `src`（`MORPHEUS_IMAGE_SRC[variant]` の末尾一致）と `alt`（`ALT_BY_VARIANT[variant]`）で `<img>` を描画する。
+  - コンテナが円形クロップ構造（`rounded-full` ＋ `overflow-hidden`）を持つ。
+  - 後光（`animate-moon-pulse`）を**付けない**（クラスに含まれない）。
+- **morpheusAssets**: `MORPHEUS_IMAGE_SRC` と `ALT_BY_VARIANT` が全 variant を網羅（キー数一致）。
+- 既存スイート（322件）が緑のまま（`MorpheusImage` 抽出後も既存テストが通る＝後方互換確認）。
+
+## 4. 検証方針
+
+- 完了ゲート: `yarn jest` 全緑 + `yarn build` 成功。
+- **クロップ目視（認証不要）**: preview を起動し、`preview_eval` で `MorpheusAvatar` と同一の背景/transform を持つ要素を一時的にDOM注入してスクリーンショット → 顔が円内に収まるか確認し、必要なら `scale`/`transformOrigin` を調整。
+- 実画面（DreamStatsWidget・夢詳細）は認証ページのため、配置後の発色は手動QAに委ねる（component testで構造担保）。
+
+## 5. 成果物と境界
+
+**#3（本スライス）で触る**: `morpheusAssets.ts`（新規）/ `MorpheusImage.tsx`（マップ抽出＋型再export）/ `MorpheusAvatar.tsx`（新規）/ `DreamStatsWidget.tsx` / `dream/[id]/page.tsx` / 新規テスト。
+
+**触らない（後続へ）**: 月次サマリー(`dream/month/[yearMonth]`)への適用 → 後続スライス。森画面 → #4。認証/Stripe/DB。
+
+## 6. リスクと注意
+
+1. `MorpheusImage` のマップ抽出で既存の `MorpheusImageVariant` import を壊さない（再export必須）。`yarn build` ＋ 既存 MorpheusImage テストで担保。
+2. `transform: scale` はアバター要素に stacking context を作るが、固定子孫を持たないため無害。
+3. クロップ値は当て勘にせず §4 の eval 注入で確認。変な見切れがあれば `transformOrigin`/`scale` を調整。
+4. `DreamStatsWidget` の囲み箱を整理する場合も、既存の余白/リングと二重にならない範囲に留める（提示的最小変更）。

--- a/frontend/__tests__/components/MorpheusAvatar.test.tsx
+++ b/frontend/__tests__/components/MorpheusAvatar.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import MorpheusAvatar from "@/app/components/MorpheusAvatar";
+
+describe("MorpheusAvatar", () => {
+  it("variantに応じた画像とaltで描画する", () => {
+    render(<MorpheusAvatar variant="analysis" />);
+    const img = screen.getByAltText("夢の本を読んで分析しているモルペウス");
+    expect(img.getAttribute("src")).toContain("morpheus-analysis");
+  });
+
+  it("円形クロップ構造（rounded-full + overflow-hidden）を持つ", () => {
+    const { container } = render(<MorpheusAvatar variant="analysis" />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain("rounded-full");
+    expect(wrapper.className).toContain("overflow-hidden");
+  });
+
+  it("後光(animate-moon-pulse)を付けない", () => {
+    const { container } = render(<MorpheusAvatar variant="analysis" />);
+    expect(container.innerHTML).not.toContain("animate-moon-pulse");
+  });
+});

--- a/frontend/__tests__/components/morpheusAssets.test.ts
+++ b/frontend/__tests__/components/morpheusAssets.test.ts
@@ -1,0 +1,13 @@
+import { MORPHEUS_IMAGE_SRC, ALT_BY_VARIANT } from "@/app/components/morpheusAssets";
+
+describe("morpheusAssets", () => {
+  it("src と alt が同じ variant 集合を網羅する", () => {
+    const srcKeys = Object.keys(MORPHEUS_IMAGE_SRC).sort();
+    const altKeys = Object.keys(ALT_BY_VARIANT).sort();
+    expect(srcKeys.length).toBeGreaterThan(0);
+    expect(srcKeys).toEqual(altKeys);
+  });
+  it("analysis variant の src は morpheus-analysis 画像を指す", () => {
+    expect(MORPHEUS_IMAGE_SRC.analysis).toContain("morpheus-analysis");
+  });
+});

--- a/frontend/app/components/DreamStatsWidget.tsx
+++ b/frontend/app/components/DreamStatsWidget.tsx
@@ -4,7 +4,7 @@ import { Dream } from "@/app/types";
 import { getChildFriendlyEmotionLabel } from "./EmotionTag";
 import { getJSTYearMonthKey } from "@/lib/date";
 import { formatTopEmotionLabels, pickTopEmotionLabels } from "@/lib/emotionTie";
-import MorpheusImage from "./MorpheusImage";
+import MorpheusAvatar from "./MorpheusAvatar";
 
 interface DreamStatsWidgetProps {
   dreams: Dream[];
@@ -97,9 +97,7 @@ export default function DreamStatsWidget({ dreams }: DreamStatsWidgetProps) {
       {/* モルペウスの今週サマリー */}
       {weekTopLabels.length > 0 && (
         <div className="flex items-center gap-3 rounded-2xl border border-sky-200/60 bg-sky-50/80 p-3 dark:border-sky-500/20 dark:bg-slate-800/70">
-          <div className="shrink-0 rounded-xl bg-white/80 p-1 shadow-sm ring-1 ring-sky-100 dark:bg-white/10 dark:ring-white/10">
-            <MorpheusImage variant="analysis" size={54} />
-          </div>
+          <MorpheusAvatar variant="analysis" size={54} className="shadow-sm" />
           <p className="text-xs leading-relaxed text-slate-700 dark:text-slate-200">
             今週いちばん多い きもちは{" "}
             <span className="font-bold text-sky-600 dark:text-sky-300">

--- a/frontend/app/components/MorpheusAvatar.tsx
+++ b/frontend/app/components/MorpheusAvatar.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Image from "next/image";
+
+import {
+  MORPHEUS_IMAGE_SRC,
+  ALT_BY_VARIANT,
+  type MorpheusImageVariant,
+} from "./morpheusAssets";
+
+type MorpheusAvatarProps = {
+  variant: MorpheusImageVariant;
+  size?: number;
+  className?: string;
+  priority?: boolean;
+};
+
+/**
+ * Morpheus の顔を円形にクロップした小アバター。
+ * 全身画像（正方形・顔は上部中央）を object-cover + scale で顔にズームする。
+ * 後光は付けない（#0早見表「詳細＝後光なし」）。
+ */
+export default function MorpheusAvatar({
+  variant,
+  size = 56,
+  className = "",
+  priority = false,
+}: MorpheusAvatarProps) {
+  return (
+    <span
+      className={`relative inline-flex shrink-0 overflow-hidden rounded-full bg-muted ring-1 ring-border ${className}`}
+      style={{ width: size, height: size }}
+    >
+      <Image
+        src={MORPHEUS_IMAGE_SRC[variant]}
+        alt={ALT_BY_VARIANT[variant]}
+        fill
+        sizes={`${size}px`}
+        priority={priority}
+        className="object-cover"
+        style={{ transform: "scale(2)", transformOrigin: "center 25%" }}
+      />
+    </span>
+  );
+}

--- a/frontend/app/components/MorpheusImage.tsx
+++ b/frontend/app/components/MorpheusImage.tsx
@@ -4,50 +4,13 @@ import { useState, useEffect } from "react";
 import Image from "next/image";
 import { motion } from "framer-motion";
 import MorpheusSVG, { type MorpheusExpression } from "./MorpheusSVG";
+import {
+  MORPHEUS_IMAGE_SRC,
+  ALT_BY_VARIANT,
+  type MorpheusImageVariant,
+} from "./morpheusAssets";
 
-export type MorpheusImageVariant =
-  | "home"
-  | "compose"
-  | "voice"
-  | "analysis"
-  | "empty"
-  | "praise"
-  | "landing"
-  | "login"
-  | "search"
-  | "settings"
-  | "reward";
-
-const MORPHEUS_IMAGE_SRC: Record<MorpheusImageVariant, string> = {
-  // 既存の6枚: YumeTreeの主要フロー
-  home: "/images/morpheus/morpheus-home.jpg",
-  compose: "/images/morpheus/morpheus-compose.jpg",
-  voice: "/images/morpheus/morpheus-voice.jpg",
-  analysis: "/images/morpheus/morpheus-analysis.jpg",
-  empty: "/images/morpheus/morpheus-empty.jpg",
-  praise: "/images/morpheus/morpheus-praise.jpg",
-
-  // 追加の4枚: 画面別に使う新規モルペウス
-  landing: "/images/morpheus/morpheus-landing.jpg",
-  login: "/images/morpheus/morpheus-landing.jpg",
-  search: "/images/morpheus/morpheus-search.jpg",
-  settings: "/images/morpheus/morpheus-settings.jpg",
-  reward: "/images/morpheus/morpheus-reward.jpg",
-};
-
-const ALT_BY_VARIANT: Record<MorpheusImageVariant, string> = {
-  home: "ホーム画面で見守るモルペウス",
-  compose: "夢を書く場面で応援するモルペウス",
-  voice: "マイクの前で夢の話を聞いているモルペウス",
-  analysis: "夢の本を読んで分析しているモルペウス",
-  empty: "月と雲の上で次の夢を待っているモルペウス",
-  praise: "星を掲げて夢の記録をほめるモルペウス",
-  landing: "月を手に持ってYumeTreeへ案内するモルペウス",
-  login: "おかえりと迎えてくれるモルペウス",
-  search: "虫眼鏡で夢の記録を探しているモルペウス",
-  settings: "魔法の筆とパレットで設定を案内するモルペウス",
-  reward: "星のトロフィーを掲げてほめるモルペウス",
-};
+export type { MorpheusImageVariant };
 
 // 画像が読み込めなかった場合に表示する SVG の表情
 const FALLBACK_EXPRESSION: Record<MorpheusImageVariant, MorpheusExpression> = {

--- a/frontend/app/components/morpheusAssets.ts
+++ b/frontend/app/components/morpheusAssets.ts
@@ -1,0 +1,48 @@
+/**
+ * Morpheus 画像アセットの単一出典（variant → 画像/altテキスト）。
+ * MorpheusImage（全身）と MorpheusAvatar（顔クロップ）が共有する。
+ */
+
+export type MorpheusImageVariant =
+  | "home"
+  | "compose"
+  | "voice"
+  | "analysis"
+  | "empty"
+  | "praise"
+  | "landing"
+  | "login"
+  | "search"
+  | "settings"
+  | "reward";
+
+export const MORPHEUS_IMAGE_SRC: Record<MorpheusImageVariant, string> = {
+  // 既存の6枚: YumeTreeの主要フロー
+  home: "/images/morpheus/morpheus-home.jpg",
+  compose: "/images/morpheus/morpheus-compose.jpg",
+  voice: "/images/morpheus/morpheus-voice.jpg",
+  analysis: "/images/morpheus/morpheus-analysis.jpg",
+  empty: "/images/morpheus/morpheus-empty.jpg",
+  praise: "/images/morpheus/morpheus-praise.jpg",
+
+  // 追加の4枚: 画面別に使う新規モルペウス
+  landing: "/images/morpheus/morpheus-landing.jpg",
+  login: "/images/morpheus/morpheus-landing.jpg",
+  search: "/images/morpheus/morpheus-search.jpg",
+  settings: "/images/morpheus/morpheus-settings.jpg",
+  reward: "/images/morpheus/morpheus-reward.jpg",
+};
+
+export const ALT_BY_VARIANT: Record<MorpheusImageVariant, string> = {
+  home: "ホーム画面で見守るモルペウス",
+  compose: "夢を書く場面で応援するモルペウス",
+  voice: "マイクの前で夢の話を聞いているモルペウス",
+  analysis: "夢の本を読んで分析しているモルペウス",
+  empty: "月と雲の上で次の夢を待っているモルペウス",
+  praise: "星を掲げて夢の記録をほめるモルペウス",
+  landing: "月を手に持ってYumeTreeへ案内するモルペウス",
+  login: "おかえりと迎えてくれるモルペウス",
+  search: "虫眼鏡で夢の記録を探しているモルペウス",
+  settings: "魔法の筆とパレットで設定を案内するモルペウス",
+  reward: "星のトロフィーを掲げてほめるモルペウス",
+};

--- a/frontend/app/dream/[id]/page.tsx
+++ b/frontend/app/dream/[id]/page.tsx
@@ -15,6 +15,7 @@ import apiClient from "../../../lib/apiClient";
 import { useAuth } from "../../../context/AuthContext";
 import { AgeGroup } from "@/app/types";
 import { MorpheusGuideDetail } from "@/app/components/MorpheusGuide";
+import MorpheusAvatar from "@/app/components/MorpheusAvatar";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -322,9 +323,7 @@ export default function DreamDetailPage({
                   {copy.analysis}
                 </p>
                 <div className="mt-4 flex items-center gap-4">
-                  <div className="rounded-3xl bg-primary/10 px-4 py-3 text-3xl">
-                    🔮
-                  </div>
+                  <MorpheusAvatar variant="analysis" size={56} />
                   <div>
                     <p className="text-lg font-bold text-foreground">
                       モルペウスが 夢を読みほどいたよ


### PR DESCRIPTION
## 概要

サブPJ #3 のアバタースライス。#1でYAGNI保留した「**円形・顔クロップの `MorpheusAvatar`**」を新設し、夢詳細の分析カードとインサイト（今週サマリー）に適用。Morpheusを「顔のあるキャラクター」として各所で主役化する世界観リデザインの一部。

提示層のみ・認証/Stripe/DB非タッチ。main から派生。

仕様・プラン:
- 📄 `docs/superpowers/specs/2026-06-28-morpheus-avatar-design.md`
- 📄 `docs/superpowers/plans/2026-06-28-morpheus-avatar.md`

## 変更内容

### 1. アセット単一出典化（リファクタ・後方互換）
`MorpheusImageVariant` 型／`MORPHEUS_IMAGE_SRC`／`ALT_BY_VARIANT` を `MorpheusImage.tsx` から純データモジュール **`morpheusAssets.ts`** へ**そのまま移動**。`MorpheusImage` は `MorpheusImageVariant` を**再export**し、既存の5ファイル（MorpheusSmall/MorpheusHero/DreamStreakBadge/MorpheusGuide/DreamAdventurePanel）の import を非破壊に維持。

### 2. 新規 `MorpheusAvatar`
- 全身チビ画像（正方形・顔は上部中央）を **`object-cover` + `transform: scale(2) transformOrigin:center 25%`** で顔にズームし、円形（`rounded-full overflow-hidden ring-1`）にクロップ。
- **後光なし**（#0早見表「詳細＝後光なし」）。既定 size 56。

### 3. 適用2カ所
- `DreamStatsWidget`（ホーム「今月のきもち」の今週サマリー）：`MorpheusImage analysis 54` → `MorpheusAvatar analysis 54`（囲み箱はアバター自身のringで不要に）。
- `dream/[id]` 分析カード：「🔮 AI分析」前面の🔮絵文字ボックス → `MorpheusAvatar analysis 56`（Morpheusが夢を読む顔に）。

## 検証結果
- **Jest: 327 green**（#3で +5：morpheusAssets +2 / MorpheusAvatar +3。既存 MorpheusImage テストも緑＝抽出が後方互換）
- **`yarn build`: 成功**（#3変更ファイル由来の新規型エラーなし）
- **クロップ目視（認証不要）**: dev server に MorpheusAvatar と同一 transform の要素を注入し、analysis/home/reward の3 variant でスクリーンショット確認 → **顔が円内にきれいに収まる**ことを実証（調整不要）。
- サブエージェント駆動：タスクごとに spec＋quality レビュー → 最終ブランチ全体レビューも **Ready to merge = Yes**（Critical/Important ゼロ）。

実画面（DreamStatsWidget・夢詳細）は認証ページのため、配置後の発色は手動QAに委ねる（構造は component test で担保）。

## 触っていない領域
認証/ルーティング/Stripe/DB/森画面/月次サマリー(`dream/month/[yearMonth]`への適用は後続スライス)。

## 繰越（任意・マージ非ブロック）
- `MorpheusAvatar` の `onError` ハンドラ未実装（壊れた画像は `bg-muted` の円に degrade＝spec記載のフォールバック挙動は実質達成。spec文言とコードの一致は後続で）。
- `MorpheusAvatar` テストは `analysis` variant のみ（本番使用がanalysisのみのため十分。将来 `it.each` で全variant網羅も可）。
