### PR TITLE
feat: デスクトップ左サイドバー(redesign-code STEP4・サイドバー先行)

### DIFF
--- a/docs/superpowers/specs/2026-06-29-sidebar-shell-design.md
+++ b/docs/superpowers/specs/2026-06-29-sidebar-shell-design.md
@@ -1,0 +1,65 @@
+# デスクトップ・サイドバー（redesign-code STEP 4・サイドバー先行）設計仕様
+
+- 日付: 2026-06-29
+- 対象: YumeTree フロントエンド（Next.js 16 + Tailwind v4 + lucide-react）
+- 出典: `~/Downloads/redesign-code/web/Sidebar.tsx` / `AppShell.tsx`（改善① ナビ）
+- 位置づけ: redesign-code STEP 4。**「サイドバー先行」スコープ**（ユーザー選択）。完全版AppShell（route group・右レール・ページ別トップバー）は最重量・高リスクのため見送り、左サイドバーだけを骨格に足す。
+- 方針: 提示層のみ。森の中身・認証ロジック・ルーティングには触れない。公開ページ/モバイルは非破壊。
+
+## 0. 背景と核心の判断
+
+今のシェルは「全画面の上に横長Header＋下にBottomTabBar(モバイル)」。ここに左サイドバーを足すと**PCでヘッダーのナビとサイドバーのナビが二重**になる。→ **PC(lg+)・ログイン時は、Headerをサイドバーに置き換える**（サイドバーが logo＋ナビ＋ユーザー＋テーマ＋ログアウトを全部持つ）。公開ページ・モバイル・未ログインでは従来どおりHeader表示・サイドバー非表示。
+
+判断機構は #3a と同じ「**認証=JS / レスポンシブ=CSS**」: サイドバーが表示時に `body.has-sidebar` を付け、CSS で lg+ かつ has-sidebar のとき Header を隠す。
+
+## 1. コンポーネント仕様
+
+### 1.1 新規 `app/components/Sidebar.tsx`（client）
+- 表示条件: `useAuth().isLoggedIn` が真のときのみ。`hidden lg:flex`（PCのみ）。未ログインは `return null`。
+- 構成（参照を実コードベースに適応）:
+  - ロゴ（🌙 ユメツリー → /home）
+  - ナビ: **ホーム**(/home, Home) / **さがす**(`useCommandPalette().open()`＋⌘Kヒント) / **夢の森**(/forest, Trees) / **マイ夢**(/my-dreams, Moon) / **設定**(/settings, Settings)。
+    - 参照の「きもち」(/insights)は **STEP 5 未実装のため出さない**（STEP 5で追加）。
+    - アクティブ判定は `usePathname` の startsWith（既存パターン）。`aria-current="page"`。
+  - 下部: ユーザーカード（頭文字アバター＋名前＋プラン）＋ **テーマ切替(`ThemeToggle`再利用)** ＋ **ログアウト(`useAuth().logout`)**。
+- 既存トークン（`bg-card`/`border-border`/`text-primary`/`bg-primary/10`/`text-muted-foreground`）でダーク自動対応。新色なし。
+- 表示時に `document.body.classList.add("has-sidebar")`、アンマウント/未ログインで `remove`（#3aの`has-bottom-nav`と同型・フックは早期returnの前）。
+
+### 1.2 `app/layout.tsx`（骨格をflex-row化）
+- `<CommandPaletteProvider>` 内を **横並び**に: `<div class="flex min-h-screen">` の中に `<Sidebar />` ＋ 「Header＋main＋Footer の縦カラム」。
+- **横paddingの移動**: 現状 `body` に付く `px-4 sm:px-6 lg:px-8` を**メインカラム側へ移す**（サイドバーは端まで `border-r`。bodyはpaddingなしのflex行）。公開ページ（サイドバーnull）でも従来と同じ単一カラム＋paddingになることを保証。
+- `BottomTabBar`/`PendingDreamsMonitor` は従来位置。
+
+### 1.3 `app/Header.tsx` / `app/globals.css`（PCで隠す）
+- `Header` の `<header>` に目印 `data-app-header` を付与。
+- `globals.css` に追加: `@media (min-width: 1024px) { body.has-sidebar [data-app-header] { display: none; } }`。
+- → lg+ かつログイン時のみHeaderが消え、サイドバーが代替。公開/モバイル/未ログインは Header 表示のまま。
+
+## 2. テスト方針（TDD・component render）
+
+`@testing-library/react` + jest（`useAuth`/`usePathname`/`useCommandPalette` をモック）。
+- **Sidebar**: 未ログインで `null`。ログイン時に ホーム/夢の森/マイ夢/設定 のリンクと「さがす」「ログアウト」が描画される。`usePathname="/forest"` で 夢の森 が `aria-current="page"`。表示時 `body` に `has-sidebar` 付与・アンマウントで除去。
+- **globals.css**（#0/#3aと同様のコンテンツ回帰）: `body.has-sidebar` ＋ `data-app-header` ＋ `min-width: 1024px` の規則がある。
+- 既存スイートが緑のまま。
+
+## 3. 検証方針
+
+- ゲート: `yarn jest` 全緑 + `yarn build` 成功（既存 forest tsc は無関係）。
+- **preview目視（最重要・非破壊確認）**:
+  - 公開 `/login`（未ログイン・PC幅）: **サイドバー非表示・Header従来どおり・レイアウト崩れなし**。
+  - モバイル幅: サイドバー非表示・ボトムバー（ログイン時）・Header従来どおり。
+  - `body.has-sidebar` が公開/未ログインで**付かない**こと（authゲート）。
+  - 認証時のサイドバー表示・Header非表示(lg+)は component test ＋手動QA。
+
+## 4. 成果物と境界
+
+**触る**: 新規 `Sidebar.tsx` / `app/layout.tsx`（flex-row＋padding移動＋Sidebarマウント）/ `app/Header.tsx`（`data-app-header`）/ `app/globals.css`（has-sidebar規則）/ 新規テスト。
+
+**触らない（後続へ）**: 右レール・ページ別トップバー・AppShell per-page（STEP 4b）/ `/insights`（STEP 5）/ `AuthNav`の中身（モバイルではそのまま使う。lg+で隠れるのはHeader丸ごと）/ 森・認証ロジック・Stripe・DB。
+
+## 5. リスクと注意
+
+1. **layout.tsx は全画面共通**。flex-row化とpadding移動は公開ページにも及ぶ→ preview で公開/モバイルの非破壊を必ず確認。サイドバー/Header隠しは auth＋lg ゲートで、未ログイン/モバイルは現状維持。
+2. `data-app-header` を隠すCSSは**lg+ かつ has-sidebar** に限定（`@media`＋body class）。他の `header` 要素に影響しないよう属性セレクタで限定。
+3. サイドバーは `h-screen sticky top-0` 等で全高固定。スクロール時の挙動を確認。
+4. テーマ切替・ログアウトをサイドバーに移すことで、PCでHeaderが消えても操作を失わない。

--- a/frontend/__tests__/components/Sidebar.test.tsx
+++ b/frontend/__tests__/components/Sidebar.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import Sidebar from "@/app/components/Sidebar";
+
+const mockPathname = jest.fn();
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockPathname(),
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("@/app/components/CommandPalette", () => ({
+  __esModule: true,
+  useCommandPalette: () => ({ open: jest.fn(), close: jest.fn(), toggle: jest.fn() }),
+}));
+
+jest.mock("@/app/components/ThemeToggle", () => ({
+  __esModule: true,
+  default: () => <button type="button">theme</button>,
+}));
+
+jest.mock("@/lib/toast", () => ({
+  toast: { error: jest.fn(), success: jest.fn() },
+}));
+
+beforeEach(() => {
+  mockPathname.mockReturnValue("/home");
+  mockUseAuth.mockReturnValue({
+    isLoggedIn: true,
+    user: { username: "はると", premium: false },
+    logout: jest.fn(),
+  });
+});
+
+afterEach(() => {
+  document.body.classList.remove("has-sidebar");
+});
+
+describe("Sidebar", () => {
+  it("未ログインでは何も描画しない", () => {
+    mockUseAuth.mockReturnValue({ isLoggedIn: false, user: null, logout: jest.fn() });
+    const { container } = render(<Sidebar />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("ログイン時にナビ・さがす・ログアウトを描画する", () => {
+    render(<Sidebar />);
+    expect(screen.getByRole("link", { name: "ホーム" })).toHaveAttribute("href", "/home");
+    expect(screen.getByRole("link", { name: "夢の森" })).toHaveAttribute("href", "/forest");
+    expect(screen.getByRole("link", { name: "マイ夢" })).toHaveAttribute("href", "/my-dreams");
+    expect(screen.getByRole("link", { name: "設定" })).toHaveAttribute("href", "/settings");
+    expect(screen.getByRole("button", { name: /さがす/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /ログアウト/ })).toBeInTheDocument();
+  });
+
+  it("現在地のナビをアクティブ表示する", () => {
+    mockPathname.mockReturnValue("/forest");
+    render(<Sidebar />);
+    expect(screen.getByRole("link", { name: "夢の森" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: "ホーム" })).not.toHaveAttribute("aria-current");
+  });
+
+  it("表示時に body へ has-sidebar を付与し、アンマウントで除去する", () => {
+    const { unmount } = render(<Sidebar />);
+    expect(document.body.classList.contains("has-sidebar")).toBe(true);
+    unmount();
+    expect(document.body.classList.contains("has-sidebar")).toBe(false);
+  });
+
+  it("未ログインでは has-sidebar を付与しない", () => {
+    mockUseAuth.mockReturnValue({ isLoggedIn: false, user: null, logout: jest.fn() });
+    render(<Sidebar />);
+    expect(document.body.classList.contains("has-sidebar")).toBe(false);
+  });
+});

--- a/frontend/app/Header.tsx
+++ b/frontend/app/Header.tsx
@@ -10,7 +10,7 @@ import CommandPaletteTrigger from "./components/CommandPaletteTrigger";
 
 export default function Header() {
   return (
-    <header className="py-3 px-4 sm:px-6 border-b border-border bg-background text-foreground flex flex-col md:flex-row items-center gap-4 md:gap-8">
+    <header data-app-header className="py-3 px-4 sm:px-6 border-b border-border bg-background text-foreground flex flex-col md:flex-row items-center gap-4 md:gap-8">
       <div className="flex-shrink-0">
         <HeaderLogo />
       </div>

--- a/frontend/app/components/Sidebar.tsx
+++ b/frontend/app/components/Sidebar.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+/**
+ * Sidebar — デスクトップ常設の左ナビゲーション（redesign-code STEP 4 / 改善①）
+ *
+ * lg+ かつログイン時のみ表示。PCではこのサイドバーが logo＋ナビ＋ユーザー＋
+ * テーマ＋ログアウトを担い、既存Header（横長）は隠す（body.has-sidebar + CSS）。
+ * モバイル・未ログイン・公開ページでは何も描画せず、従来のHeader/BottomTabBarに任せる。
+ */
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Home, LogOut, Moon, Search, Settings, Trees } from "lucide-react";
+
+import { useAuth } from "@/context/AuthContext";
+import { toast } from "@/lib/toast";
+import { useCommandPalette } from "./CommandPalette";
+import ThemeToggle from "./ThemeToggle";
+
+type NavItem = { href: string; label: string; icon: typeof Home };
+
+const NAV: NavItem[] = [
+  { href: "/home", label: "ホーム", icon: Home },
+  { href: "/forest", label: "夢の森", icon: Trees },
+  { href: "/my-dreams", label: "マイ夢", icon: Moon },
+  { href: "/settings", label: "設定", icon: Settings },
+];
+
+function navClass(active: boolean) {
+  return [
+    "flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm transition-colors",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+    active
+      ? "bg-primary/10 font-bold text-primary"
+      : "font-medium text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+  ].join(" ");
+}
+
+export default function Sidebar() {
+  const pathname = usePathname() ?? "";
+  const { isLoggedIn, user, logout } = useAuth();
+  const palette = useCommandPalette();
+
+  const show = isLoggedIn;
+
+  useEffect(() => {
+    if (!show) return;
+    document.body.classList.add("has-sidebar");
+    return () => {
+      document.body.classList.remove("has-sidebar");
+    };
+  }, [show]);
+
+  if (!show) return null;
+
+  const isActive = (href: string) =>
+    pathname === href || (href !== "/" && pathname.startsWith(href));
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "おしまいに できませんでした。"
+      );
+    }
+  };
+
+  return (
+    <aside className="sticky top-0 hidden h-screen w-60 shrink-0 flex-col border-r border-border bg-card px-4 py-6 lg:flex">
+      <Link
+        href="/home"
+        className="mb-6 flex items-center gap-2.5 px-2 text-lg font-black text-foreground"
+      >
+        <span aria-hidden="true" className="text-xl">
+          🌙
+        </span>
+        ユメツリー
+      </Link>
+
+      <nav className="flex flex-col gap-1" aria-label="サイドナビゲーション">
+        <Link
+          href={NAV[0].href}
+          aria-current={isActive(NAV[0].href) ? "page" : undefined}
+          className={navClass(isActive(NAV[0].href))}
+        >
+          <Home size={19} strokeWidth={isActive(NAV[0].href) ? 2.2 : 2} />
+          {NAV[0].label}
+        </Link>
+
+        {/* さがす = コマンドパレット起動 */}
+        <button
+          type="button"
+          onClick={() => palette.open()}
+          className={`${navClass(false)} w-full`}
+        >
+          <Search size={19} strokeWidth={2} />
+          さがす
+          <kbd className="ml-auto rounded-md border border-border bg-muted px-1.5 py-0.5 text-[10px] font-semibold text-muted-foreground">
+            ⌘K
+          </kbd>
+        </button>
+
+        {NAV.slice(1).map((item) => {
+          const Icon = item.icon;
+          const active = isActive(item.href);
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              aria-current={active ? "page" : undefined}
+              className={navClass(active)}
+            >
+              <Icon size={19} strokeWidth={active ? 2.2 : 2} />
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      <div className="mt-auto flex flex-col gap-2.5">
+        <div className="flex items-center gap-2.5 rounded-2xl border border-border bg-muted/40 p-2.5">
+          <div className="grid h-9 w-9 place-items-center rounded-full bg-gradient-to-br from-violet-400 to-primary text-sm font-bold text-white">
+            {(user?.username ?? "ゆ").slice(0, 1)}
+          </div>
+          <div className="min-w-0">
+            <div className="truncate text-[13px] font-bold text-foreground">
+              {user?.username ?? "ゲスト"}さん
+            </div>
+            {user?.premium ? (
+              <div className="text-[10px] font-semibold text-amber-600 dark:text-amber-400">
+                ✦ プレミアム
+              </div>
+            ) : (
+              <div className="text-[10px] font-medium text-muted-foreground">
+                無料プラン
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-2">
+          <ThemeToggle />
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="flex items-center gap-1.5 rounded-full px-3 py-2 text-xs font-medium text-muted-foreground transition-colors hover:text-destructive"
+          >
+            <LogOut size={16} />
+            ログアウト
+          </button>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -477,6 +477,13 @@
   }
 }
 
+/* STEP4: PC(lg+)かつサイドバー表示時は、横長の既存ヘッダーを隠す（サイドバーが代替） */
+@media (min-width: 1024px) {
+  body.has-sidebar [data-app-header] {
+    display: none;
+  }
+}
+
 @layer base {
   * {
     @apply border-border;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -10,6 +10,7 @@ import Loading from "./loading";
 import { Providers } from "./providers";
 import PendingDreamsMonitor from "./components/PendingDreamsMonitor";
 import BottomTabBar from "./components/BottomTabBar";
+import Sidebar from "./components/Sidebar";
 import { CommandPaletteProvider } from "./components/CommandPalette";
 import { SITE_URL, GOOGLE_SITE_VERIFICATION } from "@/lib/site";
 
@@ -64,21 +65,24 @@ export default function RootLayout({
 }>): React.ReactElement {
   return (
     <html lang="ja" className="min-h-full" suppressHydrationWarning>
-      <body
-        className={`${notoSansJP.className} px-4 sm:px-6 lg:px-8 flex flex-col min-h-screen`}
-      >
+      <body className={`${notoSansJP.className} min-h-screen`}>
         <Script id="theme-init" strategy="beforeInteractive">
           {themeInitScript}
         </Script>
         <Providers>
           <CommandPaletteProvider>
-            <Header />
-            <div className="flex flex-col flex-grow">
-              <main className="flex-grow">
-                <Suspense fallback={<Loading />}>{children}</Suspense>
-              </main>
-              <Footer />
-              {/* 全体で1つのインスタンスとしてマウント */}
+            {/* PC(lg+)・ログイン時のみ左サイドバー。公開/モバイル/未ログインでは null */}
+            <div className="flex min-h-screen">
+              <Sidebar />
+              <div className="flex min-w-0 flex-grow flex-col px-4 sm:px-6 lg:px-8">
+                <Header />
+                <div className="flex flex-grow flex-col">
+                  <main className="flex-grow">
+                    <Suspense fallback={<Loading />}>{children}</Suspense>
+                  </main>
+                  <Footer />
+                </div>
+              </div>
             </div>
             <PendingDreamsMonitor />
             <BottomTabBar />


### PR DESCRIPTION
## 概要

`redesign-code` の **STEP 4（改善① ナビ）「サイドバー先行」スコープ**。PC(lg+)・ログイン時に左サイドバーを追加し、PCではこのサイドバーが logo＋ナビ＋ユーザー＋テーマ＋ログアウトを担い、横長の既存Headerを隠す。完全版AppShell（route group・右レール・ページ別トップバー）は最重量・高リスクのため見送り（STEP 4b）。

仕様: 📄 `docs/superpowers/specs/2026-06-29-sidebar-shell-design.md`

## 設計の核心（既存ヘッダーとの二重ナビ回避）
#3a と同じ「**認証=JS / レスポンシブ=CSS**」機構：
- `Sidebar` が表示時に `body.has-sidebar` を付与（ログイン時のみ）。
- `globals.css`: `@media (min-width:1024px){ body.has-sidebar [data-app-header]{ display:none } }` で **lg+・ログイン時のみ**既存Headerを隠す。
- 公開ページ・モバイル・未ログインでは従来Header表示・サイドバー非表示（**非破壊**）。

## 変更内容
- **新規** `app/components/Sidebar.tsx`: `hidden lg:flex`・`useAuth().isLoggedIn` 時のみ。ロゴ／ナビ（ホーム/さがす(⌘K)/夢の森/マイ夢/設定）／ユーザーカード／`ThemeToggle`／ログアウト。参照の「きもち」(/insights)はSTEP5未実装のため除外。アクティブ判定`aria-current`。表示時 `body.has-sidebar` 付与。
- **`app/layout.tsx`**: `Providers/CommandPaletteProvider` 内を **flex-row 化**（左Sidebar＋メインカラム）。横padding(`px-4 sm:px-6 lg:px-8`)を body からメインカラムへ移動。
- **`app/Header.tsx`**: `<header>` に `data-app-header` 付与（隠す対象の目印）。
- **`app/globals.css`**: 上記 has-sidebar 規則。
- **テスト** `Sidebar.test.tsx`: 未ログインnull / ナビ・さがす・ログアウト描画 / アクティブ表示 / has-sidebar付与・除去。

## 検証結果
- **Jest 全緑**（+5）／ **`yarn build`: 成功**
- **preview目視（最重要・非破壊）**: 公開 `/login` を mobile幅・desktop幅で確認 → **サイドバー非表示・has-sidebar無し・Header表示・レイアウト崩れなし**（スクショ確認）。
- 認証時のサイドバー表示・Header非表示(lg+)は `isLoggedIn` 依存のため component test ＋手動QAに委ねる（#3aと同型の実績ある機構）。

## 触っていない領域
右レール・ページ別トップバー・AppShell per-page（STEP 4b）/ `/insights`(STEP5) / `AuthNav`の中身（モバイルではそのまま）/ 森・認証ロジック・Stripe・DB。