### PR TITLE
fix: dream_profile_id未設定の既存データをmigrationで是正

### DIFF
--- a/backend/db/migrate/20260703000000_backfill_dream_profile_id_for_existing_dreams.rb
+++ b/backend/db/migrate/20260703000000_backfill_dream_profile_id_for_existing_dreams.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# 本番DBの dream_profile_id 未設定データを是正する一回限りのバックフィルmigration。
+#
+# 【背景】
+# dream_profiles 機能導入前に作成された既存の夢は dream_profile_id が NULL のまま。
+# 通常は rake dream_profiles:ensure_self_profiles / backfill_dream_profile_id で
+# 是正するが、Render 無料プランでは Shell / one-off jobs が使えず本番で rake を
+# 直接実行できないため、デプロイ時に自動実行される migration として同等の処理を行う。
+#
+# 【ロジック】
+# 既存rake task（lib/tasks/dream_profiles.rake）と同じ2ステップを、この順序で実行する。
+# 1. ensure_self_profiles 相当: 「自分」プロフィールを持たないユーザーにだけ作成
+# 2. backfill_dream_profile_id 相当: dream_profile_id が NULL の夢だけを、
+#    同一ユーザーの「自分」プロフィールに紐付ける
+#
+# 【冪等性】
+# - Step 1 は NOT EXISTS で既存の self プロフィールを除外するため再実行しても増えない。
+#   万が一の二重INSERTも idx_dream_profiles_unique_self（relationship='self' の user_id
+#   ユニーク制約）がDBレベルで防ぐ。
+# - Step 2 は dream_profile_id IS NULL の夢だけを対象にするため、既に割当済みの夢には
+#   触れない。
+#
+# 【安全性】
+# - migrationはデフォルトで単一トランザクションに包まれるため、Step 2 で失敗しても
+#   Step 1 の INSERT ごとロールバックされ、中途半端な状態は残らない。
+# - NOT NULL化などスキーマ変更は行わない（別PRで対応）。
+# - Stripe / 認証 / UI / OpenAI には一切触れない。
+class BackfillDreamProfileIdForExistingDreams < ActiveRecord::Migration[7.1]
+  def up
+    # Step 1: ensure_self_profiles 相当
+    created = execute(<<~SQL)
+      INSERT INTO dream_profiles
+        (user_id, name, avatar_emoji, color, relationship, active, position, created_at, updated_at)
+      SELECT u.id, '自分', '😴', '#6366f1', 'self', true, 0, NOW(), NOW()
+      FROM users u
+      WHERE NOT EXISTS (
+        SELECT 1 FROM dream_profiles dp
+        WHERE dp.user_id = u.id AND dp.relationship = 'self'
+      )
+    SQL
+
+    # Step 2: backfill_dream_profile_id 相当
+    # user_id が一致する self プロフィールにだけ紐付ける
+    backfilled = execute(<<~SQL)
+      UPDATE dreams
+      SET dream_profile_id = dp.id
+      FROM dream_profiles dp
+      WHERE dp.user_id = dreams.user_id
+        AND dp.relationship = 'self'
+        AND dreams.dream_profile_id IS NULL
+    SQL
+
+    remaining = execute("SELECT COUNT(*) AS count FROM dreams WHERE dream_profile_id IS NULL")
+                  .first["count"].to_i
+
+    message = "[BackfillDreamProfileIdForExistingDreams] " \
+              "self profile作成 #{created.cmd_tuples} 件 / " \
+              "dream紐付け #{backfilled.cmd_tuples} 件 / " \
+              "残NULL #{remaining} 件"
+    Rails.logger.info(message)
+    say(message)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_03_000000) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_03_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/backend/spec/migrations/backfill_dream_profile_id_for_existing_dreams_spec.rb
+++ b/backend/spec/migrations/backfill_dream_profile_id_for_existing_dreams_spec.rb
@@ -1,0 +1,117 @@
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260703000000_backfill_dream_profile_id_for_existing_dreams.rb')
+
+RSpec.describe BackfillDreamProfileIdForExistingDreams do
+  subject(:migration) { described_class.new }
+
+  def run_migration
+    original = $stdout
+    $stdout = StringIO.new
+    migration.up
+  ensure
+    $stdout = original
+  end
+
+  context 'self プロフィールが無く、未紐付けの夢があるユーザー' do
+    let!(:user) { create(:user) }
+    let!(:legacy_dream) { create(:dream, user: user, dream_profile_id: nil) }
+
+    it 'self プロフィールを作成する' do
+      expect { run_migration }.to change(DreamProfile, :count).by(1)
+      profile = user.dream_profiles.find_by(relationship: 'self')
+      expect(profile).to be_present
+      expect(profile.name).to eq('自分')
+      expect(profile.avatar_emoji).to eq('😴')
+      expect(profile.color).to eq('#6366f1')
+      expect(profile.active).to eq(true)
+      expect(profile.position).to eq(0)
+    end
+
+    it '作成した self プロフィールに夢を紐付ける' do
+      run_migration
+      expect(legacy_dream.reload.dream_profile_id).to eq(user.dream_profiles.find_by(relationship: 'self').id)
+    end
+
+    it '実行後は未紐付けの夢が残らない' do
+      run_migration
+      expect(Dream.where(dream_profile_id: nil).count).to eq(0)
+    end
+  end
+
+  context 'すでに self プロフィールを持つユーザー' do
+    let!(:user) { create(:user) }
+    let!(:self_profile) { create(:dream_profile, :self_profile, user: user) }
+    let!(:legacy_dream) { create(:dream, user: user, dream_profile_id: nil) }
+
+    it 'self プロフィールを重複作成しない' do
+      expect { run_migration }.not_to change(DreamProfile, :count)
+    end
+
+    it '既存の self プロフィールに夢を紐付ける' do
+      run_migration
+      expect(legacy_dream.reload.dream_profile_id).to eq(self_profile.id)
+    end
+  end
+
+  context '他プロフィールに割り当て済みの夢' do
+    let!(:user) { create(:user) }
+    let!(:self_profile) { create(:dream_profile, :self_profile, user: user) }
+    let!(:other_profile) { create(:dream_profile, user: user) }
+    let!(:assigned_dream) { create(:dream, user: user, dream_profile_id: other_profile.id) }
+
+    it '割り当て済みの夢は変更しない' do
+      expect { run_migration }.not_to change { assigned_dream.reload.dream_profile_id }
+      expect(assigned_dream.dream_profile_id).to eq(other_profile.id)
+    end
+  end
+
+  context '他ユーザーの self プロフィールには紐付かない' do
+    let!(:user_a) { create(:user) }
+    let!(:user_b) { create(:user) }
+    let!(:self_profile_b) { create(:dream_profile, :self_profile, user: user_b) }
+    let!(:dream_a) { create(:dream, user: user_a, dream_profile_id: nil) }
+
+    it 'user_a の夢は user_a 自身の self プロフィールにのみ紐付く' do
+      run_migration
+      expect(dream_a.reload.dream_profile_id).to eq(user_a.dream_profiles.find_by(relationship: 'self').id)
+      expect(dream_a.dream_profile_id).not_to eq(self_profile_b.id)
+    end
+  end
+
+  context '夢を持たないユーザー' do
+    let!(:user) { create(:user) }
+
+    it 'self プロフィールだけは作成される' do
+      expect { run_migration }.to change(DreamProfile, :count).by(1)
+    end
+  end
+
+  context '2回実行した場合（冪等性）' do
+    let!(:user) { create(:user) }
+    let!(:legacy_dream) { create(:dream, user: user, dream_profile_id: nil) }
+
+    it 'self プロフィール数が変わらない' do
+      run_migration
+      expect { run_migration }.not_to change(DreamProfile, :count)
+    end
+
+    it '夢の紐付け先が変わらない' do
+      run_migration
+      assigned_id = legacy_dream.reload.dream_profile_id
+      expect { run_migration }.not_to change { legacy_dream.reload.dream_profile_id }
+      expect(legacy_dream.reload.dream_profile_id).to eq(assigned_id)
+    end
+  end
+
+  context '出力確認' do
+    let!(:user) { create(:user) }
+    let!(:legacy_dream) { create(:dream, user: user, dream_profile_id: nil) }
+
+    it '作成件数・紐付け件数・残NULL件数をログ出力する' do
+      expect(Rails.logger).to receive(:info).with(
+        a_string_matching(/self profile作成 1 件.*dream紐付け 1 件.*残NULL 0 件/)
+      )
+      run_migration
+    end
+  end
+end


### PR DESCRIPTION
## 概要

本番DBで `dream_profile_id` が未設定の既存の夢を、各ユーザーの「自分」プロフィールへ割り当てる**バックフィル専用**migration。

Render無料プランでは Shell / one-off jobs が使えず、既存の rake task
`dream_profiles:ensure_self_profiles` / `dream_profiles:backfill_dream_profile_id`
（[dream_profiles.rake](backend/lib/tasks/dream_profiles.rake)）を本番Shellで直接実行できない。そのため、デプロイ時に自動実行される migration として同等のロジックを実装した。

**本番実測値（Supabase SQL Editorで確認）**: `total_dreams = 37` / `null_dreams = 29`

## 変更内容

- `backend/db/migrate/20260703000000_backfill_dream_profile_id_for_existing_dreams.rb`
  - Step 1（`ensure_self_profiles` 相当）: 「自分」プロフィールを持たないユーザーにだけ作成
  - Step 2（`backfill_dream_profile_id` 相当）: `dream_profile_id IS NULL` の夢だけを、**同一 `user_id`** の「自分」プロフィールに紐付け
  - 残NULL件数を `Rails.logger.info` と `say`（migration標準出力）の両方でログ出力
- `backend/spec/migrations/backfill_dream_profile_id_for_existing_dreams_spec.rb`: 11ケース（作成/紐付け/他プロフィール不可侵/他ユーザー不可侵/夢なしユーザー/冪等性/ログ出力）
- `backend/db/schema.rb`: migrationバージョン反映のみ

## 設計方針・冪等性

- 既存rake taskの2ステップを**1つのmigrationにまとめ、ensure→backfillの順で実行**（backfillはselfプロフィールの存在に依存するため、常に同一トランザクション内で完結させる）
- Step 1は `NOT EXISTS` でガードし再実行しても増えない。DBの `idx_dream_profiles_unique_self`（`relationship='self'` の `user_id` ユニーク制約）も二重作成を防止
- Step 2は `dream_profile_id IS NULL` の夢だけを対象にし、`dp.user_id = dreams.user_id` で**同一ユーザーのselfプロフィールにのみ**紐付ける（他ユーザーのselfプロフィールへの誤紐付けを構造的に防止）
- migrationはデフォルトで単一トランザクションに包まれるため、Step 2で失敗してもStep 1のINSERTごとロールバックされ、中途半端な状態は残らない
- `ActiveRecord::Migration[7.1]`: 同じ`dream_profiles`関連の既存migration（`CreateDreamProfiles`, `AddDreamProfileIdToDreams`, `EnableRlsOnDreamProfiles`）に合わせたバージョン
- **NOT NULL化は含まない**（別PRで、本番の `null_dreams = 0` 確認後に対応）
- Stripe / 認証 / UI / OpenAI には触れていない

## 検証結果

Docker環境（`backend-test`サービス）で実行:

```
bundle exec rails db:migrate RAILS_ENV=test
# => [BackfillDreamProfileIdForExistingDreams] self profile作成 0 件 / dream紐付け 0 件 / 残NULL 0 件

bundle exec rspec spec/migrations/backfill_dream_profile_id_for_existing_dreams_spec.rb
# => 11 examples, 0 failures

bundle exec rspec spec/tasks/dream_profiles_rake_spec.rb spec/models/dream_profile_spec.rb spec/migrations/backfill_dream_profile_id_for_existing_dreams_spec.rb
# => 46 examples, 0 failures（既存rake task・モデルspecと合わせて全緑）
```

## マージ後の確認手順

デプロイ完了後、Supabase SQL Editorで以下3つを実行して確認する。

**1. NULLが0件になったか**

```sql
SELECT
  COUNT(*) AS total_dreams,
  COUNT(*) FILTER (WHERE dream_profile_id IS NULL) AS null_dreams
FROM dreams;
```

期待値: `null_dreams = 0`

**2. 他人のprofileや存在しないprofileに紐づいていないか**

```sql
SELECT COUNT(*) AS invalid_profile_links
FROM dreams d
LEFT JOIN dream_profiles dp ON dp.id = d.dream_profile_id
WHERE d.dream_profile_id IS NOT NULL
  AND (dp.id IS NULL OR dp.user_id <> d.user_id);
```

期待値: `invalid_profile_links = 0`

**3. 今回まだNOT NULL化されていないこと**

```sql
SELECT
  column_name,
  is_nullable
FROM information_schema.columns
WHERE table_name = 'dreams'
  AND column_name = 'dream_profile_id';
```

期待値: `is_nullable = YES`

上記3つすべて期待値どおりであることを確認できたら、NOT NULL化のmigrationを別PRとして着手する。

## 触っていない領域

Stripe決済 / 認証 / UI / OpenAI呼び出し / NOT NULL制約の追加。
