### PR TITLE
fix: forgot password API を createApiUrl 経由に統一

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -27,6 +27,7 @@ INTERNAL_API_URL=http://backend:3001
 # ⚠️ 本番(Vercel Production)では **Vercel の Environment Variables に
 #    NEXT_PUBLIC_VERCEL_ENV=production を必ず設定**すること（NEXT_PUBLIC_* はビルド時に埋め込まれる）。
 #    未設定/不一致だと本番ブラウザが /proxy に切り替わらず、ログイン等の /auth/* が 404 になる。
+#    ログイン・登録・パスワードリセットなどのブラウザAPI呼び出しは createApiUrl 経由で /proxy に統一する。
 # ローカル(.env.local)では通常このプレフィックスは不要（NEXT_PUBLIC_API_URL が使われる）。
 # NEXT_PUBLIC_VERCEL_ENV=production
 

--- a/frontend/__tests__/app/forgot-password/page.test.tsx
+++ b/frontend/__tests__/app/forgot-password/page.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import ForgotPasswordPage from "@/app/(auth)/forgot-password/page";
+
+const originalEnv = process.env;
+const originalFetch = global.fetch;
+
+describe("ForgotPasswordPage", () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv, NEXT_PUBLIC_VERCEL_ENV: "production" };
+    delete process.env.NEXT_PUBLIC_API_URL;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+    } as Response);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it("posts password reset requests through the production /proxy route", async () => {
+    render(<ForgotPasswordPage />);
+
+    fireEvent.change(screen.getByLabelText("メールアドレス"), {
+      target: { value: " user@example.com " },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "リセットリンクを送信" })
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/proxy/password_resets",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ email: "user@example.com" }),
+        })
+      );
+    });
+  });
+});

--- a/frontend/app/(auth)/forgot-password/page.tsx
+++ b/frontend/app/(auth)/forgot-password/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import Link from "next/link";
+import { createApiUrl } from "@/lib/api-config";
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState("");
@@ -31,8 +32,7 @@ export default function ForgotPasswordPage() {
     setIsLoading(true);
 
     try {
-      const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
-      const response = await fetch(`${apiUrl}/password_resets`, {
+      const response = await fetch(createApiUrl("/password_resets"), {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- 本番で `/api/password_resets` にPOSTされ404になっていた問題を修正
- forgot password の送信先を `createApiUrl("/password_resets")` 経由に変更し、本番では `/proxy/password_resets` に統一
- `.env.example` に、ログイン・登録・パスワードリセットなどのブラウザAPI呼び出しは `createApiUrl` 経由で `/proxy` に統一する旨を補足

## Context
認証系APIはすでに `/proxy` に統一されていましたが、password resetだけ `NEXT_PUBLIC_API_URL` を直接参照しており、Production bundleでは `/api/password_resets` にPOSTされ404になっていました。

## Scope
- Rails / DB / Stripe / OpenAI は触っていません
- AI料金gateの変更は含めていません

## Verification
- `cd frontend && npx jest __tests__/lib/api-config.test.ts __tests__/app/forgot-password/page.test.tsx --runInBand`
- 2 suites / 5 tests passed

## Post-merge check
- Production再デプロイ後に、forgot password送信が `/proxy/password_resets` にPOSTされることをNetwork相当で確認する