### PR TITLE
chore: メール送信元アドレスをMAIL_FROM環境変数化しResend設定手順を記載

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -116,3 +116,22 @@ SLOW_QUERY_THRESHOLD_MS=100
 # 外部監視サービス設定（任意）
 NEWRELIC_LICENSE_KEY=your_newrelic_license_key_here
 DATADOG_API_KEY=your_datadog_api_key_here
+
+# ========================================
+# 📧 メール配信設定（本番のみ・Resend推奨）
+# ========================================
+# 確認メール・パスワードリセットの実配信に必要。
+# 未設定でも送信が失敗するだけでアプリ動作には影響しない
+# （登録は成功し、Renderログに送信失敗が記録される）。
+#
+# Resendの場合:
+#   SMTP_USERNAME は文字列 "resend" 固定
+#   SMTP_PASSWORD は APIキー（re_ で始まる値）
+#   MAIL_FROM は Resendで検証済みドメインのアドレス。
+#   独自ドメインが未検証の間はテスト用 onboarding@resend.dev を使う
+#   （この場合Resendアカウント本人のメールにしか届かない）。
+# SMTP_ADDRESS=smtp.resend.com
+# SMTP_PORT=465
+# SMTP_USERNAME=resend
+# SMTP_PASSWORD=re_your_api_key_here
+# MAIL_FROM=onboarding@resend.dev

--- a/backend/app/mailers/application_mailer.rb
+++ b/backend/app/mailers/application_mailer.rb
@@ -1,4 +1,8 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "support@yumelog.com" # 好きな送信元アドレスに変更してください
+  # Resend等の配信サービスは送信元ドメインの所有検証を要求するため、
+  # コード変更なしで差し替えられるよう環境変数化する。
+  # - テスト運用: onboarding@resend.dev（Resendアカウント本人宛のみ配信可）
+  # - 本運用: no-reply@<Resendで検証済みの独自ドメイン>
+  default from: ENV.fetch("MAIL_FROM", "support@yumelog.com")
   layout "mailer"
 end

--- a/backend/spec/requests/email_verification_spec.rb
+++ b/backend/spec/requests/email_verification_spec.rb
@@ -175,8 +175,12 @@ RSpec.describe 'Email verification', type: :request do
       mail = UserMailer.email_verification(user, token)
 
       expect(mail.to).to eq(['mailbody@example.com'])
-      # From は MAIL_FROM 環境変数で上書き可能（未設定時のデフォルトを固定）
-      expect(mail.from).to eq(['support@yumelog.com'])
+      # ApplicationMailerの `default from:` はクラス読み込み時（起動時）に
+      # 一度だけ評価されるため、実行中にENVを変えても反映されない。
+      # このテストは「MAIL_FROM未設定」を決め打ちせず、実際に設定されている
+      # 値（未設定ならデフォルト値）と比較することでテスト環境に依存しない
+      # ようにする（Codexレビュー指摘・#420）
+      expect(mail.from).to eq([ENV.fetch('MAIL_FROM', 'support@yumelog.com')])
       expect(mail.subject).to include('メールアドレスの確認')
       # マルチパート（text/html）それぞれに確認URLが含まれる
       expect(mail.text_part.decoded).to include("/verify-email?token=#{token}")

--- a/backend/spec/requests/email_verification_spec.rb
+++ b/backend/spec/requests/email_verification_spec.rb
@@ -175,6 +175,8 @@ RSpec.describe 'Email verification', type: :request do
       mail = UserMailer.email_verification(user, token)
 
       expect(mail.to).to eq(['mailbody@example.com'])
+      # From は MAIL_FROM 環境変数で上書き可能（未設定時のデフォルトを固定）
+      expect(mail.from).to eq(['support@yumelog.com'])
       expect(mail.subject).to include('メールアドレスの確認')
       # マルチパート（text/html）それぞれに確認URLが含まれる
       expect(mail.text_part.decoded).to include("/verify-email?token=#{token}")


### PR DESCRIPTION
## 概要

Resend設定に向けた調査で発見した唯一の必須コード変更。Resend等の配信サービスは**送信元ドメインの所有検証**を要求するため、`ApplicationMailer`にハードコードされていた `support@yumelog.com`（未所有ドメイン）のままだと、SMTP環境変数（#415で導入済み）を設定しても送信が拒否され続ける。

`ENV.fetch("MAIL_FROM", "support@yumelog.com")` で差し替え可能にする。**未設定時は従来値のままなので、マージしただけでは挙動変化なし。**

## 変更内容

- `backend/app/mailers/application_mailer.rb`: `default from:` を `MAIL_FROM` 環境変数化（1行＋コメント）
- `backend/.env.example`: メール配信セクションを追加（SMTP_ADDRESS / SMTP_PORT / SMTP_USERNAME / SMTP_PASSWORD / MAIL_FROM のResend向け設定手順。SMTP_USERNAMEは文字列 `resend` 固定、SMTP_PASSWORDはAPIキー、という迷いやすい点を明記）
- `spec/requests/email_verification_spec.rb`: デフォルトFromの回帰テストを1行追加

## 触っていない領域

SMTP設定本体（#415で完成済み）／メール送信ロジック／フロント／Stripe／OpenAI。

## 検証結果

```
bundle exec rspec  # => 348 examples, 0 failures（Docker backend-test）
```

## マージ後の作業（Render環境変数の設定）

1. Resendアカウント作成（https://resend.com ・無料枠100通/日）→ APIキー発行
2. Renderのバックエンドサービス → Environment に追加:
   - `SMTP_USERNAME` = `resend`（文字列そのまま）
   - `SMTP_PASSWORD` = APIキー（`re_`で始まる値）
   - `MAIL_FROM` = `onboarding@resend.dev`（テスト運用。**Resendアカウント本人のメールにしか届かない**制約あり）
3. 自分のメールアドレスで新規登録 → 確認メール受信 → `/verify-email` で検証完了までの一連を確認
4. 本運用（全ユーザーに配信）には独自ドメイン取得＋ResendでのDNS検証（SPF/DKIM）→ `MAIL_FROM` を `no-reply@独自ドメイン` に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追記: Codexレビュー(P2)対応

**指摘**: `mail.from`のテストが`'support@yumelog.com'`固定を期待していたが、テスト実行環境で`MAIL_FROM`が設定されていると失敗する（`.env`に追記されている環境等）。

**対応**: `ApplicationMailer`の`default from:`はクラス読み込み時（起動時）に一度だけ評価されるため、実行中のENVスタブは効かない。そのため`ENV.fetch('MAIL_FROM', 'support@yumelog.com')`で実際の設定値と比較する形に変更し、`MAIL_FROM`の有無に依存しないテストにした。

**検証**: `MAIL_FROM`未設定・設定済み（`onboarding@resend.dev`）の両方でこのspecが緑になることを確認。修正前のハードコード版に戻すと、`MAIL_FROM`設定時に確実に失敗する（`expected: ["support@yumelog.com"], got: ["onboarding@resend.dev"]`）ことも手動で相互検証済み。`bundle exec rspec`で348 examples, 0 failures。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
