### PR TITLE
feat: user_sessionsテーブル導入とrefresh tokenのdigest化（認証強化PR1）

### DIFF
--- a/backend/app/controllers/auth_controller.rb
+++ b/backend/app/controllers/auth_controller.rb
@@ -4,7 +4,10 @@ class AuthController < ApplicationController
   # ユーザーのログイン
   def login
     begin
-      result = AuthService.login(params[:email], params[:password])
+      result = AuthService.login(
+        params[:email], params[:password],
+        user_agent: request.user_agent, ip_address: request.remote_ip
+      )
 
 
       Rails.logger.debug "生成されたトークン: #{result[:access_token]}" if Rails.env.development?
@@ -49,7 +52,10 @@ class AuthController < ApplicationController
       return render json: { error: "すでに 本登録 ずみだよ。" }, status: :unprocessable_entity
     end
 
-    result = AuthService.convert_trial(@current_user, convert_trial_params)
+    result = AuthService.convert_trial(
+      @current_user, convert_trial_params,
+      user_agent: request.user_agent, ip_address: request.remote_ip
+    )
     set_token_cookies(result[:access_token], result[:refresh_token])
     render json: { user: user_json(result[:user]) }, status: :ok
   rescue AuthService::RegistrationError => e
@@ -68,7 +74,10 @@ class AuthController < ApplicationController
     end
 
     begin
-      result = AuthService.refresh_token(refresh_token)
+      result = AuthService.refresh_token(
+        refresh_token,
+        user_agent: request.user_agent, ip_address: request.remote_ip
+      )
       Rails.logger.info "新しいアクセストークンを発行: #{result[:access_token]}" if Rails.env.development?
       set_token_cookies(result[:access_token], result[:refresh_token]) 
       render json: { message: "トークンを更新しました" }, status: :ok
@@ -93,10 +102,8 @@ class AuthController < ApplicationController
     end
 
     begin
-      # リフレッシュトークンを使ってユーザーを検索
-      user = AuthService.find_user_by_refresh_token(refresh_token)
-      # バリデーションとコールバックをスキップしてリフレッシュトークンのみを無効化
-      user.update_column(:refresh_token, nil)
+      # 該当セッションのみを失効させる（他端末のログインは維持される）
+      AuthService.revoke_session(refresh_token)
       cookies.delete(:access_token)
       cookies.delete(:refresh_token, path: '/')
       render json: { message: "ログアウトしました" }, status: :ok

--- a/backend/app/controllers/trial_users_controller.rb
+++ b/backend/app/controllers/trial_users_controller.rb
@@ -8,7 +8,10 @@ class TrialUsersController < ApplicationController
 
     ApplicationRecord.transaction do
       begin
-        result = AuthService.create_trial_user(params[:trial_user])
+        result = AuthService.create_trial_user(
+          params[:trial_user],
+          user_agent: request.user_agent, ip_address: request.remote_ip
+        )
 
         unless result[:user] && result[:access_token] && result[:refresh_token]
           Rails.logger.error "トライアルユーザー作成処理で必要な情報が不足しています: #{result.inspect}"

--- a/backend/app/controllers/users_controller.rb
+++ b/backend/app/controllers/users_controller.rb
@@ -11,7 +11,10 @@ class UsersController < ApplicationController
 
     ApplicationRecord.transaction do
       begin
-        result = AuthService.register(user_params)
+        result = AuthService.register(
+          user_params,
+          user_agent: request.user_agent, ip_address: request.remote_ip
+        )
 
         unless result[:user] && result[:access_token] && result[:refresh_token]
           Rails.logger.error "ユーザー登録処理で AuthService から必要な情報が返されませんでした: #{result.inspect}"

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   has_secure_password
   has_many :dreams, dependent: :destroy
   has_many :dream_profiles, dependent: :destroy
+  has_many :user_sessions, dependent: :destroy
   has_many :dream_image_generations, dependent: :destroy
   has_many :payments, dependent: :destroy
   has_many :subscriptions, dependent: :destroy

--- a/backend/app/models/user_session.rb
+++ b/backend/app/models/user_session.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# refresh token 1本につき1レコード（＝ログイン中の端末1つ分）。
+# トークン本文は保存せず SHA256 digest のみを持つ。
+# 設計: docs/auth-hardening-spec.md（PR1）
+class UserSession < ApplicationRecord
+  # 1ユーザーが同時に保持できる有効セッション数（端末数の上限）
+  MAX_ACTIVE_SESSIONS = 5
+
+  belongs_to :user
+
+  validates :refresh_token_digest, presence: true, uniqueness: true
+  validates :expires_at, presence: true
+
+  scope :active, -> { where(revoked_at: nil).where("expires_at > ?", Time.current) }
+
+  # refresh token は 512bit のランダム値なので、レインボーテーブル攻撃は
+  # entropy 側で守られる。等値検索（インデックス）が必要なため bcrypt ではなく
+  # 決定的な SHA256 を使う。
+  def self.digest(token)
+    Digest::SHA256.hexdigest(token)
+  end
+
+  def self.find_active_by_token(token)
+    return nil if token.blank?
+
+    active.find_by(refresh_token_digest: digest(token))
+  end
+
+  # 上限を超えた古いセッションを失効させる（多端末対応の暴走防止）
+  def self.prune_for(user)
+    overflow = user.user_sessions.active.order(created_at: :desc).offset(MAX_ACTIVE_SESSIONS)
+    overflow.update_all(revoked_at: Time.current)
+  end
+
+  def revoke!
+    update!(revoked_at: Time.current)
+  end
+
+  def rotate!(new_token, lifetime:)
+    update!(
+      refresh_token_digest: self.class.digest(new_token),
+      expires_at: lifetime.from_now,
+      last_used_at: Time.current
+    )
+  end
+end

--- a/backend/app/services/auth_service.rb
+++ b/backend/app/services/auth_service.rb
@@ -153,8 +153,7 @@ class AuthService
       # レガシー互換: 旧 users.refresh_token（平文カラム）と照合し、
       # 一致したらその場で user_sessions へ透過的に移行する。
       # デプロイ前からログイン中のユーザーを強制ログアウトさせないための一時パス。
-      user = find_user_by_legacy_refresh_token(refresh_token)
-      user.update_column(:refresh_token, nil)
+      user = consume_legacy_refresh_token(refresh_token)
       new_refresh_token = create_session(user, user_agent: user_agent, ip_address: ip_address)
       Rails.logger.info "ユーザーID: #{user.id} のレガシートークンをセッションへ移行しました。"
       { access_token: encode_token(user.id), refresh_token: new_refresh_token }
@@ -175,8 +174,7 @@ class AuthService
     end
 
     # レガシー互換: 旧カラムのトークンでのログアウト
-    user = find_user_by_legacy_refresh_token(refresh_token)
-    user.update_column(:refresh_token, nil)
+    consume_legacy_refresh_token(refresh_token)
     true
   end
 
@@ -205,14 +203,32 @@ class AuthService
     SecureRandom.urlsafe_base64(64)
   end
 
-  # 旧 users.refresh_token カラムからユーザーを検索（レガシー互換パス）
+  # 旧 users.refresh_token カラムのトークンをアトミックに検証・消費する
+  # （nullify に成功したリクエストだけがユーザーを取得できる）。
+  #
+  # ロールアウト直後、期限切れアクセストークンが引き金になって同一クライアントから
+  # 並列に /auth/refresh が飛ぶことがある。素朴に find→update だと、両リクエストが
+  # nullify 前に同じユーザーを読んでしまい、1本の使い捨てトークンから複数の
+  # user_sessions が作られてしまう（Codexレビュー指摘・#414）。
+  # 行ロック(with_lock)の中で再読込し、他リクエストが先に消費済みでないか
+  # 確認してからnullifyすることで、後続リクエストは確実に失敗させる。
+  #
   # burn-in 後にカラムごと削除予定（docs/auth-hardening-spec.md）
-  def self.find_user_by_legacy_refresh_token(refresh_token)
+  def self.consume_legacy_refresh_token(refresh_token)
     user = User.find_by(refresh_token: refresh_token)
     if user.nil?
       Rails.logger.warn "リフレッシュトークンが無効です (token_prefix=#{refresh_token.to_s[0..7]}...)"
       raise InvalidRefreshTokenError, '無効なリフレッシュトークン'
     end
+
+    user.with_lock do
+      # ロック取得後の再読込で、他リクエストが先に消費済みなら不一致になる
+      if user.refresh_token != refresh_token
+        raise InvalidRefreshTokenError, '無効なリフレッシュトークン'
+      end
+      user.update_column(:refresh_token, nil)
+    end
+
     user
   end
 

--- a/backend/app/services/auth_service.rb
+++ b/backend/app/services/auth_service.rb
@@ -16,13 +16,12 @@ class AuthService
   end
 
   # ログイン処理
-  def self.login(email, password)
+  # 多端末対応: 既存セッションは失効させず、新しいセッションを追加する
+  def self.login(email, password, user_agent: nil, ip_address: nil)
     user = User.find_by(email: email.downcase)
     if user&.authenticate(password)
       access_token = encode_token(user.id)
-      refresh_token = generate_refresh_token
-      # バリデーションとコールバックをスキップして refresh_token のみを更新
-      user.update_column(:refresh_token, refresh_token)
+      refresh_token = create_session(user, user_agent: user_agent, ip_address: ip_address)
       # 🛡️ セキュア化：トークン本文は出力せず、成功の事実のみをログに残す
       Rails.logger.info "認証成功: ユーザーID=#{user.id} トークン生成完了"
       { access_token: access_token, refresh_token: refresh_token, user: user }
@@ -30,14 +29,13 @@ class AuthService
       Rails.logger.warn "認証失敗: email=#{email}"
       raise InvalidCredentialsError, 'メールアドレスまたはパスワードが正しくありません'
     end
-  rescue ActiveRecord::RecordInvalid => e # update_column は RecordInvalid を発生させないが、念のため残す
-    Rails.logger.error "ログイン成功後、リフレッシュトークン更新に失敗: #{e.message}"
-
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error "ログイン成功後、セッション作成に失敗: #{e.message}"
     raise InvalidCredentialsError, "ログイン処理中にエラーが発生しました。"
   end
 
   # ユーザーを登録する
-  def self.register(params)
+  def self.register(params, user_agent: nil, ip_address: nil)
     user = User.new(
       email: params[:email]&.downcase,
       username: params[:username],
@@ -46,21 +44,19 @@ class AuthService
     )
     if user.save
       access_token = encode_token(user.id)
-      refresh_token = generate_refresh_token
-      # バリデーションとコールバックをスキップして refresh_token のみを更新
-      user.update_column(:refresh_token, refresh_token)
-      Rails.logger.info "新規登録ユーザーID: #{user.id} のリフレッシュトークンを保存しました。" if Rails.env.development?
+      refresh_token = create_session(user, user_agent: user_agent, ip_address: ip_address)
+      Rails.logger.info "新規登録ユーザーID: #{user.id} のセッションを作成しました。" if Rails.env.development?
       { access_token: access_token, refresh_token: refresh_token, user: user }
     else
       raise RegistrationError, user.errors.full_messages.join(", ")
     end
-  rescue ActiveRecord::RecordInvalid => e # update_column は RecordInvalid を発生させないが、念のため残す
-     Rails.logger.error "ユーザー作成成功後、リフレッシュトークン更新に失敗: #{e.message}"
-     raise RegistrationError, "ユーザー登録中にエラーが発生しました。"
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error "ユーザー作成成功後、セッション作成に失敗: #{e.message}"
+    raise RegistrationError, "ユーザー登録中にエラーが発生しました。"
   end
 
   # トライアルユーザーを作成する
-  def self.create_trial_user(params)
+  def self.create_trial_user(params, user_agent: nil, ip_address: nil)
     user = User.new(
       email: params[:email]&.downcase,
       username: params[:username],
@@ -70,26 +66,24 @@ class AuthService
     )
     if user.save
       access_token = encode_token(user.id)
-      refresh_token = generate_refresh_token
-      # バリデーションとコールバックをスキップして refresh_token のみを更新
-      user.update_column(:refresh_token, refresh_token)
-      Rails.logger.info "トライアルユーザーID: #{user.id} のリフレッシュトークンを保存しました。" if Rails.env.development?
+      refresh_token = create_session(user, user_agent: user_agent, ip_address: ip_address)
+      Rails.logger.info "トライアルユーザーID: #{user.id} のセッションを作成しました。" if Rails.env.development?
       { access_token: access_token, refresh_token: refresh_token, user: user }
     else
       raise RegistrationError, user.errors.full_messages.join(", ")
     end
-  rescue ActiveRecord::RecordInvalid => e # update_column は RecordInvalid を発生させないが、念のため残す
-     Rails.logger.error "トライアルユーザー作成成功後、リフレッシュトークン更新に失敗: #{e.message}"
-     raise RegistrationError, "トライアルユーザー登録中にエラーが発生しました。"
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error "トライアルユーザー作成成功後、セッション作成に失敗: #{e.message}"
+    raise RegistrationError, "トライアルユーザー登録中にエラーが発生しました。"
   end
 
   # トライアルユーザーを本登録ユーザーへ昇格する
   # 同じ User レコードの認証情報を更新し trial_user を外すだけなので、
   # 夢・プロフィール（user_id 紐づき）はそのまま引き継がれる。
-  # セキュリティ: 昇格時に refresh_token をローテーションし、
-  # 旧トライアル時に漏れていた可能性のあるトークンを無効化する
-  # （アクセストークンも新規発行し、Cookie を入れ替える）。
-  def self.convert_trial(user, params)
+  # セキュリティ: 昇格（権限変化）時は全セッションを失効させてから
+  # 新しいセッションを発行し、旧トライアル時に漏れていた可能性のある
+  # トークンをすべて無効化する。
+  def self.convert_trial(user, params, user_agent: nil, ip_address: nil)
     raise RegistrationError, "すでに本登録済みのアカウントです。" unless user.trial_user?
 
     user.email = params[:email]&.downcase
@@ -99,10 +93,9 @@ class AuthService
     user.trial_user = false
 
     if user.save
+      revoke_all_sessions(user)
       access_token = encode_token(user.id)
-      refresh_token = generate_refresh_token
-      # バリデーションとコールバックをスキップして refresh_token のみを更新（旧トークンは即無効化）
-      user.update_column(:refresh_token, refresh_token)
+      refresh_token = create_session(user, user_agent: user_agent, ip_address: ip_address)
       Rails.logger.info "ユーザーID: #{user.id} をトライアルから本登録へ昇格しました。" if Rails.env.development?
       { access_token: access_token, refresh_token: refresh_token, user: user }
     else
@@ -145,37 +138,66 @@ class AuthService
     end
   end
 
-  # リフレッシュトークンを生成
-  def self.refresh_token(refresh_token)
+  # refresh token を検証し、access/refresh 両トークンをローテーションする
+  def self.refresh_token(refresh_token, user_agent: nil, ip_address: nil)
     Rails.logger.info "リフレッシュトークンを検証します。" if Rails.env.development?
-    user = find_user_by_refresh_token(refresh_token)
-    new_access_token = encode_token(user.id)
-    new_refresh_token = generate_refresh_token
-    # バリデーションとコールバックをスキップして refresh_token のみを更新
-    user.update_column(:refresh_token, new_refresh_token)
-    Rails.logger.info "ユーザーID: #{user.id} のリフレッシュトークンを更新・保存しました。" if Rails.env.development?
-    { access_token: new_access_token, refresh_token: new_refresh_token }
-  rescue ActiveRecord::RecordInvalid => e # update_column は RecordInvalid を発生させないが、念のため残す
+    raise InvalidRefreshTokenError, 'リフレッシュトークンがありません' if refresh_token.blank?
+
+    session = UserSession.find_active_by_token(refresh_token)
+
+    if session
+      new_refresh_token = generate_refresh_token
+      session.rotate!(new_refresh_token, lifetime: refresh_token_lifetime)
+      { access_token: encode_token(session.user_id), refresh_token: new_refresh_token }
+    else
+      # レガシー互換: 旧 users.refresh_token（平文カラム）と照合し、
+      # 一致したらその場で user_sessions へ透過的に移行する。
+      # デプロイ前からログイン中のユーザーを強制ログアウトさせないための一時パス。
+      user = find_user_by_legacy_refresh_token(refresh_token)
+      user.update_column(:refresh_token, nil)
+      new_refresh_token = create_session(user, user_agent: user_agent, ip_address: ip_address)
+      Rails.logger.info "ユーザーID: #{user.id} のレガシートークンをセッションへ移行しました。"
+      { access_token: encode_token(user.id), refresh_token: new_refresh_token }
+    end
+  rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error "リフレッシュトークン検証成功後、DB更新に失敗: #{e.message}"
     raise InvalidRefreshTokenError, "トークンリフレッシュ処理中にエラーが発生しました。"
   end
 
-  # リフレッシュトークンからユーザーを検索
-  def self.find_user_by_refresh_token(refresh_token)
-    Rails.logger.info "リフレッシュトークンからユーザーを検索します。" if Rails.env.development?
+  # ログアウト: 該当セッションのみ失効させる（他端末のセッションは維持）
+  def self.revoke_session(refresh_token)
     raise InvalidRefreshTokenError, 'リフレッシュトークンがありません' if refresh_token.blank?
 
-    user = User.find_by(refresh_token: refresh_token)
-
-    Rails.logger.info "User.find_by(refresh_token: ...)の結果: #{user&.id || 'nil'}" if Rails.env.development?
-
-    if user.nil?
-      Rails.logger.warn "リフレッシュトークンがデータベースに存在しません (token_prefix=#{refresh_token.to_s[0..7]}...)"
-      raise InvalidRefreshTokenError, '無効なリフレッシュトークン'
+    session = UserSession.find_active_by_token(refresh_token)
+    if session
+      session.revoke!
+      return true
     end
 
-    Rails.logger.info "ユーザーが見つかりました: ユーザー ID: #{user.id}" if Rails.env.development?
-    user
+    # レガシー互換: 旧カラムのトークンでのログアウト
+    user = find_user_by_legacy_refresh_token(refresh_token)
+    user.update_column(:refresh_token, nil)
+    true
+  end
+
+  # 全セッション失効（trial昇格・パスワード変更などの権限変化時に使う）
+  def self.revoke_all_sessions(user)
+    user.user_sessions.active.update_all(revoked_at: Time.current)
+    user.update_column(:refresh_token, nil) if user.refresh_token.present?
+  end
+
+  # 新しいセッションを作成し、生の refresh token を返す（DBには digest のみ保存）
+  def self.create_session(user, user_agent: nil, ip_address: nil)
+    token = generate_refresh_token
+    user.user_sessions.create!(
+      refresh_token_digest: UserSession.digest(token),
+      expires_at: refresh_token_lifetime.from_now,
+      user_agent: user_agent&.slice(0, 255),
+      ip_address: ip_address,
+      last_used_at: Time.current
+    )
+    UserSession.prune_for(user)
+    token
   end
 
   # リフレッシュトークンを生成
@@ -183,7 +205,21 @@ class AuthService
     SecureRandom.urlsafe_base64(64)
   end
 
-  private
+  # 旧 users.refresh_token カラムからユーザーを検索（レガシー互換パス）
+  # burn-in 後にカラムごと削除予定（docs/auth-hardening-spec.md）
+  def self.find_user_by_legacy_refresh_token(refresh_token)
+    user = User.find_by(refresh_token: refresh_token)
+    if user.nil?
+      Rails.logger.warn "リフレッシュトークンが無効です (token_prefix=#{refresh_token.to_s[0..7]}...)"
+      raise InvalidRefreshTokenError, '無効なリフレッシュトークン'
+    end
+    user
+  end
+
+  # refresh token の有効期間（ローテーション時にスライド延長）
+  def self.refresh_token_lifetime
+    ENV.fetch('REFRESH_TOKEN_EXPIRATION_DAYS', '30').to_i.days
+  end
 
   # JWTの有効期限を環境変数で設定する
   def self.jwt_expiration_time

--- a/backend/db/migrate/20260707000000_create_user_sessions.rb
+++ b/backend/db/migrate/20260707000000_create_user_sessions.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# refresh token を users.refresh_token（平文・1本のみ）から
+# user_sessions テーブル（digest保存・多端末対応・失効管理つき）へ移行する基盤。
+# 設計: docs/auth-hardening-spec.md（PR1）
+#
+# users.refresh_token カラムはレガシー互換（デプロイ後もログイン中ユーザーを
+# 強制ログアウトさせないための移行パス）に使うため、このPRでは削除しない。
+class CreateUserSessions < ActiveRecord::Migration[7.1]
+  def up
+    create_table :user_sessions do |t|
+      t.references :user, null: false, foreign_key: true
+      # SHA256(token) を保存。平文トークンはDBに置かない
+      t.string   :refresh_token_digest, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :revoked_at
+      t.string   :user_agent
+      t.string   :ip_address
+      t.datetime :last_used_at
+      t.timestamps
+    end
+    add_index :user_sessions, :refresh_token_digest, unique: true
+
+    # 他テーブル（dream_profiles 等）と同じ方針:
+    # Rails API のみが postgres ロール（BYPASSRLS）で接続するため、
+    # RLS有効化＋ポリシーなし＝PostgREST からの直接アクセスを全遮断（Default Deny）
+    execute "ALTER TABLE public.user_sessions ENABLE ROW LEVEL SECURITY;"
+  end
+
+  def down
+    drop_table :user_sessions
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_04_000000) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_07_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -150,6 +150,20 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_04_000000) do
     t.index ["user_id"], name: "index_subscriptions_on_user_id"
   end
 
+  create_table "user_sessions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "refresh_token_digest", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "revoked_at"
+    t.string "user_agent"
+    t.string "ip_address"
+    t.datetime "last_used_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["refresh_token_digest"], name: "index_user_sessions_on_refresh_token_digest", unique: true
+    t.index ["user_id"], name: "index_user_sessions_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -186,4 +200,5 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_04_000000) do
   add_foreign_key "dreams", "users"
   add_foreign_key "payments", "users"
   add_foreign_key "subscriptions", "users"
+  add_foreign_key "user_sessions", "users"
 end

--- a/backend/spec/factories/user_sessions.rb
+++ b/backend/spec/factories/user_sessions.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :user_session do
+    association :user
+    refresh_token_digest { UserSession.digest(SecureRandom.urlsafe_base64(64)) }
+    expires_at { 30.days.from_now }
+    last_used_at { Time.current }
+
+    trait :revoked do
+      revoked_at { 1.hour.ago }
+    end
+
+    trait :expired do
+      expires_at { 1.hour.ago }
+    end
+  end
+end

--- a/backend/spec/models/user_session_spec.rb
+++ b/backend/spec/models/user_session_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe UserSession, type: :model do
+  let(:user) { create(:user) }
+
+  describe 'バリデーション' do
+    it { should belong_to(:user) }
+    it { should validate_presence_of(:refresh_token_digest) }
+    it { should validate_presence_of(:expires_at) }
+  end
+
+  describe '.digest' do
+    it '同じトークンからは常に同じdigestが得られる（等値検索可能）' do
+      expect(UserSession.digest('token-a')).to eq(UserSession.digest('token-a'))
+    end
+
+    it 'トークン本文とdigestは一致しない（平文保存しない）' do
+      expect(UserSession.digest('token-a')).not_to eq('token-a')
+    end
+  end
+
+  describe '.find_active_by_token' do
+    let(:token) { SecureRandom.urlsafe_base64(64) }
+    let!(:session) do
+      create(:user_session, user: user, refresh_token_digest: UserSession.digest(token))
+    end
+
+    it '有効なセッションを引ける' do
+      expect(UserSession.find_active_by_token(token)).to eq(session)
+    end
+
+    it 'blank なら nil' do
+      expect(UserSession.find_active_by_token(nil)).to be_nil
+      expect(UserSession.find_active_by_token('')).to be_nil
+    end
+
+    it '失効済みセッションは引けない' do
+      session.revoke!
+      expect(UserSession.find_active_by_token(token)).to be_nil
+    end
+
+    it '期限切れセッションは引けない' do
+      session.update!(expires_at: 1.minute.ago)
+      expect(UserSession.find_active_by_token(token)).to be_nil
+    end
+  end
+
+  describe '.prune_for' do
+    it '上限を超えた古いセッションを失効させる' do
+      sessions = Array.new(UserSession::MAX_ACTIVE_SESSIONS + 2) do |i|
+        create(:user_session, user: user, created_at: i.minutes.ago)
+      end
+
+      UserSession.prune_for(user)
+
+      expect(user.user_sessions.active.count).to eq(UserSession::MAX_ACTIVE_SESSIONS)
+      # 最も古い2件が失効している
+      expect(sessions.last(2).map { |s| s.reload.revoked_at }).to all(be_present)
+    end
+  end
+
+  describe '#rotate!' do
+    let(:old_token) { SecureRandom.urlsafe_base64(64) }
+    let(:session) do
+      create(:user_session, user: user, refresh_token_digest: UserSession.digest(old_token))
+    end
+
+    it 'digestを新トークンのものへ差し替え、旧トークンを無効化する' do
+      new_token = SecureRandom.urlsafe_base64(64)
+      session.rotate!(new_token, lifetime: 30.days)
+
+      expect(UserSession.find_active_by_token(new_token)).to eq(session)
+      expect(UserSession.find_active_by_token(old_token)).to be_nil
+      expect(session.reload.last_used_at).to be_present
+    end
+  end
+end

--- a/backend/spec/requests/auth_sessions_spec.rb
+++ b/backend/spec/requests/auth_sessions_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+
+# user_sessions テーブル導入後のセッション管理の振る舞い
+# （多端末ログイン・トークンローテーション・端末別ログアウト・レガシー移行）
+RSpec.describe 'Auth sessions (refresh token digest)', type: :request do
+  let!(:user) { create(:user, email: 'session@example.com') }
+  let(:host) { { 'HOST' => 'backend' } }
+
+  def login!
+    post '/auth/login', params: { email: user.email, password: 'password123' }, as: :json, headers: host
+    expect(response).to have_http_status(:ok)
+    response.cookies['refresh_token']
+  end
+
+  def refresh_with(token)
+    post '/auth/refresh', headers: host.merge('Cookie' => "refresh_token=#{token}"), as: :json
+  end
+
+  describe 'ログイン' do
+    it 'user_sessions レコードが作成され、DBにはdigestのみ保存される' do
+      raw_token = nil
+      expect { raw_token = login! }.to change(UserSession, :count).by(1)
+
+      session = user.user_sessions.last
+      expect(session.refresh_token_digest).not_to eq(raw_token)
+      expect(UserSession.find_active_by_token(raw_token)).to eq(session)
+      expect(session.expires_at).to be > Time.current
+    end
+
+    it '2回ログインしても先のセッションは生きている（多端末対応）' do
+      token_a = login!
+      token_b = login!
+
+      expect(user.user_sessions.active.count).to eq(2)
+      expect(UserSession.find_active_by_token(token_a)).to be_present
+      expect(UserSession.find_active_by_token(token_b)).to be_present
+    end
+
+    it '有効セッションは上限件数まで（超過分は古い順に失効）' do
+      (UserSession::MAX_ACTIVE_SESSIONS + 2).times { login! }
+      expect(user.user_sessions.active.count).to eq(UserSession::MAX_ACTIVE_SESSIONS)
+    end
+  end
+
+  describe 'POST /auth/refresh' do
+    it 'トークンがローテーションされ、旧トークンは使えなくなる' do
+      old_token = login!
+
+      refresh_with(old_token)
+      expect(response).to have_http_status(:ok)
+      new_token = response.cookies['refresh_token']
+      expect(new_token).not_to eq(old_token)
+
+      # 旧トークンでの再リフレッシュは拒否される
+      refresh_with(old_token)
+      expect(response).to have_http_status(:unauthorized)
+
+      # 新トークンは有効
+      refresh_with(new_token)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it '失効済みセッションのトークンは 401' do
+      token = login!
+      UserSession.find_active_by_token(token).revoke!
+
+      refresh_with(token)
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it '期限切れセッションのトークンは 401' do
+      token = login!
+      UserSession.find_active_by_token(token).update!(expires_at: 1.minute.ago)
+
+      refresh_with(token)
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'レガシー（users.refresh_token）のトークンはセッションへ透過的に移行される' do
+      legacy_token = SecureRandom.urlsafe_base64(64)
+      user.update_column(:refresh_token, legacy_token)
+
+      expect { refresh_with(legacy_token) }.to change(UserSession, :count).by(1)
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.refresh_token).to be_nil
+
+      # 発行された新トークンで継続利用できる
+      refresh_with(response.cookies['refresh_token'])
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'POST /auth/logout' do
+    it '該当セッションだけが失効し、他端末のセッションは維持される' do
+      token_a = login!
+      token_b = login!
+
+      post '/auth/logout', headers: host.merge('Cookie' => "refresh_token=#{token_a}"), as: :json
+      expect(response).to have_http_status(:ok)
+
+      expect(UserSession.find_active_by_token(token_a)).to be_nil
+      expect(UserSession.find_active_by_token(token_b)).to be_present
+    end
+  end
+
+  describe 'PATCH /auth/convert_trial' do
+    let!(:trial_user) do
+      create(:user, trial_user: true, email: 'trial-session@example.com', password: 'password123',
+                    password_confirmation: 'password123')
+    end
+
+    it '昇格時に旧セッションが全て失効し、新セッションだけが有効になる' do
+      post '/auth/login', params: { email: trial_user.email, password: 'password123' }, as: :json, headers: host
+      old_token = response.cookies['refresh_token']
+      access_token = response.cookies['access_token']
+
+      patch '/auth/convert_trial',
+            params: { user: { email: 'converted@example.com', username: 'converted',
+                              password: 'newpass123', password_confirmation: 'newpass123' } },
+            headers: host.merge('Cookie' => "access_token=#{access_token}; refresh_token=#{old_token}"),
+            as: :json
+      expect(response).to have_http_status(:ok)
+
+      expect(UserSession.find_active_by_token(old_token)).to be_nil
+      new_token = response.cookies['refresh_token']
+      expect(UserSession.find_active_by_token(new_token)).to be_present
+      expect(UserSession.find_active_by_token(new_token).user).to eq(trial_user)
+    end
+  end
+end

--- a/backend/spec/requests/auth_spec.rb
+++ b/backend/spec/requests/auth_spec.rb
@@ -321,15 +321,18 @@ RSpec.describe 'Authentication API', type: :request do
       expect(trial_user.authenticate('newpass123')).to be_truthy
     end
 
-    it '昇格時に refresh_token をローテーションして旧トークンを無効化する' do
+    it '昇格時にセッションをローテーションして旧トークンを無効化する' do
+      # レガシーカラムのトークンも昇格時にまとめて無効化される
       trial_user.update_column(:refresh_token, 'old-trial-refresh-token')
 
       authenticated_patch('/auth/convert_trial', trial_user, params: convert_params)
       expect(response).to have_http_status(:ok)
 
       trial_user.reload
-      expect(trial_user.refresh_token).to be_present
-      expect(trial_user.refresh_token).not_to eq('old-trial-refresh-token')
+      expect(trial_user.refresh_token).to be_nil
+      # 新しいセッションが1件だけ有効になっている
+      # （authenticated_patch のログインで作られたセッションは昇格時に失効済み）
+      expect(trial_user.user_sessions.active.count).to eq(1)
     end
 
     it '昇格しても同じ user.id のまま夢・プロフィールが引き継がれる' do

--- a/backend/spec/services/auth_service_spec.rb
+++ b/backend/spec/services/auth_service_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+# Codexレビュー(#414 P2)対応の回帰確認。
+# レガシー refresh token（users.refresh_token）は使い捨てのはずだが、
+# 素朴な find→update だと並列リクエストが両方とも nullify 前に同じユーザーを
+# 読んでしまい、1本のトークンから複数セッションが生成されてしまう。
+#
+# 実スレッドでの競合再現は Ruby の GVL とローカルDBの高速な往復のせいで
+# ウィンドウが狭すぎて安定的に踏めない（検証済み: 素朴実装に戻しても
+# 単純なスレッド+バリアでは3回中3回とも競合が再現しなかった）。
+# そのため、find_by が返った直後・with_lock に入る前に「別リクエストが
+# 先に消費した」状態を確定的に作り出し、ロック後の再読込チェックが
+# 効いていることを直接検証する。
+RSpec.describe AuthService, type: :service do
+  describe '.consume_legacy_refresh_token' do
+    let(:legacy_token) { SecureRandom.urlsafe_base64(64) }
+    let!(:user) { create(:user) }
+
+    before { user.update_column(:refresh_token, legacy_token) }
+
+    it '通常時は消費に成功し、トークンをnullifyしてユーザーを返す' do
+      consumed = AuthService.consume_legacy_refresh_token(legacy_token)
+
+      expect(consumed).to eq(user)
+      expect(user.reload.refresh_token).to be_nil
+    end
+
+    it '存在しないトークンは InvalidRefreshTokenError' do
+      expect {
+        AuthService.consume_legacy_refresh_token('bogus-token')
+      }.to raise_error(AuthService::InvalidRefreshTokenError)
+    end
+
+    it '2回目の消費は失敗する（同一トークンの使い回し不可）' do
+      AuthService.consume_legacy_refresh_token(legacy_token)
+
+      expect {
+        AuthService.consume_legacy_refresh_token(legacy_token)
+      }.to raise_error(AuthService::InvalidRefreshTokenError)
+    end
+
+    context 'find_by 直後・with_lock に入る前に、別リクエストが先に消費していた場合' do
+      before do
+        # find_by が user オブジェクトを返した「直後」に割り込み、
+        # 実DBの行を別トランザクションが既に nullify 済みの状態にする。
+        # with_lock の再読込チェックがなければ、ここで二重に消費されてしまう。
+        allow(User).to receive(:find_by).with(refresh_token: legacy_token).and_wrap_original do |original, *args|
+          result = original.call(*args)
+          User.where(id: result.id).update_all(refresh_token: nil) if result
+          result
+        end
+      end
+
+      it '不一致を検知して InvalidRefreshTokenError になり、update_column を呼ばない' do
+        expect {
+          AuthService.consume_legacy_refresh_token(legacy_token)
+        }.to raise_error(AuthService::InvalidRefreshTokenError)
+      end
+
+      it 'セッションを作らない（refresh_token 経由で呼んだ場合も二重発行されない）' do
+        expect {
+          begin
+            AuthService.refresh_token(legacy_token)
+          rescue AuthService::InvalidRefreshTokenError
+            nil
+          end
+        }.not_to change(UserSession, :count)
+      end
+    end
+  end
+end

--- a/docs/auth-hardening-spec.md
+++ b/docs/auth-hardening-spec.md
@@ -1,0 +1,103 @@
+# 認証強化 設計仕様（2026-07）
+
+7月計画「守りのMust」の一環。世界観MVPに進む前に、ユーザーが増えたとき困らない
+セッション管理とメール有効化を**小さいPRの連続**で固める。
+
+## 現状の課題（2026-07時点の実装調査）
+
+現行は Rails 標準セッションではなく、`access_token`（JWT・短命）＋`refresh_token` を
+HttpOnly Cookie に入れる独自方式（`AuthService` / `ApplicationController#set_token_cookies`）。
+方式自体は Next.js + Rails API 構成として妥当だが、refresh token の管理が弱い:
+
+| # | 課題 | リスク |
+|---|------|--------|
+| 1 | `users.refresh_token` 1カラムのみ | 端末Aでログインすると端末Bのセッションが即死（多端末不可）。端末別ログアウト不可 |
+| 2 | refresh token がDBに**平文**保存 | DBが読まれた場合、全ユーザーのセッションを乗っ取れる |
+| 3 | 失効時刻・端末情報・最終利用時刻なし | 無期限に有効。不審セッションの調査・失効ができない |
+| 4 | メール有効化なし | 他人のメールアドレスで登録できる。到達しないメールへ課金領収書等を送るリスク |
+| 5 | パスワードリセットトークンが平文カラム | 課題2と同種（既存機能。本仕様のフォローアップで対応） |
+
+## 方針
+
+- **総入れ替えはしない**。JWT access token / Cookie 運用 / フロントの `AuthContext` 契約
+  （エンドポイント・Cookie名・レスポンス形）は維持する。
+- Rails 8 の公式 authentication generator が採用する「User と別に Session モデルを持つ」
+  構成に寄せる。Devise への全面移行は trial conversion フローと衝突するため見送り。
+- 既存ログイン中ユーザーを**デプロイで強制ログアウトさせない**（レガシー互換パスを一時併存）。
+
+## PR1: `user_sessions` テーブル + refresh token digest 化
+
+### スキーマ
+
+```ruby
+create_table :user_sessions do |t|
+  t.references :user, null: false, foreign_key: true
+  t.string   :refresh_token_digest, null: false  # SHA256(token) を保存。平文は保存しない
+  t.datetime :expires_at, null: false            # デフォルト30日（REFRESH_TOKEN_EXPIRATION_DAYS）
+  t.datetime :revoked_at                          # 端末別ログアウト・強制失効
+  t.string   :user_agent
+  t.string   :ip_address
+  t.datetime :last_used_at
+  t.timestamps
+end
+add_index :user_sessions, :refresh_token_digest, unique: true
+# 他テーブル同様に RLS 有効化（Default Deny）
+```
+
+digest は bcrypt ではなく **SHA256**。refresh token は128bit以上のランダム値なので
+レインボーテーブル耐性は entropy 側で担保され、インデックスによる等値検索が必要なため。
+
+### フロー変更
+
+- **login / register / trial_login**: `users.refresh_token` 更新をやめ、`user_sessions` に
+  新規セッションを作成（多端末対応）。1ユーザーの有効セッションは最大5件。超過時は古い順に失効。
+- **refresh**: digest 一致 & 未失効 & 未期限切れのセッションを検索し、トークンをローテーション
+  （digest を新値に更新、`last_used_at` 更新、期限をスライド延長）。
+- **convert_trial**: 全セッション失効 + 新セッション発行（権限変化時の全ローテーション）。
+- **logout**: 該当セッションのみ `revoked_at` を打つ（他端末は生き続ける）。
+- **レガシー互換**: セッションが見つからない場合のみ旧 `users.refresh_token`（平文）と照合し、
+  一致したらその場で `user_sessions` へ移行して旧カラムを `nil` 化。
+  デプロイ後もログイン中ユーザーは次回 refresh 時に透過的に新方式へ移る。
+
+### 後続クリーンアップ（別PR・burn-in後）
+
+- `users.refresh_token` カラムの削除（レガシー互換パスの削除と同時）
+- 期限切れ・失効セッションの定期削除（rake or migration）
+
+## PR2: メールアドレス有効化（account activation）
+
+### スキーマ
+
+```ruby
+add_column :users, :email_verified_at, :datetime
+add_column :users, :email_verification_token_digest, :string
+add_column :users, :email_verification_sent_at, :datetime
+add_index  :users, :email_verification_token_digest, unique: true
+# 既存ユーザーは grandfather（email_verified_at = NOW() でバックフィル）
+```
+
+### フロー
+
+- **register**: 未認証状態で作成し、検証メールを送信（`deliver_later`・失敗しても登録は成功）。
+- **trial_login**: メール検証しない（トライアルは実メール不要のまま）。
+- **convert_trial**: 新メールは未認証扱いにして検証メールを送信。
+- **POST /auth/verify_email**（token）: digest 照合→`email_verified_at` を打つ。token は24時間有効。
+- **POST /auth/resend_verification**（認証必須）: 前回送信から5分以上で再送可。
+- **段階制御**: 未認証でも閲覧・夢作成は可。**課金（POST /checkout）のみ検証必須**
+  （既存ユーザーは grandfather 済みなので影響なし）。
+- **フロント**: `/verify-email` ページ（公開・robots除外）。`user_json` に `email_verified` を追加し
+  バナー表示等はフロント側の後続対応とする。
+
+### メール配信基盤
+
+Action Mailer は導入済み（パスワードリセットで使用中）。本番の配信サービスは
+**Resend**（Rails 公式手順あり・無料枠100通/日）を第一候補、Postmark / Amazon SES を代替とする。
+本番送信には環境変数（SMTP認証情報・From アドレス）の設定が必要 → **ユーザー作業**。
+未設定でも登録自体は失敗しない設計にする（メール送信は best-effort + ログ）。
+
+## フォローアップ（本仕様のスコープ外・優先度順）
+
+1. パスワードリセットトークンの digest 化（PR1と同じパターン）
+2. `users.refresh_token` カラム削除
+3. メール変更時の再検証フロー
+4. セッション一覧・端末別ログアウトUI（EM/テックリード志向のポートフォリオ素材として良い）


### PR DESCRIPTION
## 概要

7月計画「守りのMust」の認証強化・第1弾。`users.refresh_token`（**平文・1本のみ**）による refresh token 管理を、`user_sessions` テーブル（**SHA256 digest保存・多端末対応・失効/期限管理つき**）へ移行する。

設計全体は同梱の [docs/auth-hardening-spec.md](docs/auth-hardening-spec.md) を参照（PR2のメール有効化仕様も含む）。

## 現状の課題（このPRで解消するもの）

| 課題 | リスク |
|---|---|
| refresh token が1カラムのみ | 端末Aでログインすると端末Bが即死（多端末不可）・端末別ログアウト不可 |
| DBに平文保存 | DBが読まれた場合に全ユーザーのセッションを乗っ取れる |
| 失効時刻・端末情報なし | 無期限に有効・不審セッションの調査/失効ができない |

## 変更内容

### スキーマ
- `user_sessions` テーブル新設: `refresh_token_digest`(unique) / `expires_at` / `revoked_at` / `user_agent` / `ip_address` / `last_used_at`
- 他テーブル同様 **RLS有効化**（Default Deny・Rails は BYPASSRLS で接続）
- `users.refresh_token` カラムは**レガシー互換のため残置**（下記参照。削除は burn-in 後の別PR）

### 挙動
- **login/register/trial_login**: セッションを追加作成（多端末対応）。有効セッション上限5件、超過は古い順に自動失効
- **refresh**: digest照合 → トークンローテーション＋期限スライド延長（`REFRESH_TOKEN_EXPIRATION_DAYS`、デフォルト30日）
- **logout**: 該当セッションのみ失効（他端末は生き続ける＝端末別ログアウト）
- **convert_trial**: 全セッション失効＋新規発行（権限変化時の全ローテーション）
- **レガシー互換**: セッション未ヒット時のみ旧 `users.refresh_token` と照合し、一致したらその場で `user_sessions` へ透過移行して旧カラムをnil化。**デプロイしても既存ログイン中ユーザーは切れない**

### digest方式について
bcryptではなく**SHA256**を採用。refresh token は512bitのランダム値なのでレインボーテーブル耐性はentropy側で担保され、インデックスによる等値検索が必要なため（Rails 8公式のauthentication generatorと同じ考え方）。

### フロント影響
**なし**。エンドポイント・Cookie名・レスポンス形は完全に維持。

## 触っていない領域
Stripe / UI / OpenAI / メール。パスワードリセットトークンのdigest化はフォローアップ（spec参照）。

## 検証結果

Docker環境（`backend-test`サービス）で実行:

```
bundle exec rails db:migrate RAILS_ENV=test
# => create_table(:user_sessions) + RLS有効化 成功

bundle exec rspec spec/models/user_session_spec.rb spec/requests/auth_sessions_spec.rb
# => 20 examples, 0 failures（多端末/ローテーション/失効/期限切れ/レガシー移行/上限prune）

bundle exec rspec
# => 322 examples, 0 failures（全suite緑）
```

既存specの修正は1件のみ: convert_trial の「refresh_tokenカラムがローテーションされる」を「セッションがローテーションされる」に更新（新仕様への追従）。

## マージ後の確認手順

1. デプロイ後、ログイン → Supabaseで `SELECT count(*) FROM user_sessions;` が増えること
2. `SELECT refresh_token_digest FROM user_sessions LIMIT 1;` が64文字hex（平文でない）こと
3. **デプロイ前からログイン中の端末**がログアウトされずに使い続けられること（レガシー透過移行の確認）

---

## 追記: Codexレビュー(P2)対応

**指摘**: レガシー `users.refresh_token`（平文カラム）の消費が `find_by` → `update_column` の素朴な2ステップだったため、ロールアウト直後に期限切れアクセストークンが引き金となって同一クライアントから並列に `/auth/refresh` が飛ぶと、両リクエストが nullify 前に同じユーザーを読んでしまい、1本の使い捨てレガシートークンから複数の `user_sessions` が作られうる状態だった。

**対応**:
- `find_user_by_legacy_refresh_token` を `consume_legacy_refresh_token` に置き換え、`with_lock`（行ロック）内で再読込・値の再確認をしてから nullify するアトミックな実装に変更
- ロック取得後、他リクエストが先に消費済みなら `refresh_token` の値が一致しなくなるため、確実に `InvalidRefreshTokenError` で弾かれる
- `refresh_token` / `revoke_session` の両呼び出し元を新メソッドに統一（重複していた `update_column` 呼び出しも解消）

**テストについて**: 実スレッド+バリアでの競合再現を試したが、RubyのGVLとローカルDBの高速な往復のためレース窓が狭すぎて安定再現できなかった（3回中3回とも素朴実装のバグを検出できず）。代わりに `find_by` 直後・`with_lock` に入る前に「別リクエストが先に消費済み」の状態を確定的に作り出すテストを追加。**このテストが素朴実装（修正前）に対しては確実に失敗し、修正後は通過することを手動で相互検証済み**。

**検証結果**: `bundle exec rspec` で327 examples, 0 failures（既存322 + 新規5）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
