### PR TITLE
fix: メール未確認の本登録ユーザーのAI課金機能を制限

### DIFF
--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -52,6 +52,22 @@ class ApplicationController < ActionController::API
     )
   end
 
+  # メールアドレス確認を必須にする before_action（checkout / AI課金系で共通利用）。
+  # - トライアルユーザーは対象外（実メール検証フローの外。本登録昇格時に検証する）
+  # - 既存ユーザーはmigrationで検証済みにバックフィル済みのため影響なし
+  # 各コントローラで `before_action :require_verified_email, only: [...]` として使う。
+  # AI課金系では check_analysis_limit 等の枠消費チェックより**前**に置くこと
+  # （403で拒否したのに月次カウントだけ減る事故を防ぐ）。
+  def require_verified_email
+    return if current_user.trial_user?
+    return if current_user.email_verified?
+
+    render json: {
+      error: "メールアドレスの確認が必要です。確認メールのリンクを開いてください。",
+      email_verification_required: true
+    }, status: :forbidden
+  end
+
   # メール確認メールを送信する（登録・トライアル昇格・再送で共通利用）。
   # メール配信基盤の不調で登録自体を失敗させないよう best-effort とし、
   # 失敗はログに残すだけにする。

--- a/backend/app/controllers/audio_dreams_controller.rb
+++ b/backend/app/controllers/audio_dreams_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AudioDreamsController < ApplicationController
+  # 音声分析はWhisper+GPTの二重課金のため、メール確認済みユーザーのみ（trialは対象外）
+  before_action :require_verified_email, only: [:create]
   before_action :check_trial_audio_limit, only: [:create]
 
   TRIAL_AUDIO_LIMIT = 1 # トライアルユーザーの音声分析上限（Whisper+GPTで高コスト）

--- a/backend/app/controllers/checkout_controller.rb
+++ b/backend/app/controllers/checkout_controller.rb
@@ -2,8 +2,7 @@ class CheckoutController < ApplicationController
   class MissingPremiumPriceIdError < StandardError; end
 
   # 決済前にメールアドレス確認を必須にする（領収書・重要通知の到達性を担保）。
-  # 既存ユーザーはmigrationで検証済みにバックフィル済みのため影響なし。
-  # トライアルユーザーは実メール検証フローの対象外（本登録昇格時に検証する）。
+  # 実装は ApplicationController#require_verified_email（AI課金系と共通）。
   before_action :require_verified_email, only: [:create]
 
   DONATION_UNIT_AMOUNT = 500
@@ -100,16 +99,6 @@ class CheckoutController < ApplicationController
   end
 
   private
-
-  def require_verified_email
-    return if current_user.trial_user?
-    return if current_user.email_verified?
-
-    render json: {
-      error: "メールアドレスの確認が必要です。確認メールのリンクを開いてください。",
-      email_verification_required: true
-    }, status: :forbidden
-  end
 
   def requested_plan
     params[:plan].to_s == 'premium' ? 'premium' : 'donation'

--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -1,5 +1,9 @@
 class DreamsController < ApplicationController
   before_action :set_dream_and_authorize_user, only: [:show, :update, :destroy, :analyze, :analysis, :generate_image]
+  # OpenAI課金が発生するアクションはメール確認済みユーザーのみ（trialは対象外）。
+  # 宣言順が重要: set_dream の後（他人の夢は404のまま）、
+  # check_analysis_limit の前（枠を消費してから403にしない）。
+  before_action :require_verified_email, only: [:analyze, :preview_analysis, :generate_image]
   before_action :check_analysis_limit, only: [:analyze, :preview_analysis]
   before_action :check_monthly_image_limit, only: [:generate_image]
   before_action :check_trial_dream_limit, only: [:create]

--- a/backend/spec/requests/audio_dreams_spec.rb
+++ b/backend/spec/requests/audio_dreams_spec.rb
@@ -62,6 +62,35 @@ RSpec.describe 'AudioDreams API', type: :request do
       end
     end
 
+    context 'メール未確認ユーザーのAI課金機能ゲート' do
+      it '未確認の本登録ユーザーは403で、夢もジョブも作られない' do
+        unverified = create(:user, :unverified, :with_self_profile)
+
+        expect {
+          post '/analyze_audio_dream',
+               params: { file: audio_upload },
+               headers: auth_headers(unverified)
+        }.not_to change(Dream, :count)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)['email_verification_required']).to be true
+        analyze_jobs = ActiveJob::Base.queue_adapter.enqueued_jobs.select { |j| j['job_class'] == 'AnalyzeDreamJob' }
+        expect(analyze_jobs).to be_empty
+      end
+
+      it '未確認のトライアルユーザーは上限内なら従来通り実行できる（体験導線を壊さない）' do
+        trial = create(:user, :unverified, :with_self_profile, trial_user: true, trial_audio_count: 0)
+
+        expect {
+          post '/analyze_audio_dream',
+               params: { file: audio_upload },
+               headers: auth_headers(trial)
+        }.to change { trial.dreams.count }.by(1)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
     context '認証されていない場合' do
       it_behaves_like 'unauthorized request', :post, '/analyze_audio_dream'
 

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -1049,4 +1049,93 @@ RSpec.describe 'Dreams API', type: :request do
       it_behaves_like 'unauthorized request', :get, '/dreams/analysis_quota'
     end
   end
+
+  # ------------------------------------------------------------------ #
+  # メール未確認ユーザーのAI課金機能ゲート                               #
+  # OpenAI料金が発生するアクションは、本登録済みかつメール確認済みの      #
+  # ユーザーのみ実行可能（trialは体験導線を守るため対象外）               #
+  # ------------------------------------------------------------------ #
+  describe 'メール未確認ユーザーのAI課金機能ゲート' do
+    let!(:unverified_user) { create(:user, :unverified, :with_self_profile) }
+    let!(:unverified_dream) do
+      create(:dream, user: unverified_user, content: '未確認ユーザーの夢です。空を飛んでいました。')
+    end
+
+    around do |example|
+      original_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+      example.run
+    ensure
+      ActiveJob::Base.queue_adapter = original_adapter
+    end
+
+    describe 'POST /dreams/:id/analyze' do
+      it '未確認の本登録ユーザーは403で、ジョブもAiUsageLogも作られない' do
+        expect {
+          authenticated_post "/dreams/#{unverified_dream.id}/analyze", unverified_user
+        }.not_to change(AiUsageLog, :count)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json_response['email_verification_required']).to be true
+        analyze_jobs = ActiveJob::Base.queue_adapter.enqueued_jobs.select { |j| j['job_class'] == 'AnalyzeDreamJob' }
+        expect(analyze_jobs).to be_empty
+      end
+    end
+
+    describe 'POST /dreams/preview_analysis' do
+      it '未確認の本登録ユーザーは403で、OpenAIは呼ばれず月次カウントも消費されない' do
+        expect(DreamAnalysisService).not_to receive(:analyze)
+
+        expect {
+          authenticated_post '/dreams/preview_analysis', unverified_user, params: { content: '空を飛ぶ夢' }
+        }.not_to change { unverified_user.reload.monthly_analysis_count }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json_response['email_verification_required']).to be true
+      end
+
+      it 'メール確認済みの本登録ユーザーは従来通り実行できる' do
+        allow(DreamAnalysisService).to receive(:analyze).and_return({ analysis: 'result', emotion_tags: ['happy'] })
+
+        authenticated_post '/dreams/preview_analysis', user, params: { content: '空を飛ぶ夢' }
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '未確認のトライアルユーザーは上限内なら従来通り実行できる（体験導線を壊さない）' do
+        trial = create(:user, :unverified, trial_user: true, trial_analysis_count: 0)
+        allow(DreamAnalysisService).to receive(:analyze).and_return({ analysis: 'result', emotion_tags: ['happy'] })
+
+        authenticated_post '/dreams/preview_analysis', trial, params: { content: '空を飛ぶ夢' }
+
+        expect(response).to have_http_status(:ok)
+        expect(trial.reload.trial_analysis_count).to eq(1)
+      end
+    end
+
+    describe 'POST /dreams/:id/generate_image' do
+      let(:images_client) { double('OpenAI::Images') }
+
+      before do
+        @original_openai_client = $openai_client
+        # images.generate が呼ばれたらテストが失敗する（allow していないため）
+        $openai_client = double('OpenAI::Client', images: images_client)
+      end
+
+      after do
+        $openai_client = @original_openai_client
+      end
+
+      it '未確認の本登録ユーザーは403で、OpenAIは呼ばれず生成レコードも作られない' do
+        expect(images_client).not_to receive(:generate)
+
+        expect {
+          authenticated_post "/dreams/#{unverified_dream.id}/generate_image", unverified_user
+        }.not_to change(DreamImageGeneration, :count)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(json_response['email_verification_required']).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要

OpenAI API料金が発生する機能（夢分析・画像生成・音声分析）が、メールアドレス未確認の本登録ユーザーでも無制限に使えていた。捨てメールアドレスで登録すれば確認メールを無視したまま**月10回の分析・1日3枚の画像生成**が可能な状態だった。バックエンドのみの小PR（フロントUIは触らない）。

## 調査結果（このPR着手前に確認した事実）

- `POST /dreams/:id/analyze` / `POST /dreams/preview_analysis` / `POST /dreams/:id/generate_image` / `POST /analyze_audio_dream` のいずれにも `email_verified?` チェックは存在しなかった
- `email_verified?` を参照していたのは `CheckoutController#require_verified_email` の1箇所のみ
- trialユーザーはこれらのアクションで元々上限管理（分析3回・音声1回）されており、`email_verified_at`は検証対象外という既存設計（#415）

## 変更内容

### 共通化
- `CheckoutController` にprivateメソッドとして個別定義されていた `require_verified_email` を `ApplicationController` へ移動
- 仕様は変更なし（trialは対象外／既存ユーザーはmigrationでgrandfather済みのため無影響）
- `CheckoutController` は `before_action :require_verified_email, only: [:create]` の宣言だけ残し、共通メソッドを使うように変更

### ゲート追加
- `DreamsController`: `analyze` / `preview_analysis` / `generate_image` に `before_action :require_verified_email` を追加
- `AudioDreamsController`: `create` に同様に追加
- **before_actionの宣言順に注意した点**:
  - `DreamsController` では `set_dream_and_authorize_user` の**後**（他人の夢IDを叩いたときの404挙動を変えない）
  - `check_analysis_limit` / `check_monthly_image_limit` の**前**（403で拒否したのに月次分析カウントだけ消費される事故を防ぐ）

### 対象外（意図的）
- **trial_user**: 体験導線（コンバージョンの心臓部）を保護するため対象外のまま。上限は既存の`TRIAL_ANALYSIS_LIMIT`/`TRIAL_AUDIO_LIMIT`で引き続き制御
- 月次サマリー（`MonthlySummariesController`）: premium限定＝checkout通過済み＝検証済みなので対象外（変更不要と判断し触っていない）

## 触っていない領域

フロントエンドは一切変更していない。`email_verification_required: true` を受け取った際の表示改善（DreamForm・画像生成ボタン）は後続PRで対応する。UI・Stripe・OpenAI・認証本体には触れていない。

## 検証結果

Docker環境（`backend-test`サービス）で実行:

```
bundle exec rspec spec/requests/dreams_spec.rb spec/requests/audio_dreams_spec.rb
# => 94 examples, 0 failures

bundle exec rspec spec/requests/checkout_spec.rb
# => 14 examples, 0 failures（共通化リファクタの回帰なし確認）

bundle exec rspec
# => 348 examples, 0 failures（既存341 + 新規7、全suite緑）
```

### 追加したRSpecケース

**`spec/requests/dreams_spec.rb`**（新規describe「メール未確認ユーザーのAI課金機能ゲート」）
- analyze: 未確認の本登録ユーザーは403・`AnalyzeDreamJob`もキューに入らずAiUsageLogも作られない
- preview_analysis: 未確認は403・`DreamAnalysisService.analyze`が呼ばれず月次カウントも消費されない／検証済みは従来通り通る／**未確認のtrialは上限内なら従来通り通る**
- generate_image: 未確認は403・OpenAI Images APIが呼ばれず`DreamImageGeneration`も作られない

**`spec/requests/audio_dreams_spec.rb`**
- 未確認の本登録ユーザーは403・夢もジョブも作られない
- **未確認のtrialは上限内なら従来通り通る**（体験導線の回帰確認）

## マージ後の確認手順

1. 本番で未検証の本登録ユーザーを作り、「AIにきいてみる」「夢の画像を生成」「音声で記録」を試す → 403 + `email_verification_required: true` が返ること
2. `/verify-email` でメール確認後、同じ操作が通ること
3. トライアルユーザーの分析・音声記録体験（`/trial`）が従来通り動くこと
4. Renderログで想定外の500が出ていないこと