### PR TITLE
feat: メールアドレス未確認バナーをホーム画面に追加

### DIFF
--- a/frontend/__tests__/components/EmailVerificationBanner.test.tsx
+++ b/frontend/__tests__/components/EmailVerificationBanner.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import EmailVerificationBanner from "@/app/components/EmailVerificationBanner";
+import { resendVerificationEmail, ApiError } from "@/lib/apiClient";
+
+jest.mock("@/lib/apiClient", () => {
+  class ApiError extends Error {
+    status!: number;
+  }
+  return {
+    resendVerificationEmail: jest.fn(),
+    ApiError,
+  };
+});
+
+const mockResend = resendVerificationEmail as jest.Mock;
+
+describe("EmailVerificationBanner", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("メール未確認のお知らせと再送ボタンを表示する", () => {
+    render(<EmailVerificationBanner />);
+
+    expect(
+      screen.getByText("メールアドレスの かくにんが まだだよ")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "かくにんメールを もういちど おくる" })
+    ).toBeInTheDocument();
+  });
+
+  it("再送ボタンを押すと送信中表示になり、成功したら完了メッセージに切り替わる", async () => {
+    const user = userEvent.setup();
+    mockResend.mockResolvedValue({ message: "確認メールを送りました" });
+
+    render(<EmailVerificationBanner />);
+    await user.click(
+      screen.getByRole("button", { name: "かくにんメールを もういちど おくる" })
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("かくにんメールを おくったよ。うけとりボックスを みてね。")
+      ).toBeInTheDocument();
+    });
+    expect(mockResend).toHaveBeenCalledTimes(1);
+  });
+
+  it("送信に失敗したらエラーメッセージを表示し、再送ボタンに戻る", async () => {
+    const user = userEvent.setup();
+    const error = new ApiError("確認メールを送信済みです。少し待ってからもう一度お試しください。");
+    error.status = 429;
+    mockResend.mockRejectedValue(error);
+
+    render(<EmailVerificationBanner />);
+    await user.click(
+      screen.getByRole("button", { name: "かくにんメールを もういちど おくる" })
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("確認メールを送信済みです。少し待ってからもう一度お試しください。")
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: "かくにんメールを もういちど おくる" })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/app/components/EmailVerificationBanner.tsx
+++ b/frontend/app/components/EmailVerificationBanner.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { Mail } from "lucide-react";
+import { resendVerificationEmail } from "@/lib/apiClient";
+import { ApiError } from "@/lib/apiClient";
+
+type SendState = "idle" | "sending" | "sent";
+
+/**
+ * メールアドレス未確認ユーザー向けのお知らせバナー。
+ * 確認メールの再送ボタンを備える（backend側で5分間隔の再送制限あり）。
+ */
+export default function EmailVerificationBanner() {
+  const [state, setState] = useState<SendState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleResend = async () => {
+    setState("sending");
+    setErrorMessage(null);
+    try {
+      await resendVerificationEmail();
+      setState("sent");
+    } catch (err) {
+      setState("idle");
+      setErrorMessage(
+        err instanceof ApiError
+          ? err.message
+          : "かくにんメールを おくれなかったよ。もういちど ためしてね。"
+      );
+    }
+  };
+
+  return (
+    <div
+      role="region"
+      aria-label="メールアドレス確認のお知らせ"
+      className="mb-4 w-full rounded-2xl border border-primary/30 bg-primary/5 p-4"
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <Mail size={16} className="text-primary" aria-hidden="true" />
+        <p className="text-sm font-medium text-foreground">
+          メールアドレスの かくにんが まだだよ
+        </p>
+      </div>
+
+      <p className="text-sm text-muted-foreground mb-3">
+        とどいた メールの リンクを ひらいて、かくにんを かんりょうしてね。
+      </p>
+
+      {state === "sent" ? (
+        <p className="text-sm font-bold text-primary">
+          かくにんメールを おくったよ。うけとりボックスを みてね。
+        </p>
+      ) : (
+        <button
+          type="button"
+          onClick={handleResend}
+          disabled={state === "sending"}
+          className="inline-flex min-h-11 items-center gap-2 rounded-xl bg-primary px-5 py-2.5 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-60"
+        >
+          {state === "sending" ? "おくっているよ…" : "かくにんメールを もういちど おくる"}
+        </button>
+      )}
+
+      {errorMessage && (
+        <p className="mt-2 text-sm text-destructive">{errorMessage}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -16,6 +16,7 @@ import SearchBar from "@/app/components/SearchBar";
 import ProfileFilterChips from "@/app/components/ProfileFilterChips";
 import DreamEntryLauncher from "@/app/components/DreamEntryLauncher";
 import TrialBanner from "@/app/components/TrialBanner";
+import EmailVerificationBanner from "@/app/components/EmailVerificationBanner";
 import DreamAdventurePanel from "@/app/components/DreamAdventurePanel";
 import ForestPreviewWidget from "@/app/components/forest/ForestPreviewWidget";
 import { MorpheusGuideHome } from "@/app/components/MorpheusGuide";
@@ -319,6 +320,10 @@ export default function HomePage() {
             analysisCount={user.trial_analysis_count}
             audioCount={user.trial_audio_count}
           />
+        )}
+        {/* メール未確認の本登録ユーザー向けバナー（トライアルはメール検証対象外） */}
+        {user && !user.trial_user && user.email_verified === false && (
+          <EmailVerificationBanner />
         )}
         <MorpheusHero
           expression="cheerful"

--- a/frontend/app/types.ts
+++ b/frontend/app/types.ts
@@ -29,6 +29,7 @@ export interface User {
   trial_user?: boolean;          // お試しユーザーかどうか
   trial_analysis_count?: number; // お試しのAI分析 使用回数
   trial_audio_count?: number;    // お試しの音声記録 使用回数
+  email_verified?: boolean;      // メールアドレス確認済みかどうか
 }
 
 // Backendから直接受け取るユーザー情報の型。IDは数値。
@@ -44,6 +45,7 @@ export interface BackendUser {
   trial_user?: boolean;
   trial_analysis_count?: number;
   trial_audio_count?: number;
+  email_verified?: boolean;
 }
 
 export interface Emotion {


### PR DESCRIPTION
## 概要

[#415](https://github.com/isekaisaru/dreamjournal-app/pull/415)で追加したバックエンドのメール有効化機能に対して、フロント側が`user_json`の`email_verified`を一切参照していなかったギャップを埋める。未検証ユーザーがホームで気づいて再送できるようにする、自己完結したフロントUI実装。

## 変更内容

- `frontend/app/components/EmailVerificationBanner.tsx`: メール未確認時のお知らせバナー＋再送ボタン。既存の`TrialBanner`と同じスタイルパターン（`role="region"`・カード・CTAボタン）を踏襲
  - 送信中/送信完了/エラーの3状態を管理
  - エラーメッセージは`ApiError.message`をそのまま表示（backendの429レート制限メッセージ等がそのまま出る）
- `frontend/app/home/page.tsx`: `user && !user.trial_user && user.email_verified === false` の条件でバナーを表示。トライアルユーザーはメール検証対象外のため除外
- `frontend/app/types.ts`: `User` / `BackendUser` 型に `email_verified?: boolean` を追加

## 触っていない領域
バックエンド・Stripe・OpenAI・既存コンポーネント（新規バナーの追加のみ、他のバナー表示ロジックは変更なし）。

## 検証結果

```
yarn test
# => 49 suites / 362 tests, all passed（新規3件含む）
```

実ブラウザ（本worktreeのfrontend dev server + Docker dev backend on port 3002）で目視確認:
- 初期表示: アイコン・見出し・説明文・再送ボタンが意図通り表示される
- 再送ボタンクリック → エラー時: 赤字メッセージ表示、ボタンは再クリック可能な状態に戻る（送信中で固まらない）
- ダークモード: 配色・視認性ともに問題なし

スクリーンショットで確認済み（ライト/ダーク両方）。

## マージ後の確認手順

本番で未検証のトライアル→本登録ユーザーを作成し、ホーム画面にバナーが表示されること、再送ボタンで確認メールが届くことを確認する。