### PR TITLE
feat: 設定ガイドにMorpheusAvatar適用(#3スライス)

### DIFF
--- a/frontend/__tests__/app/settings/page.test.tsx
+++ b/frontend/__tests__/app/settings/page.test.tsx
@@ -28,9 +28,21 @@ jest.mock("@/lib/toast", () => ({
   toast: { success: jest.fn(), error: jest.fn() },
 }));
 
-jest.mock("@/app/components/MorpheusImage", () => ({
+jest.mock("@/app/components/MorpheusAvatar", () => ({
   __esModule: true,
-  default: () => <div data-testid="morpheus-image" />,
+  default: ({
+    variant,
+    size,
+  }: {
+    variant: string;
+    size?: number;
+  }) => (
+    <div
+      data-testid="morpheus-avatar"
+      data-variant={variant}
+      data-size={size}
+    />
+  ),
 }));
 
 jest.mock("@/app/components/MorpheusLoginRequired", () => ({
@@ -102,7 +114,24 @@ describe("未認証ガード", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 2. userId が無い状態での削除
+// 2. 設定ガイド
+// ---------------------------------------------------------------------------
+
+describe("設定ガイド", () => {
+  it("settings variant の円形MorpheusAvatarを表示する", () => {
+    mockedUseAuth.mockReturnValue(makeAuthValue());
+
+    render(<SettingsPage />);
+
+    const avatar = screen.getByTestId("morpheus-avatar");
+    expect(avatar).toHaveAttribute("data-variant", "settings");
+    expect(avatar).toHaveAttribute("data-size", "112");
+    expect(screen.queryByTestId("morpheus-image")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. userId が無い状態での削除
 // ---------------------------------------------------------------------------
 
 describe("userId が無い状態での削除", () => {
@@ -123,7 +152,7 @@ describe("userId が無い状態での削除", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 3. 削除APIが失敗した場合
+// 4. 削除APIが失敗した場合
 // ---------------------------------------------------------------------------
 
 describe("削除APIが失敗した場合", () => {
@@ -147,7 +176,7 @@ describe("削除APIが失敗した場合", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 4. 削除成功時
+// 5. 削除成功時
 // ---------------------------------------------------------------------------
 
 describe("削除成功時", () => {

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -8,7 +8,7 @@ import { ChevronLeft } from "lucide-react";
 import { updateProfile } from "@/lib/apiClient";
 import { toast } from "@/lib/toast";
 import type { AgeGroup, AnalysisTone } from "@/app/types";
-import MorpheusImage from "@/app/components/MorpheusImage";
+import MorpheusAvatar from "@/app/components/MorpheusAvatar";
 import MorpheusLoginRequired from "@/app/components/MorpheusLoginRequired";
 
 const AGE_GROUP_OPTIONS: { value: AgeGroup; label: string }[] = [
@@ -240,7 +240,11 @@ const SettingsPage = () => {
                 年れいや分析スタイルを合わせると、ゆめの説明がもっと読みやすくなるよ。
               </p>
             </div>
-            <MorpheusImage variant="settings" size={150} />
+            <MorpheusAvatar
+              variant="settings"
+              size={112}
+              className="shadow-lg ring-white/25"
+            />
           </div>
         </section>
 


### PR DESCRIPTION
## 概要

#3「残り画面適用」の小スライスです。

設定画面の `Settings Guide` カードに残っていた全身 `MorpheusImage variant="settings" size={150}` を、#398 で導入された円形顔クロップ `MorpheusAvatar variant="settings"` に置き換えました。

提案層のみの変更で、認証 / DB / Stripe / ルーティング / 森画面には触れていません。

## 変更内容

- `frontend/app/settings/page.tsx`
  - `MorpheusImage` import を `MorpheusAvatar` に変更
  - 設定ガイド右側の全身画像を `MorpheusAvatar variant="settings" size={112}` に置換
  - ダークなガイドカード上で見えるよう `shadow-lg ring-white/25` を付与

- `frontend/__tests__/app/settings/page.test.tsx`
  - `MorpheusAvatar` mock に更新
  - settings variant / size 112 の表示テストを追加

## 検証結果

- `npx jest __tests__/app/settings/page.test.tsx --runInBand`
  - 1 suite / 5 tests green
- `npx jest --runInBand`
  - 41 suites / 328 tests green
- `npm run build -- --webpack`
  - webpack compile は成功
  - TypeScript step で既存の Next Page export 型エラーにより失敗:
    - `app/forest/[profileId]/page.tsx`
    - `"isValidForestProfileId" is not a valid Page export field`
  - 今回変更した settings avatar 差分起因ではありません

## 触っていない領域

- 認証
- DB
- Stripe
- migration
- rake
- 森画面
- AI生成/分析ロジック
- `frontend/public/images/morpheus/generated/`

## #3 残り

音声入力中カード、プロフィール/設定内の他の小型表示、その他の小さな案内表示は後続スライスで扱います。
