### PR TITLE
feat: ストリーミング分析(redesign-code STEP2) — 夢分析をタイプライター表示

### DIFF
--- a/frontend/__tests__/components/DreamDetailPage.test.tsx
+++ b/frontend/__tests__/components/DreamDetailPage.test.tsx
@@ -43,6 +43,27 @@ jest.mock("@/app/components/DreamForm", () => ({
   default: () => <div>DreamForm</div>,
 }));
 
+jest.mock("@/app/components/StreamingAnalysis", () => ({
+  __esModule: true,
+  default: ({
+    title,
+    text,
+    emotions = [],
+  }: {
+    title: string;
+    text: string;
+    emotions?: string[];
+  }) => (
+    <section>
+      <p>{title}</p>
+      <p>{text}</p>
+      {emotions.map((emotion) => (
+        <span key={emotion}>{emotion}</span>
+      ))}
+    </section>
+  ),
+}));
+
 jest.mock("@/components/ui/alert-dialog", () => {
   const React = require("react");
   const passthrough =

--- a/frontend/__tests__/components/StreamingAnalysis.test.tsx
+++ b/frontend/__tests__/components/StreamingAnalysis.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import StreamingAnalysis from "@/app/components/StreamingAnalysis";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({
+    alt,
+    fill,
+    priority,
+    unoptimized,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & {
+    fill?: boolean;
+    priority?: boolean;
+    unoptimized?: boolean;
+  }) => <img alt={alt} {...props} />,
+}));
+
+describe("StreamingAnalysis", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    window.localStorage.clear();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("types saved analysis text and then shows emotion tags", () => {
+    render(
+      <StreamingAnalysis
+        title="🔮 モルペウスの ゆめうらない"
+        text="楽しい気持ちが強い夢です"
+        emotions={["楽しい"]}
+        storageKey="dream-1"
+      />
+    );
+
+    expect(screen.getByText("生成中")).toBeTruthy();
+    expect(screen.queryByText("楽しい")).toBeNull();
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(screen.getByText("楽しい気持ちが強い夢です")).toBeTruthy();
+    expect(screen.getByText("😆 たのしい")).toBeTruthy();
+    expect(window.localStorage.getItem("yumetree:streaming-analysis:dream-1")).toBe(
+      "1"
+    );
+  });
+
+  it("shows the full text immediately after the dream was seen once", () => {
+    window.localStorage.setItem("yumetree:streaming-analysis:dream-2", "1");
+
+    render(
+      <StreamingAnalysis
+        title="🔮 モルペウスの ゆめうらない"
+        text="二回目はすぐ読める"
+        storageKey="dream-2"
+      />
+    );
+
+    expect(screen.queryByText("生成中")).toBeNull();
+    expect(screen.getByText("二回目はすぐ読める")).toBeTruthy();
+  });
+});

--- a/frontend/app/components/StreamingAnalysis.tsx
+++ b/frontend/app/components/StreamingAnalysis.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { EmotionTag } from "./EmotionTag";
+import MorpheusAvatar from "./MorpheusAvatar";
+
+function getSeenStorageKey(storageKey?: string) {
+  return storageKey ? `yumetree:streaming-analysis:${storageKey}` : null;
+}
+
+function prefersReducedMotion() {
+  return (
+    typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+function useTypewriter(
+  fullText: string,
+  options: {
+    charsPerTick?: number;
+    tickMs?: number;
+    skip?: boolean;
+    onDone?: () => void;
+  } = {}
+) {
+  const { charsPerTick = 2, tickMs = 24, skip = false, onDone } = options;
+  const [shown, setShown] = useState("");
+  const [done, setDone] = useState(false);
+  const indexRef = useRef(0);
+
+  useEffect(() => {
+    indexRef.current = 0;
+
+    if (!fullText || skip || prefersReducedMotion()) {
+      setShown(fullText);
+      setDone(true);
+      onDone?.();
+      return;
+    }
+
+    setShown("");
+    setDone(false);
+
+    const intervalId = window.setInterval(() => {
+      indexRef.current += charsPerTick;
+
+      if (indexRef.current >= fullText.length) {
+        setShown(fullText);
+        setDone(true);
+        onDone?.();
+        window.clearInterval(intervalId);
+        return;
+      }
+
+      setShown(fullText.slice(0, indexRef.current));
+    }, tickMs);
+
+    return () => window.clearInterval(intervalId);
+  }, [charsPerTick, fullText, onDone, skip, tickMs]);
+
+  return { shown, done };
+}
+
+type StreamingAnalysisProps = {
+  title: string;
+  text: string;
+  emotions?: string[];
+  storageKey?: string;
+};
+
+export default function StreamingAnalysis({
+  title,
+  text,
+  emotions = [],
+  storageKey,
+}: StreamingAnalysisProps) {
+  const seenStorageKey = useMemo(
+    () => getSeenStorageKey(storageKey),
+    [storageKey]
+  );
+  const [hasSeen, setHasSeen] = useState(() => {
+    const initialKey = getSeenStorageKey(storageKey);
+    if (!initialKey || typeof window === "undefined") return false;
+
+    try {
+      return window.localStorage.getItem(initialKey) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    if (!seenStorageKey) return;
+
+    try {
+      setHasSeen(window.localStorage.getItem(seenStorageKey) === "1");
+    } catch {
+      setHasSeen(false);
+    }
+  }, [seenStorageKey]);
+
+  const markSeen = useCallback(() => {
+    if (!seenStorageKey) return;
+
+    try {
+      window.localStorage.setItem(seenStorageKey, "1");
+    } catch {
+      // localStorage is an enhancement; the analysis should still render.
+    }
+  }, [seenStorageKey]);
+
+  const { shown, done } = useTypewriter(text, {
+    skip: hasSeen,
+    onDone: markSeen,
+  });
+
+  return (
+    <section className="rounded-[24px] border border-primary/20 bg-card p-5 shadow-lg">
+      <header className="mb-4 flex items-center gap-4">
+        <MorpheusAvatar variant="analysis" size={56} className="shrink-0" />
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-muted-foreground">{title}</p>
+          <h2 className="text-lg font-bold leading-snug text-card-foreground">
+            モルペウスが 夢を読みほどいたよ
+          </h2>
+        </div>
+        {!done && (
+          <span className="ml-auto shrink-0 rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+            生成中
+          </span>
+        )}
+      </header>
+
+      <div className="rounded-2xl bg-background/80 px-4 py-4">
+        <p className="whitespace-pre-wrap text-sm leading-loose text-foreground">
+          {shown}
+          {!done && (
+            <span
+              aria-hidden="true"
+              className="ml-0.5 inline-block h-[1em] w-0.5 translate-y-0.5 bg-primary align-middle motion-safe:animate-yt-caret"
+            />
+          )}
+        </p>
+      </div>
+
+      {done && emotions.length > 0 && (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {emotions.map((emotion, index) => (
+            <EmotionTag key={`${emotion}-${index}`} label={emotion} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/app/dream/[id]/page.tsx
+++ b/frontend/app/dream/[id]/page.tsx
@@ -10,12 +10,11 @@ import {
 import { useDream, type DreamInput } from "../../../hooks/useDream";
 import { useRouter } from "next/navigation";
 import { useState, useEffect, use } from "react";
-import { motion } from "framer-motion";
 import apiClient from "../../../lib/apiClient";
 import { useAuth } from "../../../context/AuthContext";
 import { AgeGroup } from "@/app/types";
 import { MorpheusGuideDetail } from "@/app/components/MorpheusGuide";
-import MorpheusAvatar from "@/app/components/MorpheusAvatar";
+import StreamingAnalysis from "@/app/components/StreamingAnalysis";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -103,7 +102,6 @@ export default function DreamDetailPage({
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isGeneratingImage, setIsGeneratingImage] = useState(false);
-  const [isAnalysisFlipped, setIsAnalysisFlipped] = useState(false);
   const [generatedImageUrl, setGeneratedImageUrl] = useState<string | null>(null);
   const [imageError, setImageError] = useState<string | null>(null);
   const [imageQuota, setImageQuota] = useState<{ used: number; limit: number; remaining: number } | null>(null);
@@ -125,10 +123,6 @@ export default function DreamDetailPage({
       setGeneratedImageUrl(dream.generated_image_url);
     }
   }, [dream?.generated_image_url]);
-
-  useEffect(() => {
-    setIsAnalysisFlipped(false);
-  }, [dream?.id]);
 
   const handleGenerateImage = async () => {
     if (!dreamId || isGeneratingImage) return;
@@ -259,9 +253,6 @@ export default function DreamDetailPage({
   const displayTags = aiEmotionTags.length > 0 ? aiEmotionTags : dbEmotionTags;
   const analysisText =
     dream.analysis_json?.analysis || dream.analysis_json?.text || "";
-  const analysisPreview = displayTags.length
-    ? "感じたことを みつけたよ"
-    : "タップすると モルペウスの読み取りがひらくよ";
 
   return (
     <div className="min-h-screen py-8 px-4 md:px-12 max-w-3xl mx-auto text-foreground">
@@ -298,71 +289,13 @@ export default function DreamDetailPage({
 
       {/* モルペウスのゆめうらない */}
       {analysisText && (
-        <div className="mb-6" style={{ perspective: 1400 }}>
-          <button
-            type="button"
-            onClick={() => setIsAnalysisFlipped((current) => !current)}
-            className="block w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-            aria-pressed={isAnalysisFlipped}
-          >
-            <motion.div
-              animate={{ rotateY: isAnalysisFlipped ? 180 : 0 }}
-              transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
-              style={{ transformStyle: "preserve-3d" }}
-              className="relative min-h-[220px]"
-            >
-              <div
-                className="absolute inset-0 overflow-y-auto rounded-[28px] border border-primary/20 p-5 shadow-lg"
-                style={{
-                  backfaceVisibility: "hidden",
-                  background:
-                    "linear-gradient(160deg, rgba(255,255,255,0.96), rgba(240,249,255,0.94))",
-                }}
-              >
-                <p className="text-sm font-semibold text-muted-foreground">
-                  {copy.analysis}
-                </p>
-                <div className="mt-4 flex items-center gap-4">
-                  <MorpheusAvatar variant="analysis" size={56} />
-                  <div>
-                    <p className="text-lg font-bold text-foreground">
-                      モルペウスが 夢を読みほどいたよ
-                    </p>
-                    <p className="mt-1 text-sm text-muted-foreground">
-                      {analysisPreview}
-                    </p>
-                  </div>
-                </div>
-                <div className="mt-6 rounded-2xl bg-background/80 px-4 py-4">
-                  <p className="text-sm leading-relaxed text-foreground/85 line-clamp-4">
-                    {!isAnalysisFlipped ? analysisText : null}
-                  </p>
-                </div>
-                <p className="mt-4 text-xs font-medium text-primary">
-                  タップで くるっと裏返して全文をみる
-                </p>
-              </div>
-              <div
-                className="absolute inset-0 overflow-y-auto rounded-[28px] border border-border bg-muted/50 p-5 shadow-lg"
-                style={{
-                  backfaceVisibility: "hidden",
-                  transform: "rotateY(180deg)",
-                }}
-              >
-                <div className="flex items-center justify-between gap-3">
-                  <p className="text-sm font-semibold text-muted-foreground">
-                    {copy.analysis}
-                  </p>
-                  <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
-                    flip back
-                  </span>
-                </div>
-                <p className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-foreground">
-                  {isAnalysisFlipped ? analysisText : null}
-                </p>
-              </div>
-            </motion.div>
-          </button>
+        <div className="mb-6">
+          <StreamingAnalysis
+            title={copy.analysis}
+            text={analysisText}
+            emotions={displayTags}
+            storageKey={dream.id ? String(dream.id) : undefined}
+          />
         </div>
       )}
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -59,6 +59,7 @@
   --animate-fade-up: fade-up 0.35s ease both;
   --animate-book-open: book-open 0.5s ease both;
   --animate-scale-in: scale-in 0.25s ease both;
+  --animate-yt-caret: yt-caret 1s step-end infinite;
 
   @keyframes accordion-down {
     from {
@@ -157,6 +158,15 @@
     to {
       opacity: 1;
       transform: scale(1);
+    }
+  }
+
+  @keyframes yt-caret {
+    0%, 100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0;
     }
   }
 

--- a/frontend/e2e/dream-detail-flow.spec.ts
+++ b/frontend/e2e/dream-detail-flow.spec.ts
@@ -103,8 +103,8 @@ test.describe("夢詳細の閲覧・編集・再分析・保存フロー", () =>
       page.getByText("空を飛ぶ夢は自由への願望を表しています。")
     ).toBeVisible();
 
-    // 感情タグが表示されていることを確認（analysis_json.emotion_tags の "happy" が表示される）
-    await expect(page.getByText("happy")).toBeVisible();
+    // 感情タグが表示されていることを確認（StreamingAnalysis内にも同じタグが出るため先頭要素を指定）
+    await expect(page.getByText("happy").first()).toBeVisible();
 
     // 「✏️ なおす」ボタンが表示されていることを確認
     await expect(


### PR DESCRIPTION
## 概要

`redesign-code` の **STEP 2（改善③ AI体験）**。夢詳細のAI分析を、静的なフリップカードから**タイプライター表示の `StreamingAnalysis`** に置換。「モルペウスがいま考えながら話している」体験にする。バックエンド変更なし（保存済みテキストの再生）。

> Codexが先行実装していた `codex/redesign-step2-streaming-analysis` の作業を、ユーザー選択「**置換＋初回だけタイプ**」に沿って検証・最新mainへ載せ替え・正式PR化したもの。

## 設計判断（再読のUX対策）
分析テキストは保存済みのため、毎回タイプ再生だと再読が煩わしい。そこで **`storageKey`(夢ID) を localStorage に記録し、その夢を初めて見た時だけタイプライター**を再生、2回目以降は即表示。`prefers-reduced-motion` でも一括表示。

## 変更内容
- **新規** `app/components/StreamingAnalysis.tsx`: `useTypewriter`(skip対応) + `storageKey` で初回限定再生。`MorpheusAvatar variant="analysis"`(#3) と `EmotionTag` を再利用。caretは `motion-safe:animate-yt-caret`。localStorageはtry/catchで安全（SSR/プライベートモード可）。
- **置換** `app/dream/[id]/page.tsx`: フリップカード（+state/effect/framer-motion）を撤去し `<StreamingAnalysis title={copy.analysis} text={analysisText} emotions={displayTags} storageKey={String(dream.id)} />` に。
- **追加** `app/globals.css`: `@keyframes yt-caret`（カーソル点滅）＋ `--animate-yt-caret`。
- **テスト** `StreamingAnalysis.test.tsx`（初回タイプ→タグ表示＋localStorage記録 / 2回目即表示）、`DreamDetailPage.test.tsx` 更新。

## 検証結果
- **Jest: 339 green**（+5）
- **`yarn build`: 成功**
- 実画面（夢詳細）は認証ページのため発色/タイプ感は手動QA。初回限定ロジック・タグ表示は component test で担保。

## 触っていない領域
認証/ルーティング/Stripe/DB/森/redesign-codeの他STEP（③⌘K・④サイドバー・⑤インサイトは後続）。