### PR TITLE
feat: 夢フォーム分析中にMorpheusAvatar適用(#3スライス)

### DIFF
--- a/frontend/__tests__/components/DreamForm.test.js
+++ b/frontend/__tests__/components/DreamForm.test.js
@@ -47,6 +47,17 @@ jest.mock("@/lib/toast", () => ({
   },
 }));
 
+jest.mock("@/app/components/MorpheusAvatar", () => ({
+  __esModule: true,
+  default: ({ variant, size }) => (
+    <div
+      data-testid="morpheus-avatar"
+      data-variant={variant}
+      data-size={size}
+    />
+  ),
+}));
+
 const { getEmotions, previewAnalysis } = require("@/lib/apiClient");
 const { ApiError } = require("@/lib/apiClient");
 const { toast } = require("@/lib/toast");
@@ -299,6 +310,22 @@ describe("DreamForm", () => {
     });
     expect(upgradeLink).toHaveAttribute("href", "/subscription");
     expect(screen.getByText("今月の無料分析回数を使い切ったよ")).toBeInTheDocument();
+  });
+
+  it("shows an analysis MorpheusAvatar while Morpheus is reading the dream", async () => {
+    getEmotions.mockResolvedValueOnce([]);
+    previewAnalysis.mockImplementationOnce(() => new Promise(() => {}));
+    const user = userEvent.setup();
+
+    render(<DreamForm onSubmit={jest.fn()} />);
+
+    await user.type(screen.getByLabelText("どんな おはなし？"), "空を飛ぶ夢");
+    await user.click(screen.getByRole("button", { name: /モルペウスに\s*きく/ }));
+
+    expect(await screen.findByText("Morpheus Reading")).toBeInTheDocument();
+    const avatar = screen.getByTestId("morpheus-avatar");
+    expect(avatar).toHaveAttribute("data-variant", "analysis");
+    expect(avatar).toHaveAttribute("data-size", "74");
   });
 
   it("shows the backend analysis error message when analysis fails", async () => {

--- a/frontend/app/components/DreamForm.tsx
+++ b/frontend/app/components/DreamForm.tsx
@@ -7,7 +7,7 @@ import { Dream, DreamProfile, Emotion, DreamDraftData } from "../types";
 import { getDreamProfiles, getEmotions, previewAnalysis, ApiError } from "@/lib/apiClient";
 import { toast } from "@/lib/toast";
 import { groupEmotionsByDisplayLabel } from "./emotionGrouping";
-import MorpheusImage from "./MorpheusImage";
+import MorpheusAvatar from "./MorpheusAvatar";
 
 interface DreamFormData {
   title: string;
@@ -368,9 +368,11 @@ export default function DreamForm({
         {isAnalyzing ? (
           <div className="mt-4 overflow-hidden rounded-[28px] border border-sky-200/50 bg-slate-950 px-4 py-4 text-slate-50 shadow-lg">
             <div className="flex items-center gap-4">
-              <div className="shrink-0 rounded-2xl bg-white/90 p-1 shadow-sm ring-1 ring-white/30">
-                <MorpheusImage variant="analysis" size={74} />
-              </div>
+              <MorpheusAvatar
+                variant="analysis"
+                size={74}
+                className="shadow-sm ring-white/30"
+              />
               <div className="flex-1">
                 <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-300">
                   Morpheus Reading


### PR DESCRIPTION
## 概要

#3「残り画面適用」の小スライスです。

夢作成/編集フォームの分析中カードに残っていた全身 `MorpheusImage variant="analysis" size={74}` を、#398 で導入された円形顔クロップ `MorpheusAvatar variant="analysis"` に置き換えました。

提案層のみの変更で、認証 / DB / Stripe / ルーティング / 森画面 / AI分析ロジックには触れていません。

## 変更内容

- `frontend/app/components/DreamForm.tsx`
  - `MorpheusImage` import を `MorpheusAvatar` に変更
  - 分析中カードの四角枠 + 全身画像を `MorpheusAvatar variant="analysis" size={74}` に置換
  - 既存の `Morpheus Reading` 文言、進捗バー、分析処理は不変更

- `frontend/__tests__/components/DreamForm.test.js`
  - `MorpheusAvatar` mock を追加
  - 分析中カードが `analysis` variant / size 74 のAvatarを表示するテストを追加

## 検証結果

- `npx jest __tests__/components/DreamForm.test.js --runInBand`
  - 1 suite / 9 tests green
- `npx jest --runInBand`
  - 41 suites / 329 tests green
- `npm run build -- --webpack`
  - webpack compile は成功
  - TypeScript step で既存の Next Page export 型エラーにより失敗:
    - `app/forest/[profileId]/page.tsx`
    - `"isValidForestProfileId" is not a valid Page export field`
  - 今回変更した DreamForm avatar 差分起因ではありません

## 触っていない領域

- 認証
- DB
- Stripe
- migration
- rake
- 森画面
- AI生成/分析ロジック
- `frontend/public/images/morpheus/generated/`

## #3 残り

プロフィール/設定内の他の小さな表示、その他の小さな案内表示は後続スライスで扱います。
