### PR TITLE
feat: AI機能のメール確認要求エラーをバナー表示に改善

### DIFF
--- a/frontend/__tests__/components/DreamForm.test.js
+++ b/frontend/__tests__/components/DreamForm.test.js
@@ -31,6 +31,10 @@ jest.mock("framer-motion", () => {
 jest.mock("@/lib/apiClient", () => ({
   getEmotions: jest.fn(),
   previewAnalysis: jest.fn(),
+  resendVerificationEmail: jest.fn(),
+  // 実装（lib/apiClient.ts）と同じ判定ロジックをモックにも持たせる
+  isEmailVerificationRequiredError: (error) =>
+    error?.status === 403 && error?.data?.email_verification_required === true,
   ApiError: class ApiError extends Error {
     constructor(message, status, data) {
       super(message);
@@ -310,6 +314,29 @@ describe("DreamForm", () => {
     });
     expect(upgradeLink).toHaveAttribute("href", "/subscription");
     expect(screen.getByText("今月の無料分析回数を使い切ったよ")).toBeInTheDocument();
+  });
+
+  it("shows the email verification banner when analysis is blocked for unverified users", async () => {
+    getEmotions.mockResolvedValueOnce([]);
+    previewAnalysis.mockRejectedValueOnce(
+      new ApiError("メールアドレスの確認が必要です。", 403, {
+        email_verification_required: true,
+      })
+    );
+    const user = userEvent.setup();
+
+    render(<DreamForm onSubmit={jest.fn()} />);
+
+    await user.type(screen.getByLabelText("どんな おはなし？"), "空を飛ぶ夢");
+    await user.click(screen.getByRole("button", { name: /モルペウスに\s*きく/ }));
+
+    expect(
+      await screen.findByText("AIぶんせきには メールの かくにんが ひつようだよ")
+    ).toBeInTheDocument();
+    // 再送ボタン付きのバナーが出る（トーストではなく恒常表示）
+    expect(
+      screen.getByRole("button", { name: "かくにんメールを もういちど おくる" })
+    ).toBeInTheDocument();
   });
 
   it("shows an analysis MorpheusAvatar while Morpheus is reading the dream", async () => {

--- a/frontend/__tests__/components/EmailVerificationBanner.test.tsx
+++ b/frontend/__tests__/components/EmailVerificationBanner.test.tsx
@@ -32,6 +32,22 @@ describe("EmailVerificationBanner", () => {
     ).toBeInTheDocument();
   });
 
+  it("title / description を文脈に合わせて差し替えられる", () => {
+    render(
+      <EmailVerificationBanner
+        title="AIぶんせきには メールの かくにんが ひつようだよ"
+        description="とどいた メールの リンクを ひらいてから、もういちど きいてみてね。"
+      />
+    );
+
+    expect(
+      screen.getByText("AIぶんせきには メールの かくにんが ひつようだよ")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("とどいた メールの リンクを ひらいてから、もういちど きいてみてね。")
+    ).toBeInTheDocument();
+  });
+
   it("再送ボタンを押すと送信中表示になり、成功したら完了メッセージに切り替わる", async () => {
     const user = userEvent.setup();
     mockResend.mockResolvedValue({ message: "確認メールを送りました" });

--- a/frontend/app/components/DreamForm.tsx
+++ b/frontend/app/components/DreamForm.tsx
@@ -4,7 +4,14 @@ import React, { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 
 import { Dream, DreamProfile, Emotion, DreamDraftData } from "../types";
-import { getDreamProfiles, getEmotions, previewAnalysis, ApiError } from "@/lib/apiClient";
+import {
+  getDreamProfiles,
+  getEmotions,
+  previewAnalysis,
+  ApiError,
+  isEmailVerificationRequiredError,
+} from "@/lib/apiClient";
+import EmailVerificationBanner from "./EmailVerificationBanner";
 import { toast } from "@/lib/toast";
 import { groupEmotionsByDisplayLabel } from "./emotionGrouping";
 import MorpheusAvatar from "./MorpheusAvatar";
@@ -60,6 +67,7 @@ export default function DreamForm({
   const [isDraftApplied, setIsDraftApplied] = useState(false);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [analysisLimitReached, setAnalysisLimitReached] = useState(false);
+  const [emailVerificationRequired, setEmailVerificationRequired] = useState(false);
   const [analysisRevealKey, setAnalysisRevealKey] = useState(0);
   const [profiles, setProfiles] = useState<DreamProfile[]>([]);
   const [selectedProfileId, setSelectedProfileId] = useState<number | undefined>(
@@ -190,6 +198,7 @@ export default function DreamForm({
     }
 
     setAnalysisLimitReached(false);
+    setEmailVerificationRequired(false);
     setIsAnalyzing(true);
     try {
       const result = await previewAnalysis(content);
@@ -201,7 +210,9 @@ export default function DreamForm({
       localStorage.removeItem(morpheusRatingKey);
       toast.success("モルペウスが おへんじ したよ！");
     } catch (error) {
-      if (error instanceof ApiError && error.status === 403 && error.data?.limit_reached) {
+      if (isEmailVerificationRequiredError(error)) {
+        setEmailVerificationRequired(true);
+      } else if (error instanceof ApiError && error.status === 403 && error.data?.limit_reached) {
         setAnalysisLimitReached(true);
       } else if (error instanceof ApiError && error.message) {
         console.error("Analysis failed:", error);
@@ -316,6 +327,14 @@ export default function DreamForm({
           placeholder="どんな ゆめ だった？ おもいだせる だけ かいてみてね..."
         ></textarea>
         {/* Analysis Button */}
+        {emailVerificationRequired && (
+          <div className="mt-3">
+            <EmailVerificationBanner
+              title="AIぶんせきには メールの かくにんが ひつようだよ"
+              description="とどいた メールの リンクを ひらいてから、もういちど きいてみてね。"
+            />
+          </div>
+        )}
         <div className="mt-3 flex justify-end">
           {analysisLimitReached ? (
             <div className="flex flex-col items-end gap-2">

--- a/frontend/app/components/EmailVerificationBanner.tsx
+++ b/frontend/app/components/EmailVerificationBanner.tsx
@@ -7,11 +7,20 @@ import { ApiError } from "@/lib/apiClient";
 
 type SendState = "idle" | "sending" | "sent";
 
+type EmailVerificationBannerProps = {
+  // AI分析や画像生成がゲートで拒否された場面など、文脈に合わせて文言を差し替える
+  title?: string;
+  description?: string;
+};
+
 /**
  * メールアドレス未確認ユーザー向けのお知らせバナー。
  * 確認メールの再送ボタンを備える（backend側で5分間隔の再送制限あり）。
  */
-export default function EmailVerificationBanner() {
+export default function EmailVerificationBanner({
+  title = "メールアドレスの かくにんが まだだよ",
+  description = "とどいた メールの リンクを ひらいて、かくにんを かんりょうしてね。",
+}: EmailVerificationBannerProps) {
   const [state, setState] = useState<SendState>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -39,14 +48,10 @@ export default function EmailVerificationBanner() {
     >
       <div className="flex items-center gap-2 mb-2">
         <Mail size={16} className="text-primary" aria-hidden="true" />
-        <p className="text-sm font-medium text-foreground">
-          メールアドレスの かくにんが まだだよ
-        </p>
+        <p className="text-sm font-medium text-foreground">{title}</p>
       </div>
 
-      <p className="text-sm text-muted-foreground mb-3">
-        とどいた メールの リンクを ひらいて、かくにんを かんりょうしてね。
-      </p>
+      <p className="text-sm text-muted-foreground mb-3">{description}</p>
 
       {state === "sent" ? (
         <p className="text-sm font-bold text-primary">

--- a/frontend/app/dream/[id]/page.tsx
+++ b/frontend/app/dream/[id]/page.tsx
@@ -10,7 +10,8 @@ import {
 import { useDream, type DreamInput } from "../../../hooks/useDream";
 import { useRouter } from "next/navigation";
 import { useState, useEffect, use } from "react";
-import apiClient from "../../../lib/apiClient";
+import apiClient, { isEmailVerificationRequiredError } from "../../../lib/apiClient";
+import EmailVerificationBanner from "@/app/components/EmailVerificationBanner";
 import { useAuth } from "../../../context/AuthContext";
 import { AgeGroup } from "@/app/types";
 import { MorpheusGuideDetail } from "@/app/components/MorpheusGuide";
@@ -104,6 +105,7 @@ export default function DreamDetailPage({
   const [isGeneratingImage, setIsGeneratingImage] = useState(false);
   const [generatedImageUrl, setGeneratedImageUrl] = useState<string | null>(null);
   const [imageError, setImageError] = useState<string | null>(null);
+  const [imageVerificationRequired, setImageVerificationRequired] = useState(false);
   const [imageQuota, setImageQuota] = useState<{ used: number; limit: number; remaining: number } | null>(null);
 
   useEffect(() => {
@@ -128,6 +130,7 @@ export default function DreamDetailPage({
     if (!dreamId || isGeneratingImage) return;
     setIsGeneratingImage(true);
     setImageError(null);
+    setImageVerificationRequired(false);
     try {
       const result = await apiClient.post<{ image_url: string }>(
         `/dreams/${dreamId}/generate_image`,
@@ -136,9 +139,13 @@ export default function DreamDetailPage({
       );
       setGeneratedImageUrl(result.image_url);
     } catch (err) {
-      setImageError(
-        err instanceof Error ? err.message : "えの せいせい に しっぱい しました"
-      );
+      if (isEmailVerificationRequiredError(err)) {
+        setImageVerificationRequired(true);
+      } else {
+        setImageError(
+          err instanceof Error ? err.message : "えの せいせい に しっぱい しました"
+        );
+      }
     } finally {
       setIsGeneratingImage(false);
     }
@@ -301,6 +308,12 @@ export default function DreamDetailPage({
 
       {/* ゆめのえ */}
       <div className="mb-6">
+        {imageVerificationRequired && (
+          <EmailVerificationBanner
+            title="ゆめのえを かくには メールの かくにんが ひつようだよ"
+            description="とどいた メールの リンクを ひらいてから、もういちど かいてみてね。"
+          />
+        )}
         {generatedImageUrl ? (
           <div className="space-y-2">
             {imageError && (

--- a/frontend/lib/apiClient.ts
+++ b/frontend/lib/apiClient.ts
@@ -482,6 +482,16 @@ export async function resendVerificationEmail(): Promise<{ message: string }> {
   });
 }
 
+// AI課金機能（分析・画像生成・音声）や決済が「メールアドレス確認が必要」で
+// 拒否されたエラーかどうか（backendの require_verified_email が返す403）
+export function isEmailVerificationRequiredError(error: unknown): boolean {
+  return (
+    error instanceof ApiError &&
+    error.status === 403 &&
+    error.data?.email_verification_required === true
+  );
+}
+
 const apiClient = {
   get: <T>(url: string, options?: ApiFetchOptions) =>
     apiFetch<T>(url, { ...options, method: "GET", cache: "no-store" }),


### PR DESCRIPTION
## 概要

[#417](https://github.com/isekaisaru/dreamjournal-app/pull/417)でメール未確認の本登録ユーザーのAI課金機能が `403 + email_verification_required: true` で拒否されるようになったが、フロントは汎用エラー処理に落ちていた:

- **DreamForm（AI分析）**: バックエンドの文言が**一時的なトースト**で流れるだけで、アクションもなく消える
- **夢詳細（画像生成）**: エラーテキストは出るが「どうすればよいか」の導線がない

これを**再送ボタン付きの恒常バナー**（#416で追加した `EmailVerificationBanner` の再利用）に改善する。#417のPR本文で予告していたフロント後続対応。

## 変更内容

- `lib/apiClient.ts`: `isEmailVerificationRequiredError(error)` ヘルパーを追加（`ApiError` × 403 × `email_verification_required` の判定を一元化）
- `EmailVerificationBanner`: `title` / `description` props を追加（デフォルトは従来文言のまま＝ホームの表示は不変）
- `DreamForm`: 検証要求で拒否されたら「AIぶんせきには メールの かくにんが ひつようだよ」バナー＋再送ボタンを分析ボタンの上に恒常表示（`analysisLimitReached` と同じ既存パターン）。再試行時にフラグをリセット
- `app/dream/[id]/page.tsx`: 画像生成が拒否されたら「ゆめのえ」セクションに同バナー（画像あり/なし両分岐をカバーする位置に配置）

## 触っていない領域

- バックエンド・Stripe・OpenAI・認証
- **音声記録（DreamEntryLauncher）**: バックエンドの `メールアドレスの確認が必要です…` メッセージがそのままトースト表示される既存挙動を維持。録音シートUIにバナーを組み込むとレイアウト変更が大きくなるため、必要になったら別対応
- ホームの `EmailVerificationBanner` 表示（デフォルトpropsで挙動不変。既存テストが回帰を担保）

## 検証結果

```
yarn test
# => 50 suites / 365 tests, all passed（新規3件含む）
```

新規テスト:
- DreamForm: 検証要求403でバナー＋再送ボタンが表示される（トーストでなく恒常表示）
- EmailVerificationBanner: title/description の差し替え表示
- 既存の `limit_reached` 403 → プレミアム導線テストは変更なしで通過（分岐順の回帰確認）

`npx tsc --noEmit`: 変更したアプリコードの型エラーなし（テストファイルの `jest.Mock` 型エラーは#416以前からの既知の同種エラー）。

## マージ後の確認手順

1. 未確認の本登録ユーザーで夢フォームの「モルペウスに きく」→ トーストではなく**再送ボタン付きバナー**が出ること
2. バナーの再送ボタン → 「かくにんメールを おくったよ」表示（5分以内の連打は429メッセージ）
3. 夢詳細の「ゆめのえを かく」→ 同様のバナーが出ること
4. メール確認後に同じ操作 → 従来通り分析・画像生成できること