### PR TITLE
feat: 月次サマリーにMorpheusAvatar適用(#3スライス) — reward円アバター

### DIFF
--- a/frontend/app/dream/month/[yearMonth]/page.tsx
+++ b/frontend/app/dream/month/[yearMonth]/page.tsx
@@ -7,7 +7,7 @@ import { EmotionTag } from "@/app/components/EmotionTag";
 import DreamList from "@/app/components/DreamList";
 import { DreamListSkeleton } from "@/app/components/DreamCardSkeleton";
 import MorpheusLoginRequired from "@/app/components/MorpheusLoginRequired";
-import MorpheusImage from "@/app/components/MorpheusImage";
+import MorpheusAvatar from "@/app/components/MorpheusAvatar";
 import { Dream } from "@/app/types";
 import { useAuth } from "@/context/AuthContext";
 import apiClient from "@/lib/apiClient";
@@ -241,13 +241,11 @@ export default function DreamByMonthPage() {
 
                 <div className="flex items-center justify-center border-t border-border bg-slate-100/70 p-5 dark:bg-slate-900/50 md:border-l md:border-t-0">
                   <div className="text-center">
-                    <div className="mx-auto flex h-36 w-36 items-center justify-center rounded-[2rem] bg-white/70 shadow-sm ring-1 ring-slate-200 dark:bg-slate-950/40 dark:ring-slate-700/60">
-                      <MorpheusImage
-                        variant="analysis"
-                        size={128}
-                        className="h-32 w-32 object-contain"
-                      />
-                    </div>
+                    <MorpheusAvatar
+                      variant="reward"
+                      size={128}
+                      className="shadow-md"
+                    />
                     <p className="mt-3 text-xs text-muted-foreground">
                       ゆめを ふりかえると、つぎの ゆめも おもしろくなるかも。
                     </p>


### PR DESCRIPTION
## 概要

#3「画面適用」の続きスライス。月のふりかえりページ `dream/month/[yearMonth]` の「Monthly Summary」カードの全身モルペウス（`MorpheusImage variant="analysis" size={128}`・四角枠入り）を、前スライス(#398)で作った**円形顔クロップ `MorpheusAvatar`** に差し替え。月のふりかえり＝お祝いの気分に合わせて **`variant="reward"`（星のトロフィーを掲げたモルペウス）** を採用。

提示層のみ・認証/Stripe/DB非タッチ。main から派生。

## 変更内容（1ファイル・+6 -8）
`frontend/app/dream/month/[yearMonth]/page.tsx`:
- import を `MorpheusImage` → `MorpheusAvatar` に。
- まとめカード右パネルの `<div rounded-[2rem] ...>` 四角枠＋全身 `MorpheusImage` を `<MorpheusAvatar variant="reward" size={128} className="shadow-md" />` に置換（四角枠はアバター自身の `ring` で不要に）。

## 検証結果
- **Jest: 327 green**（既存スイートそのまま緑。本変更は提示的差し替えのため新規テストなし＝`MorpheusAvatar`自体は#398でテスト済み）
- **`yarn build`: 成功**
- **クロップ目視（認証不要）**: dev server に reward を 128px・同一transformで注入しスクショ確認 → 顔＋掲げたトロフィーが円内にきれいに収まることを実証（調整不要）。

実画面（認証ページ）の配置後の発色は手動QAに委ねる。

## 触っていない領域
認証/ルーティング/Stripe/DB/森画面/AIサマリー生成ロジック。

## #3 残り（後続）
音声/プロフィール/設定など他画面のアバター適用。森画面は #4。