### PR TITLE
feat: ムードカレンダー(redesign-code STEP1) — 月別ページに感情ヒートマップ

### DIFF
--- a/docs/superpowers/specs/2026-06-29-mood-calendar-design.md
+++ b/docs/superpowers/specs/2026-06-29-mood-calendar-design.md
@@ -1,0 +1,47 @@
+# ムードカレンダー（redesign-code STEP 1）設計仕様
+
+- 日付: 2026-06-29
+- 対象: YumeTree フロントエンド（Next.js 16 + Tailwind v4）
+- 出典: `~/Downloads/redesign-code/components/MoodCalendar.tsx`（改善④データ可視化の最小スライス）
+- 位置づけ: redesign-code の5ステップ（①カレンダー ②ストリーミング分析 ③⌘K ④サイドバー/AppShell ⑤インサイトページ）の **STEP 1（最小・低リスク）**。以降も依存順で個別PR。
+
+## 0. 方針
+
+参照コードは自己完結で良質。**そのまま貼らず**、実コードベースの型/import/規約に合わせて適応する。新しい色は足さない（既存Tailwindパレット）。森には触れない。提示層のみ。
+
+## 1. コンポーネント仕様 `app/components/MoodCalendar.tsx`（新規・client）
+
+- props: `{ dreams: Dream[]; month?: string }`（`month` 省略時は今月JST）。
+- 役割: 指定月の各日を「その日の最頻感情の色」で塗るGitHub草グラフ風ヒートマップ＋曜日見出し＋凡例。
+- 依存（既存資産・確認済み）:
+  - `getChildFriendlyEmotionLabel`（`./EmotionTag`）で感情ラベル正規化。
+  - `getJSTYearMonthKey`（`@/lib/date`）でJST月キー。
+  - `Dream` 型（`@/app/types`）。集計は `d.analysis_json?.emotion_tags ?? d.emotions?.map(e=>e.name) ?? []`（DreamStatsWidgetと同じ）。
+- 色: 感情カテゴリ→Tailwind（うれしい=orange-400 / たのしい=amber-400 / かなしい=sky-400 / こわい=violet-500 等、記録なし=`bg-muted`）。`border-border`/`bg-card`/`text-card-foreground`/`text-muted-foreground` でダーク自動対応。
+- 集計ロジック（参照踏襲）: 月内の夢を日付(JST `en-CA` YYYY-MM-DD)ごとに感情カウント→各日の最頻感情でセル色。月初の曜日ぶん空きマス。
+
+## 2. 配置
+
+`app/dream/month/[yearMonth]/page.tsx` の Stats セクションと Dream list の間に追加（その月の `dreams` と `yearMonth` を渡す）。ユーザー選択＝月別ページ。ホーム右サイドバーへの追加は後続の任意スライス。
+
+```tsx
+<MoodCalendar dreams={dreams} month={yearMonth} />
+```
+
+## 3. テスト方針（TDD・component render）
+
+`@testing-library/react` + jest。
+- 曜日見出し（日〜土）が描画される。
+- 夢のある日が `bg-muted`(記録なし) ではなく感情色セルになる（最頻感情→色）。
+- 凡例が描画される。
+- 既存スイートが緑のまま。
+
+## 4. 検証方針
+
+- ゲート: `yarn jest` 全緑 + `yarn build` 成功（既存 forest tsc エラーは無関係）。
+- 配置先（月別ページ）は認証ページのため、配置後の発色は手動QA。ヒートマップの構造/色はcomponent testで担保。
+
+## 5. 境界
+
+**触る**: `app/components/MoodCalendar.tsx`（新規）/ `app/dream/month/[yearMonth]/page.tsx`（組み込み）/ テスト。
+**触らない**: 認証/ルーティング/Stripe/DB/森/他STEP（②〜⑤は後続PR）。

--- a/frontend/__tests__/components/MoodCalendar.test.tsx
+++ b/frontend/__tests__/components/MoodCalendar.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import MoodCalendar from "@/app/components/MoodCalendar";
+import { Dream } from "@/app/types";
+
+function dream(id: number, createdAt: string, emotion: string): Dream {
+  return {
+    id,
+    created_at: createdAt,
+    analysis_json: { emotion_tags: [emotion] },
+  } as unknown as Dream;
+}
+
+describe("MoodCalendar", () => {
+  it("曜日見出し（日〜土）を描画する", () => {
+    render(<MoodCalendar dreams={[]} month="2026-06" />);
+    ["日", "月", "火", "水", "木", "金", "土"].forEach((w) => {
+      expect(screen.getByText(w)).toBeInTheDocument();
+    });
+  });
+
+  it("夢のある日を感情色のセルにする（記録なしのbg-mutedではない）", () => {
+    const { container } = render(
+      <MoodCalendar
+        dreams={[dream(1, "2026-06-15T03:00:00Z", "嬉しい")]}
+        month="2026-06"
+      />
+    );
+    // うれしい系 → bg-orange-400 の日セル（titleに感情と件数）が存在する
+    const cell = container.querySelector('[title*="うれしい"]');
+    expect(cell).not.toBeNull();
+    expect(cell?.className).toContain("bg-orange-400");
+    expect(cell?.className).not.toContain("bg-muted");
+  });
+
+  it("凡例を描画する", () => {
+    render(<MoodCalendar dreams={[]} month="2026-06" />);
+    expect(screen.getByText("記録なし")).toBeInTheDocument();
+  });
+});

--- a/frontend/app/components/MoodCalendar.tsx
+++ b/frontend/app/components/MoodCalendar.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+/**
+ * MoodCalendar — 月のムードヒートマップ（GitHubの草グラフ風）
+ *
+ * その月、どんな気持ちの夢が多かったかを一目で振り返れるカレンダー。
+ * 各日のセルを「その日の最頻感情の色」で塗る。
+ *
+ * 既存資産を再利用:
+ *  - getChildFriendlyEmotionLabel（EmotionTag.tsx）で感情ラベルを正規化
+ *  - getJSTYearMonthKey（lib/date.ts）でJST基準の月キーを生成
+ *
+ * 使い方:
+ *  <MoodCalendar dreams={dreams} month={getJSTYearMonthKey(new Date())} />
+ */
+
+import { useMemo } from "react";
+
+import { Dream } from "@/app/types";
+import { getJSTYearMonthKey } from "@/lib/date";
+import { getChildFriendlyEmotionLabel } from "./EmotionTag";
+
+// 感情カテゴリ → セル色（Tailwind）。EmotionTag のカテゴリと対応。
+function emotionToCellClass(label: string): string {
+  if (label.includes("うれしい")) return "bg-orange-400";
+  if (label.includes("たのしい")) return "bg-amber-400";
+  if (label.includes("じーんとした")) return "bg-rose-400";
+  if (label.includes("おこってる")) return "bg-red-500";
+  if (label.includes("こわい")) return "bg-violet-500";
+  if (label.includes("しんぱい")) return "bg-indigo-400";
+  if (label.includes("かなしい")) return "bg-sky-400";
+  if (label.includes("ほっとした")) return "bg-emerald-400";
+  if (label.includes("びっくり")) return "bg-yellow-400";
+  if (label.includes("わからない")) return "bg-slate-400";
+  return "bg-sky-300";
+}
+
+const WEEKDAYS = ["日", "月", "火", "水", "木", "金", "土"];
+
+type DayCell = {
+  date: number | null; // null = 前月の空きマス
+  iso?: string;
+  cellClass: string; // 色（記録なしは muted）
+  label?: string; // ツールチップ用の代表感情
+  count?: number;
+};
+
+type MoodCalendarProps = {
+  dreams: Dream[];
+  /** "2026-06" 形式。省略時は今月（JST） */
+  month?: string;
+};
+
+export default function MoodCalendar({ dreams, month }: MoodCalendarProps) {
+  const ym = month ?? getJSTYearMonthKey(new Date());
+  const [year, mon] = ym.split("-").map(Number);
+
+  const cells = useMemo<DayCell[]>(() => {
+    // 日付ごとに感情を集計
+    const byDay = new Map<string, Map<string, number>>();
+    for (const d of dreams) {
+      if (!d.created_at || getJSTYearMonthKey(d.created_at) !== ym) continue;
+      const day = new Date(d.created_at).toLocaleDateString("en-CA", {
+        timeZone: "Asia/Tokyo",
+      }); // YYYY-MM-DD
+      const tags =
+        d.analysis_json?.emotion_tags ?? d.emotions?.map((e) => e.name) ?? [];
+      const counts = byDay.get(day) ?? new Map<string, number>();
+      for (const t of tags) {
+        const label = getChildFriendlyEmotionLabel(t);
+        counts.set(label, (counts.get(label) ?? 0) + 1);
+      }
+      byDay.set(day, counts);
+    }
+
+    const firstWeekday = new Date(year, mon - 1, 1).getDay();
+    const daysInMonth = new Date(year, mon, 0).getDate();
+
+    const out: DayCell[] = [];
+    // 月初までの空きマス
+    for (let i = 0; i < firstWeekday; i++) {
+      out.push({ date: null, cellClass: "bg-transparent" });
+    }
+
+    for (let day = 1; day <= daysInMonth; day++) {
+      const iso = `${ym}-${String(day).padStart(2, "0")}`;
+      const counts = byDay.get(iso);
+      if (!counts || counts.size === 0) {
+        out.push({ date: day, iso, cellClass: "bg-muted" });
+        continue;
+      }
+      // その日の最頻感情
+      let topLabel = "";
+      let topCount = 0;
+      let total = 0;
+      for (const [label, c] of counts) {
+        total += c;
+        if (c > topCount) {
+          topCount = c;
+          topLabel = label;
+        }
+      }
+      out.push({
+        date: day,
+        iso,
+        cellClass: emotionToCellClass(topLabel),
+        label: topLabel,
+        count: total,
+      });
+    }
+    return out;
+  }, [dreams, ym, year, mon]);
+
+  return (
+    <section className="w-full rounded-2xl border border-border bg-card p-4 shadow-sm">
+      <h3 className="mb-3 flex items-center gap-2 font-bold text-card-foreground">
+        <span aria-hidden="true">🗓️</span>
+        <span>ムードカレンダー</span>
+      </h3>
+
+      <div className="grid grid-cols-7 gap-1.5 text-center">
+        {WEEKDAYS.map((w) => (
+          <div key={w} className="text-[10px] font-medium text-muted-foreground">
+            {w}
+          </div>
+        ))}
+        {cells.map((cell, i) => (
+          <div
+            key={cell.iso ?? `empty-${i}`}
+            title={
+              cell.date && cell.label
+                ? `${mon}/${cell.date} ${cell.label}（${cell.count}件）`
+                : cell.date
+                  ? `${mon}/${cell.date} 記録なし`
+                  : undefined
+            }
+            className={`aspect-square rounded-[6px] ${cell.cellClass} ${
+              cell.date ? "ring-1 ring-inset ring-black/[0.03]" : ""
+            }`}
+          />
+        ))}
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1.5">
+        {[
+          ["うれしい系", "bg-orange-400"],
+          ["たのしい系", "bg-amber-400"],
+          ["かなしい系", "bg-sky-400"],
+          ["ふしぎ系", "bg-violet-500"],
+          ["記録なし", "bg-muted"],
+        ].map(([label, cls]) => (
+          <span
+            key={label}
+            className="flex items-center gap-1.5 text-[10.5px] text-muted-foreground"
+          >
+            <span className={`h-2.5 w-2.5 rounded-[3px] ${cls}`} />
+            {label}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/dream/month/[yearMonth]/page.tsx
+++ b/frontend/app/dream/month/[yearMonth]/page.tsx
@@ -8,6 +8,7 @@ import DreamList from "@/app/components/DreamList";
 import { DreamListSkeleton } from "@/app/components/DreamCardSkeleton";
 import MorpheusLoginRequired from "@/app/components/MorpheusLoginRequired";
 import MorpheusAvatar from "@/app/components/MorpheusAvatar";
+import MoodCalendar from "@/app/components/MoodCalendar";
 import { Dream } from "@/app/types";
 import { useAuth } from "@/context/AuthContext";
 import apiClient from "@/lib/apiClient";
@@ -274,6 +275,11 @@ export default function DreamByMonthPage() {
                 </p>
                 <p className="mt-2 text-3xl font-bold">{summary.analyzedCount}</p>
               </div>
+            </section>
+
+            {/* Mood calendar */}
+            <section className="mb-3">
+              <MoodCalendar dreams={dreams} month={yearMonth} />
             </section>
 
             {/* Dream list */}


### PR DESCRIPTION
## 概要

`~/Downloads/redesign-code` のUI/UX改善（改善④データ可視化）の **STEP 1（最小・低リスク）**。月の各日を「その日いちばん多かった夢の感情の色」で塗るGitHub草グラフ風ヒートマップ `MoodCalendar` を新設し、月別ページに配置。

redesign-code は5ステップ（①カレンダー ②ストリーミング分析 ③⌘K ④サイドバー/AppShell ⑤インサイトページ）。依存順に**1つずつ個別PR**で進める初回。森には触れない・提示層のみ。

仕様: 📄 `docs/superpowers/specs/2026-06-29-mood-calendar-design.md`

## 変更内容
- **新規** `app/components/MoodCalendar.tsx`: props `{ dreams, month? }`。参照コードを実コードベースに適応（型/import/規約合わせ、`created_at` 欠落ガード追加）。既存資産を再利用：`getChildFriendlyEmotionLabel`(EmotionTag)・`getJSTYearMonthKey`(lib/date)・`Dream`型。色は既存Tailwindパレット（新色なし）、`border-border`/`bg-card`等でダーク自動対応。
- **組み込み** `app/dream/month/[yearMonth]/page.tsx`: Stats と 夢一覧の間に `<MoodCalendar dreams={dreams} month={yearMonth} />`。
- **テスト** `__tests__/components/MoodCalendar.test.tsx`（曜日見出し・夢のある日が感情色セル・凡例）。

## 検証結果
- **Jest: 331 green**（+3）
- **`yarn build`: 成功**
- 配置先（月別ページ）は認証ページのため、配置後の発色は手動QA。構造/色はcomponent testで担保。設計の見た目はPR説明用に実配色で確認済み。

## 触っていない領域
認証/ルーティング/Stripe/DB/森画面/redesign-codeの他STEP（②〜⑤は後続PR）。
