### PR TITLE
feat: ⌘Kコマンドパレット(redesign-code STEP3) — 検索/記録/移動を1ストロークで

### DIFF
--- a/docs/superpowers/specs/2026-06-29-command-palette-design.md
+++ b/docs/superpowers/specs/2026-06-29-command-palette-design.md
@@ -1,0 +1,60 @@
+# ⌘K コマンドパレット（redesign-code STEP 3）設計仕様
+
+- 日付: 2026-06-29
+- 対象: YumeTree フロントエンド（Next.js 16 + Tailwind v4 + lucide-react）
+- 出典: `~/Downloads/redesign-code/web/CommandPalette.tsx`（改善② 検索・入力）
+- 位置づけ: redesign-code STEP 3。検索・記録・移動を1ストロークで行うコマンドパレット。外部ライブラリ不要。
+- 方針: 参照を**そのまま貼らず**、実ルート/認証/データ取得に合わせて適応。提示層のみ。森非タッチ。
+
+## 0. 概要
+
+`⌘K` / `Ctrl+K` でモーダルパレットを開き、入力で絞り込み、`↑↓` 選択・`Enter` 実行・`Esc` 閉じる。クイック操作（記録/移動）と「さいきんの ゆめ」（最近の夢へ移動）を提供する。
+
+## 1. 適応の判断（参照→実コードベース）
+
+1. **コマンドのルートを実在に合わせる**:
+   - クイック操作: `新しい夢を記録`→`/dream/new` / `ホーム`→`/home` / `もり`→`/forest` / `マイ夢`→`/my-dreams` / `設定`→`/settings`。
+   - 参照の `/insights`（きもちインサイト）は **STEP 5 で未実装のため今回は出さない**。音声モード(`/dream/new?mode=voice`)も実体がないため出さず、記録は `/dream/new` に集約。
+   - さいきんの ゆめ: 最近の夢6件 → `/dream/{id}`。
+2. **recentDreams の供給**: 参照は prop だが、`layout.tsx`（サーバー）からは夢データを渡せない。→ **パレットを初めて開いた時に遅延 fetch**（`apiClient.get<Dream[]>("/dreams")` の先頭6件）。セッション内キャッシュ。失敗時はクイック操作のみ表示（非致命）。
+3. **認証ゲート**: コマンドは認証ページ前提。→ **`isLoggedIn` のときだけ** ⌘K リスナーとパレットを有効化（未ログイン/公開ページでは no-op、何も描画しない）。
+4. **見える起動口**: ⌘K はデスクトップ操作。モバイルは既存導線（ボトムバー・検索）で足りる。→ **デスクトップ(md+)のヘッダーに小さな「⌘K 検索」ボタン**を1つ追加（`useCommandPalette().open()` を呼ぶ）。モバイルでは非表示。
+
+## 2. コンポーネント仕様
+
+### 2.1 `app/components/CommandPalette.tsx`（新規・client）
+- `CommandPaletteProvider`（Context）: `open/close/toggle` を提供。内部で `useAuth()` を見て `isLoggedIn` 時のみ ⌘K リスナー＋パレットを有効化。`recentDreams` は open時に遅延fetch（自前state、外部propは不要）。
+- `useCommandPalette(): { open; close; toggle }`（Provider外では no-op）。
+- パレットUI（参照踏襲）: 入力欄（Search アイコン・esc kbd）、絞り込み（label部分一致）、`クイック操作`/`さいきんの ゆめ` のグループ表示、フッター（↑↓/↵/⌘K ヒント）。`role="dialog"` `aria-modal` `aria-label`、開いたら入力に focus、`↑↓`/`Enter`/`Esc` 操作。トークン（`bg-card`/`border-border`/`bg-primary/10` 等）でダーク自動対応。
+
+### 2.2 マウントと起動口
+- `app/layout.tsx`: `<Providers>` 内を `<CommandPaletteProvider>` でラップ（`Header`/`children`/`BottomTabBar` がパレットContext配下に入る）。Providerは未ログイン時は子をそのまま通すだけ（オーバーレイ非描画）。
+- 起動口: `app/components/CommandPaletteTrigger.tsx`（新規・小）= `useCommandPalette().open()` を呼ぶ `hidden md:inline-flex` の検索ボタン。`Header` 内（`ThemeToggle` の近く）に配置。
+
+## 3. テスト方針（TDD・component render）
+
+`@testing-library/react` + jest。`useAuth`/`useRouter`/`apiClient` をモック。
+- ログイン時、`⌘K`（metaKey+k）でパレットが開く。`Esc` で閉じる。
+- 未ログイン時は `⌘K` で何も開かない。
+- 入力で候補が絞り込まれる（label部分一致）。
+- `Enter` で active コマンドの `router.push` が正しいルートに呼ばれる（例: 新しい夢を記録→`/dream/new`）。
+- `useCommandPalette` を Provider 外で呼んでも no-op（落ちない）。
+- 既存スイートが緑のまま。
+
+## 4. 検証方針
+
+- ゲート: `yarn jest` 全緑 + `yarn build` 成功（既存 forest tsc は無関係）。
+- preview目視: 公開 `/login` では ⌘K で何も開かない・トリガーボタン非表示（認証ゲート確認）。認証時のパレット表示は component test で担保＋手動QA。
+
+## 5. 成果物と境界
+
+**触る**: `app/components/CommandPalette.tsx`（新規）/ `app/components/CommandPaletteTrigger.tsx`（新規）/ `app/layout.tsx`（Providerマウント）/ `app/Header.tsx`（トリガー配置）/ 新規テスト。
+
+**触らない（後続へ）**: `/insights`（STEP 5）/ サイドバー・AppShell（STEP 4）/ 音声モーダルのパレット連携 / 認証/Stripe/DB/森。
+
+## 6. リスクと注意
+
+1. ⌘K の `keydown` リスナーはブラウザ既定（Chromeの検索バー等）と衝突しうるため `preventDefault`。入力中の `Esc`/`Enter`/矢印はパレット内 input の `onKeyDown` で処理。
+2. `apiClient.get("/dreams")` の遅延fetchは open時のみ＋キャッシュ。失敗は握りつぶしてクイック操作のみ表示。
+3. オーバーレイは `fixed inset-0 z-50`。`backdrop-blur` を持つが、内部に `position:fixed` の子を持たないため #2 のFABモーダルのような包含ブロック問題は無い（パレット自体が最前面モーダル）。
+4. Provider を未ログインで描画しても副作用が無いこと（リスナー未登録・fetch未実行）を保証。

--- a/frontend/__tests__/components/CommandPalette.test.tsx
+++ b/frontend/__tests__/components/CommandPalette.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import {
+  CommandPaletteProvider,
+  useCommandPalette,
+} from "@/app/components/CommandPalette";
+
+// 遅延fetch(setRecentDreams)の解決を act 内で消化し、警告を出さない
+async function flushFetch() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("@/lib/apiClient", () => ({
+  __esModule: true,
+  default: { get: jest.fn().mockResolvedValue([]) },
+}));
+
+function setup() {
+  return render(
+    <CommandPaletteProvider>
+      <div>app</div>
+    </CommandPaletteProvider>
+  );
+}
+
+beforeEach(() => {
+  mockPush.mockClear();
+  mockUseAuth.mockReturnValue({ isLoggedIn: true, authStatus: "authenticated" });
+});
+
+describe("CommandPalette", () => {
+  it("ログイン時に ⌘K で開き、Esc で閉じる", async () => {
+    setup();
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await flushFetch();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("未ログインでは ⌘K で何も開かない", () => {
+    mockUseAuth.mockReturnValue({ isLoggedIn: false, authStatus: "unauthenticated" });
+    setup();
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("入力で候補を絞り込む", async () => {
+    setup();
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input = screen.getByPlaceholderText("夢を検索 / コマンド…");
+    fireEvent.change(input, { target: { value: "もり" } });
+    expect(screen.getByText("もりへ")).toBeInTheDocument();
+    expect(screen.queryByText("ホームへ")).toBeNull();
+    await flushFetch();
+  });
+
+  it("Enter で選択中コマンドを実行する（先頭=新しい夢を記録→/dream/new）", async () => {
+    setup();
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const input = screen.getByPlaceholderText("夢を検索 / コマンド…");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mockPush).toHaveBeenCalledWith("/dream/new");
+    await flushFetch();
+  });
+
+  it("Provider外でuseCommandPaletteを呼んでもno-opで落ちない", () => {
+    function Probe() {
+      const palette = useCommandPalette();
+      return (
+        <button onClick={() => palette.open()}>open</button>
+      );
+    }
+    render(<Probe />);
+    expect(() => fireEvent.click(screen.getByText("open"))).not.toThrow();
+  });
+});

--- a/frontend/app/Header.tsx
+++ b/frontend/app/Header.tsx
@@ -1,6 +1,7 @@
 import HeaderLogo from "./components/HeaderLogo";
 import AuthNav from "./components/AuthNav";
 import ThemeToggle from "./components/ThemeToggle";
+import CommandPaletteTrigger from "./components/CommandPaletteTrigger";
 
 // クロスドメイン環境（Vercel × Render）では、Server側でCookieを読めないため、
 // 認証状態の取得はAuthNav内のAuthContextで行う。
@@ -15,6 +16,10 @@ export default function Header() {
       </div>
       <div className="w-full flex-grow">
         <AuthNav />
+      </div>
+      {/* ⌘K コマンドパレットの起動口（デスクトップのみ） */}
+      <div className="flex-shrink-0">
+        <CommandPaletteTrigger />
       </div>
       {/* テーマ切り替え */}
       <div className="flex-shrink-0">

--- a/frontend/app/components/CommandPalette.tsx
+++ b/frontend/app/components/CommandPalette.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+/**
+ * CommandPalette — ⌘K コマンドパレット（redesign-code STEP 3 / 改善②）
+ *
+ * 検索・記録・移動を1ストロークで。Context で全アプリから palette.open() を呼べる。
+ * ⌘K / Ctrl+K で開閉、Esc で閉じる、↑↓ で選択、Enter で実行。
+ * 依存は lucide-react / next/navigation / AuthContext / apiClient のみ（外部ライブラリ不要）。
+ *
+ * - 認証時のみ有効（未ログインでは何も描画せず、キー監視もしない）。
+ * - 「さいきんの ゆめ」は初回 open 時に遅延 fetch（/dreams 先頭6件）。
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useRouter } from "next/navigation";
+import { House, Moon, Plus, Search, Settings, Sparkles, Trees } from "lucide-react";
+
+import { useAuth } from "@/context/AuthContext";
+import apiClient from "@/lib/apiClient";
+import type { Dream } from "@/app/types";
+
+type PaletteCtx = { open: () => void; close: () => void; toggle: () => void };
+
+const Ctx = createContext<PaletteCtx | null>(null);
+
+export function useCommandPalette(): PaletteCtx {
+  const ctx = useContext(Ctx);
+  // Provider 外で呼ばれても落とさない（no-op）
+  return ctx ?? { open: () => {}, close: () => {}, toggle: () => {} };
+}
+
+type Command = {
+  id: string;
+  label: string;
+  hint?: string;
+  icon: ReactNode;
+  run: () => void;
+  group: "action" | "dream";
+};
+
+export function CommandPaletteProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const { isLoggedIn } = useAuth();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+  const [recentDreams, setRecentDreams] = useState<Dream[]>([]);
+  const fetchedRef = useRef(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const open = useCallback(() => {
+    if (isLoggedIn) setIsOpen(true);
+  }, [isLoggedIn]);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => {
+    if (isLoggedIn) setIsOpen((v) => !v);
+  }, [isLoggedIn]);
+
+  // ⌘K / Ctrl+K（認証時のみ）
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setIsOpen((v) => !v);
+      } else if (e.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isLoggedIn]);
+
+  // 開いたら入力欄を初期化・フォーカス
+  useEffect(() => {
+    if (!isOpen) return;
+    setQuery("");
+    setActive(0);
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, [isOpen]);
+
+  // 初回 open 時に最近の夢を遅延 fetch（失敗は非致命）
+  useEffect(() => {
+    if (!isOpen || fetchedRef.current || !isLoggedIn) return;
+    fetchedRef.current = true;
+    apiClient
+      .get<Dream[]>("/dreams")
+      .then((dreams) => setRecentDreams(dreams.slice(0, 6)))
+      .catch(() => {
+        // 取得失敗時はクイック操作のみ表示
+      });
+  }, [isOpen, isLoggedIn]);
+
+  const commands = useMemo<Command[]>(() => {
+    const actions: Command[] = [
+      { id: "new", label: "新しい夢を記録", icon: <Plus size={16} />, group: "action", run: () => router.push("/dream/new") },
+      { id: "home", label: "ホームへ", icon: <House size={16} />, group: "action", run: () => router.push("/home") },
+      { id: "forest", label: "もりへ", icon: <Trees size={16} />, group: "action", run: () => router.push("/forest") },
+      { id: "my-dreams", label: "マイ夢へ", icon: <Moon size={16} />, group: "action", run: () => router.push("/my-dreams") },
+      { id: "settings", label: "設定へ", icon: <Settings size={16} />, group: "action", run: () => router.push("/settings") },
+    ];
+    const dreamCmds: Command[] = recentDreams.map((d) => ({
+      id: `dream-${d.id}`,
+      label: d.title,
+      hint: d.created_at
+        ? new Date(d.created_at).toLocaleDateString("ja-JP", {
+            month: "long",
+            day: "numeric",
+            timeZone: "Asia/Tokyo",
+          })
+        : undefined,
+      icon: <Sparkles size={16} />,
+      group: "dream",
+      run: () => router.push(`/dream/${d.id}`),
+    }));
+    return [...actions, ...dreamCmds];
+  }, [recentDreams, router]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return commands;
+    return commands.filter((c) => c.label.toLowerCase().includes(q));
+  }, [commands, query]);
+
+  const runActive = useCallback(() => {
+    const cmd = filtered[active];
+    if (!cmd) return;
+    setIsOpen(false);
+    cmd.run();
+  }, [filtered, active]);
+
+  const ctxValue = useMemo<PaletteCtx>(
+    () => ({ open, close, toggle }),
+    [open, close, toggle]
+  );
+
+  return (
+    <Ctx.Provider value={ctxValue}>
+      {children}
+      {isOpen && isLoggedIn && (
+        <div
+          className="fixed inset-0 z-50 flex items-start justify-center bg-slate-900/40 px-4 pt-[12vh] backdrop-blur-sm"
+          onClick={close}
+          role="dialog"
+          aria-modal="true"
+          aria-label="コマンドパレット"
+        >
+          <div
+            className="w-full max-w-xl overflow-hidden rounded-2xl border border-border bg-card shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-3 border-b border-border px-5 py-4">
+              <Search size={20} className="text-muted-foreground" />
+              <input
+                ref={inputRef}
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setActive(0);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "ArrowDown") {
+                    e.preventDefault();
+                    setActive((i) => Math.min(i + 1, filtered.length - 1));
+                  } else if (e.key === "ArrowUp") {
+                    e.preventDefault();
+                    setActive((i) => Math.max(i - 1, 0));
+                  } else if (e.key === "Enter") {
+                    e.preventDefault();
+                    runActive();
+                  }
+                }}
+                placeholder="夢を検索 / コマンド…"
+                aria-label="夢を検索 / コマンド"
+                className="flex-1 bg-transparent text-base text-foreground outline-none placeholder:text-muted-foreground"
+              />
+              <kbd className="rounded-md border border-border bg-muted px-2 py-0.5 text-[11px] font-semibold text-muted-foreground">
+                esc
+              </kbd>
+            </div>
+
+            <div className="max-h-[50vh] overflow-y-auto p-2">
+              {filtered.length === 0 ? (
+                <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+                  一致する夢やコマンドがありません
+                </div>
+              ) : (
+                <>
+                  <CommandGroup title="クイック操作" group="action" filtered={filtered} active={active} setActive={setActive} runActive={runActive} />
+                  <CommandGroup title="さいきんの ゆめ" group="dream" filtered={filtered} active={active} setActive={setActive} runActive={runActive} />
+                </>
+              )}
+            </div>
+
+            <div className="flex items-center gap-4 border-t border-border bg-muted/30 px-5 py-2.5 text-[11px] font-medium text-muted-foreground">
+              <span>↑↓ 移動</span>
+              <span>↵ 開く</span>
+              <span className="ml-auto">⌘K でいつでも</span>
+            </div>
+          </div>
+        </div>
+      )}
+    </Ctx.Provider>
+  );
+}
+
+function CommandGroup({
+  title,
+  group,
+  filtered,
+  active,
+  setActive,
+  runActive,
+}: {
+  title: string;
+  group: Command["group"];
+  filtered: Command[];
+  active: number;
+  setActive: (i: number) => void;
+  runActive: () => void;
+}) {
+  const items = filtered.filter((c) => c.group === group);
+  if (items.length === 0) return null;
+  return (
+    <div className="mb-1">
+      <div className="px-3 py-1.5 text-[10.5px] font-semibold tracking-wide text-muted-foreground">
+        {title}
+      </div>
+      {items.map((cmd) => {
+        const idx = filtered.indexOf(cmd);
+        const isActive = idx === active;
+        return (
+          <button
+            key={cmd.id}
+            type="button"
+            onMouseEnter={() => setActive(idx)}
+            onClick={runActive}
+            className={`flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors ${
+              isActive ? "bg-primary/10" : "hover:bg-muted/60"
+            }`}
+          >
+            <span
+              className={`grid h-8 w-8 place-items-center rounded-lg ${
+                isActive ? "bg-card text-primary" : "bg-muted text-muted-foreground"
+              }`}
+            >
+              {cmd.icon}
+            </span>
+            <span className="truncate text-sm font-semibold text-foreground">
+              {cmd.label}
+            </span>
+            {cmd.hint && (
+              <span className="ml-auto shrink-0 text-[11px] font-medium text-muted-foreground">
+                {cmd.hint}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/app/components/CommandPaletteTrigger.tsx
+++ b/frontend/app/components/CommandPaletteTrigger.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Search } from "lucide-react";
+
+import { useAuth } from "@/context/AuthContext";
+import { useCommandPalette } from "./CommandPalette";
+
+/**
+ * コマンドパレットの見える起動口（デスクトップ用）。
+ * ⌘K はキーボード操作なので、マウス派・発見性のために md+ で小さな検索ボタンを出す。
+ * モバイルは既存導線（ボトムバー/検索）で足りるため非表示。認証時のみ表示。
+ */
+export default function CommandPaletteTrigger() {
+  const { isLoggedIn } = useAuth();
+  const palette = useCommandPalette();
+
+  if (!isLoggedIn) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => palette.open()}
+      aria-label="コマンドパレットを開く"
+      className="hidden md:inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+    >
+      <Search size={16} />
+      <span>検索</span>
+      <kbd className="rounded-md border border-border bg-muted px-1.5 py-0.5 text-[10px] font-semibold">
+        ⌘K
+      </kbd>
+    </button>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -10,6 +10,7 @@ import Loading from "./loading";
 import { Providers } from "./providers";
 import PendingDreamsMonitor from "./components/PendingDreamsMonitor";
 import BottomTabBar from "./components/BottomTabBar";
+import { CommandPaletteProvider } from "./components/CommandPalette";
 import { SITE_URL, GOOGLE_SITE_VERIFICATION } from "@/lib/site";
 
 const notoSansJP = Noto_Sans_JP({ subsets: ["latin"] });
@@ -70,16 +71,18 @@ export default function RootLayout({
           {themeInitScript}
         </Script>
         <Providers>
-          <Header />
-          <div className="flex flex-col flex-grow">
-            <main className="flex-grow">
-              <Suspense fallback={<Loading />}>{children}</Suspense>
-            </main>
-            <Footer />
-            {/* 全体で1つのインスタンスとしてマウント */}
-          </div>
-          <PendingDreamsMonitor />
-          <BottomTabBar />
+          <CommandPaletteProvider>
+            <Header />
+            <div className="flex flex-col flex-grow">
+              <main className="flex-grow">
+                <Suspense fallback={<Loading />}>{children}</Suspense>
+              </main>
+              <Footer />
+              {/* 全体で1つのインスタンスとしてマウント */}
+            </div>
+            <PendingDreamsMonitor />
+            <BottomTabBar />
+          </CommandPaletteProvider>
         </Providers>
       </body>
     </html>


### PR DESCRIPTION
## 概要

`redesign-code` の **STEP 3（改善② 検索・入力）**。`⌘K`/`Ctrl+K` で開くコマンドパレットを追加し、検索・記録・移動を1ストロークで行えるようにする。外部ライブラリ不要。提示層のみ・森非タッチ。

仕様: 📄 `docs/superpowers/specs/2026-06-29-command-palette-design.md`

## 参照→実コードベースへの適応
- **コマンドは実在ルートのみ**: 新しい夢を記録(`/dream/new`) / ホーム(`/home`) / もり(`/forest`) / マイ夢(`/my-dreams`) / 設定(`/settings`) ＋ さいきんの夢(`/dream/:id`)。参照の `/insights`（STEP5未実装）と音声モードは除外。
- **認証ゲート**: ログイン時のみ ⌘K リスナーとパレットを有効化。未ログイン/公開ページでは no-op・非描画。
- **最近の夢は遅延fetch**: パレット初回openで `/dreams` 先頭6件を取得（失敗時はクイック操作のみ）。
- **見える起動口**: デスクトップ(md+)のヘッダーに「🔍検索 ⌘K」ボタンを追加。モバイルは既存導線で足りるため非表示。

## 変更内容
- **新規** `app/components/CommandPalette.tsx`: `CommandPaletteProvider`(Context)+`useCommandPalette`。⌘K/Ctrl+K開閉・Esc閉じ・↑↓選択・Enter実行。`role=dialog`/focus管理/トークンでダーク対応。
- **新規** `app/components/CommandPaletteTrigger.tsx`: デスクトップ用起動ボタン。
- **配線** `app/layout.tsx`（`Providers`内を`CommandPaletteProvider`でラップ）、`app/Header.tsx`（トリガー配置）。
- **テスト** `CommandPalette.test.tsx`: ⌘Kで開/Esc閉 / 未ログインは開かない / 入力で絞り込み / Enterで`/dream/new` / Provider外no-op。

## 検証結果
- **Jest 全緑**（+5、act警告なしでクリーン）
- **`yarn build`: 成功**
- **preview目視（公開 `/login`）**: ⌘Kで何も開かない・トリガー非表示・コンソールエラー無し（認証ゲート実証）。認証時の表示は component test ＋手動QA。

## 触っていない領域
認証/ルーティングのロジック/Stripe/DB/森 / `/insights`(STEP5) / サイドバー・AppShell(STEP4) / 音声モーダル連携。