### PR TITLE
feat: プロフィール別シェアカード（DreamShareCardをプロフィール対応・AI画像なし対応に拡張）

### DIFF
--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -83,7 +83,10 @@ class DreamsController < ApplicationController
   def show
     render json: @dream.as_json(
       only: [:id, :title, :created_at, :content, :analysis_json, :analysis_status, :analyzed_at, :generated_image_url, :dream_profile_id],
-      include: :emotions
+      include: {
+        emotions: {},
+        dream_profile: dream_profile_json_options
+      }
     )
   end
 

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -163,9 +163,35 @@ RSpec.describe 'Dreams API', type: :request do
         authenticated_get('/dreams/99999', user)
 
         expect(response).to have_http_status(:not_found)
-        
+
         json_response = JSON.parse(response.body)
         expect(json_response).to have_key('error')
+      end
+
+      it '夢プロフィールの軽量情報を含める' do
+        profile = create(
+          :dream_profile,
+          user: user,
+          name: '長男',
+          avatar_emoji: '👦',
+          color: '#10b981',
+          active: true
+        )
+        dream = create(:dream, user: user, dream_profile: profile)
+
+        authenticated_get("/dreams/#{dream.id}", user)
+
+        expect(response).to have_http_status(:ok)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['dream_profile_id']).to eq(profile.id)
+        expect(json_response['dream_profile']).to eq(
+          'id' => profile.id,
+          'name' => '長男',
+          'avatar_emoji' => '👦',
+          'color' => '#10b981',
+          'active' => true
+        )
       end
     end
 

--- a/docs/superpowers/plans/2026-07-13-dream-share-card-profile.md
+++ b/docs/superpowers/plans/2026-07-13-dream-share-card-profile.md
@@ -1,0 +1,220 @@
+# プロフィール別シェアカード（DreamShareCard拡張）Implementation Plan
+
+**Goal:** 既存の夢シェアカードにプロフィール名・アバター・色を加え、AI画像がない夢や画像読込に失敗した夢でも、プロフィールらしいPNGカードを保存できるようにする。
+
+**Architecture:** `DreamsController#show` が既存の軽量 `dream_profile` JSONを返し、夢詳細ページがその値を `DreamShareCard` に渡す。カードは画像URLがある場合は既存画像を使い、ない場合はCSSと絵文字によるフォールバックを描画する。既存のPNG保存、画像proxy、iOS共有、リンクコピーの契約は維持する。
+
+**Tech Stack:** Rails 7.2 / RSpec request specs / Next.js 16 App Router / React / TypeScript / Tailwind v4 / Jest + Testing Library / `html-to-image`。
+
+**Source spec:** `docs/superpowers/specs/2026-07-13-dream-share-card-profile-design.md`
+
+## Global Constraints
+
+- 新規API、migration、DBスキーマ変更、OpenAI呼び出し、認証変更は追加しない。
+- 公開共有URLは作らない。「リンクをコピー」は既存どおり認証付き夢詳細URLをコピーするだけとする。
+- 既存の画像proxy、data URL許可リスト、iOS Web Share、ダウンロード処理を後退させない。
+- プロフィール情報が一時的に欠けてもカード自体を壊さず、プロフィールチップだけを省略する。
+- `profileColor` はバックエンドの6桁hex validationを前提にしつつ、未指定時は固定の安全な既定色を使う。
+- 画像読込エラー時は既存 `handleImageLoadError` によりURLを破棄し、フォールバックカードへ切り替える。
+- 夢本文は引き続きカードDOMと保存PNGに含めない。
+
+## Files
+
+- Modify: `backend/app/controllers/dreams_controller.rb`
+- Modify: `backend/spec/requests/dreams_spec.rb`
+- Modify: `frontend/app/components/DreamShareCard.tsx`
+- Modify: `frontend/__tests__/components/DreamShareCard.test.tsx`
+- Modify: `frontend/app/dream/[id]/page.tsx`
+- Modify: `frontend/__tests__/components/DreamDetailPage.test.tsx`
+
+## Task 1: 夢詳細APIに軽量プロフィールを追加
+
+### Step 1: 失敗するrequest specを書く
+
+`backend/spec/requests/dreams_spec.rb` の `describe 'GET /dreams/:id'` に、同じユーザーのプロフィールを明示した夢を作るケースを追加する。
+
+- `authenticated_get("/dreams/#{dream.id}", user)` が `200` を返す。
+- `dream_profile_id` がプロフィールIDと一致する。
+- `dream_profile` は `id`, `name`, `avatar_emoji`, `color`, `active` の5項目だけを返す。
+- 既存の「他人の夢は取得できない」テストは変更しない。
+- DBの NOT NULL 制約と矛盾する `dream_profile: nil` ケースは作らない。
+
+Run:
+
+```bash
+docker compose run --rm backend-test bundle exec rspec spec/requests/dreams_spec.rb
+```
+
+Expected: 新しい `dream_profile` expectation が失敗する。
+
+### Step 2: `show` のJSON includeを既存定義へ揃える
+
+`backend/app/controllers/dreams_controller.rb` の `show` を次の契約へ変更する。
+
+```ruby
+include: {
+  emotions: {},
+  dream_profile: dream_profile_json_options
+}
+```
+
+新しいserializer helperは作らず、`index` / `by_month_index` と同じ `dream_profile_json_options` を再利用する。
+
+### Step 3: backend回帰確認
+
+Run:
+
+```bash
+docker compose run --rm backend-test bundle exec rspec spec/requests/dreams_spec.rb
+```
+
+Expected: PASS。プロフィール情報と既存の認可・一覧・月別取得がすべて緑。
+
+## Task 2: DreamShareCardをプロフィール・画像なし対応にする
+
+### Step 1: コンポーネント契約の失敗テストを追加
+
+`frontend/__tests__/components/DreamShareCard.test.tsx` に次を追加する。
+
+- `profileName="ねこさん"`, `profileEmoji="🐱"`, `profileColor="#f97316"` でプロフィールチップがカード内に表示される。
+- profile props未指定ではプロフィールチップを描画しない。
+- `imageUrl={null}` では `<img>` を描画せず、`data-testid="dream-share-card-fallback"` と既定または指定アバターを表示する。
+- `imageUrl={null}` でも保存ボタンから `toPng` に到達し、画像proxyへのfetchを行わない。
+- 既存のHTTPS、data URL、不正scheme、iOS共有、二重保存防止テストは残す。
+
+Run:
+
+```bash
+cd frontend && npx jest __tests__/components/DreamShareCard.test.tsx
+```
+
+Expected: optional propsとフォールバックが未実装のためFAIL。
+
+### Step 2: propsと表示を後方互換で拡張
+
+`frontend/app/components/DreamShareCard.tsx` を以下の契約にする。
+
+- `imageUrl?: string | null`
+- `profileName?: string`
+- `profileEmoji?: string`
+- `profileColor?: string`
+- 画像ありは既存 `<Image>` をそのまま使う。
+- 画像なしは同じ `aspect-square` 領域に、薄いプロフィール色の背景、大きなアバター、短い補助文を表示する。
+- プロフィールチップはカード本体内、ブランド行と日付・タイトルの間に置く。
+- 長い名前は `min-w-0`, `max-w-full`, `truncate` でカード幅を押し広げない。
+- プロフィール名がない場合はチップを省略し、フォールバック画像には既定絵文字を使う。
+
+### Step 3: 保存処理をoptional URLに対応
+
+- コンポーネント先頭の無条件 `proxyUrl` 計算を削除する。
+- `if (img && imageUrl)` で型と実行条件を同時に絞る。
+- HTTPSの場合だけ、その分岐内でproxy URLを組み立てる。
+- 画像なしでは差し替え処理をスキップして `toPng(card, { pixelRatio: 2 })` へ進む。
+- 既存の安全なdata URL判定、不正scheme拒否、`img.src` 復元、object URL解放は維持する。
+
+### Step 4: コンポーネント回帰確認
+
+Run:
+
+```bash
+cd frontend && npx jest __tests__/components/DreamShareCard.test.tsx
+```
+
+Expected: 新規・既存ケースがすべてPASS。
+
+## Task 3: 夢詳細ページでカードを常時表示
+
+### Step 1: ページ統合の失敗テストを追加
+
+`frontend/__tests__/components/DreamDetailPage.test.tsx` に次を追加する。
+
+- `generated_image_url` がない夢でも `dream-share-card` とフォールバックが表示される。
+- `dream.dream_profile` の名前・絵文字がカード内に表示される。
+- AI画像ありの既存ケースでは画像が1枚だけ表示される。
+- `<img>` のerrorを発火すると既存エラー文が表示され、フォールバックへ切り替わる。
+- 夢本文がカード内に入らない既存テストは残す。
+
+Run:
+
+```bash
+cd frontend && npx jest __tests__/components/DreamDetailPage.test.tsx
+```
+
+Expected: 画像なしではカードが未描画のためFAIL。
+
+### Step 2: 画像有無による大分岐を整理
+
+`frontend/app/dream/[id]/page.tsx` で `DreamShareCard` を常時描画し、次を渡す。
+
+```tsx
+imageUrl={generatedImageUrl}
+profileName={dream.dream_profile?.name}
+profileEmoji={dream.dream_profile?.avatar_emoji}
+profileColor={dream.dream_profile?.color}
+```
+
+画像生成ボタンはカード下に残し、状態により既存の「画像を生成する」または「描き直す」を表示する。`imageError`, `imageVerificationRequired`, `imageQuota`, `isGeneratingImage` の既存表示と制御は維持する。
+
+### Step 3: 期限切れ画像のフォールバックを確認
+
+既存 `handleImageLoadError` が `setGeneratedImageUrl(null)` を呼ぶ契約を変えない。これにより画像エラー後に同じカード領域がフォールバックへ再描画され、再生成ボタンも利用可能なままになることをページテストで確認する。
+
+### Step 4: ページ統合テストを再実行
+
+Run:
+
+```bash
+cd frontend && npx jest __tests__/components/DreamDetailPage.test.tsx
+```
+
+Expected: PASS。
+
+## Task 4: 全体検証
+
+### Step 1: 対象フロントテスト
+
+```bash
+cd frontend && npx jest __tests__/components/DreamShareCard.test.tsx __tests__/components/DreamDetailPage.test.tsx
+```
+
+### Step 2: フロント全体と型検査
+
+```bash
+cd frontend && npx jest
+cd frontend && npx tsc --noEmit
+```
+
+Expected: 既存スイートを含めてPASS、新規型エラーなし。
+
+### Step 3: backend対象spec
+
+```bash
+docker compose run --rm backend-test bundle exec rspec spec/requests/dreams_spec.rb
+```
+
+Expected: PASS。
+
+### Step 4: 静的差分確認
+
+```bash
+git diff --check
+git status --short
+```
+
+変更が計画対象6ファイルと設計・計画ドキュメントだけであることを確認する。
+
+### Step 5: 手動QA
+
+- AI画像あり: プロフィールチップ、保存、描き直し導線を確認。
+- AI画像なし: フォールバック、保存、画像生成導線を確認。
+- 期限切れ画像: エラー文とフォールバックへの切替を確認。
+- 375px幅: 長いプロフィール名・夢タイトルが横にはみ出さないことを確認。
+- 保存PNG: プロフィール、タイトル、感情タグが入り、夢本文や操作ボタンが入らないことを確認。
+
+## Done Criteria
+
+- `GET /dreams/:id` が認可済み夢の軽量プロフィールを返す。
+- 画像の有無・読込成否にかかわらず、夢詳細に保存可能なカードが1枚表示される。
+- プロフィール識別がカードとPNGに含まれる。
+- 既存の画像保存、iOS共有、リンクコピー、画像生成導線が後退していない。
+- backend request spec、フロントJest、TypeScript検査、375px手動QAが完了している。

--- a/docs/superpowers/specs/2026-07-13-dream-share-card-profile-design.md
+++ b/docs/superpowers/specs/2026-07-13-dream-share-card-profile-design.md
@@ -1,0 +1,141 @@
+# プロフィール別シェアカード（DreamShareCard プロフィール対応）設計仕様
+
+- 日付: 2026-07-13
+- 対象: YumeTree フロントエンド（Next.js 16 + Tailwind v4）＋ バックエンド（Rails 7.2, 最小追加）
+- 位置づけ: `phase5-dream-profiles-design.md` の将来アイディア「プロフィール別シェアカード（『太郎の夢』としてシェアカードを生成）」。
+  世界観MVP**第2弾**（第1弾は「今週のゆめニュース」PR #423）。
+
+## 0. 方針・調査結果
+
+**シェアカード機能自体は既に実装済み**。今回はゼロからの新規開発ではなく、既存 `DreamShareCard` の**プロフィール対応拡張**である。
+
+調査で判明した現状:
+- `frontend/app/components/DreamShareCard.tsx` が既に存在し、以下を実装済み（複数の修正コミットで枯れている）:
+  - AI夢画像＋夢タイトル＋日付＋感情タグ＋YumeTreeブランドのカード表示
+  - 「画像として保存」: `html-to-image` の `toPng`、`/api/image-proxy` 経由のCORS/tainted-canvas回避、iOS Web Share API、`<a download>` フォールバック
+  - 「リンクをコピー」
+  - 単体テスト `frontend/__tests__/components/DreamShareCard.test.tsx`（約490行）
+- **欠けているのは「プロフィール別」の要素**: カードにプロフィールの名前・アバターが一切出ない（props に profile 情報がなく、`dream/[id]/page.tsx` からも渡していない）。
+- **現状の制約**: カードは `generatedImageUrl` が存在する夢でしか表示されない（AI画像未生成の夢には共有カード自体が出ない）。
+- 夢詳細API（`DreamsController#show`）は `dream_profile_id` のみ返し、**`dream_profile` オブジェクト（name/avatar_emoji/color）は返していない**。一方 `index` / `month` は既に `dream_profile_json_options`（`{ only: [:id, :name, :avatar_emoji, :color, :active] }`）で `dream_profile` を include 済み。
+- `frontend/app/types.ts` の `Dream` 型は `dream_profile?: Pick<DreamProfile, "id"|"name"|"avatar_emoji"|"color"|"active"> | null` を既に定義済み。
+
+→ **やること: (A) `show` に `dream_profile` include を1つ足す（`index` と同じ `dream_profile_json_options` を再利用）。(B) `DreamShareCard` にプロフィール識別と、AI画像なし時のフォールバック意匠を追加。(C) `dream/[id]/page.tsx` の配置を「画像あり時のみ」から常時表示へ整理。** 新規エンドポイント・migration・DBスキーマ変更・Stripe・OpenAI呼び出しの追加は無し。
+
+## 1. スコープ（決定事項）
+
+- 共有の仕組み: **画像ダウンロード（client完結）**。公開シェアURL・新規バックエンドエンドポイントは作らない（既存 `DreamShareCard` の方式を踏襲）。
+- カードの主役: **1件の夢**（夢詳細画面から起動）。
+- 広さ: **プロフィール対応 ＋ AI画像なしの夢にも対応**（画像がない夢もカード化・共有できるようにする）。
+- プロフィールデータの取得元: **夢詳細API（`show`）に `dream_profile` を include**（フロントでの別取得はしない）。
+
+## 2. バックエンド変更（最小・追加のみ）
+
+`backend/app/controllers/dreams_controller.rb` の `show` アクションの `as_json` に、既存 `dream_profile_json_options` を使って `dream_profile` を include する。
+
+現状:
+```ruby
+def show
+  render json: @dream.as_json(
+    only: [:id, :title, :created_at, :content, :analysis_json, :analysis_status, :analyzed_at, :generated_image_url, :dream_profile_id],
+    include: :emotions
+  )
+end
+```
+
+変更後:
+```ruby
+def show
+  render json: @dream.as_json(
+    only: [:id, :title, :created_at, :content, :analysis_json, :analysis_status, :analyzed_at, :generated_image_url, :dream_profile_id],
+    include: {
+      emotions: {},
+      dream_profile: dream_profile_json_options
+    }
+  )
+end
+```
+
+- `dream_profile_json_options` は既存の private メソッド（`{ only: [:id, :name, :avatar_emoji, :color, :active] }`）をそのまま再利用（新しいシリアライズ定義を作らない）。
+- `dream_profile_id` が NULL の夢（理論上は NOT NULL 化済みだが防御的に）や、アーカイブ済みプロフィールに属する夢でも安全に動く（`dream_profile` が nil のときは include が nil を返すだけ）。
+- N+1 回避: `set_dream_and_authorize_user` は単一レコード取得なので `includes` 不要（1レコードの関連ロードは1クエリ追加のみ）。
+- 認可: `show` は既に `set_dream_and_authorize_user` で current_user の夢に限定済み。`dream_profile` も同一ユーザーの所有物なので情報漏洩なし。
+
+## 3. フロントエンド: `DreamShareCard` プロフィール対応
+
+`frontend/app/components/DreamShareCard.tsx` を**後方互換を保って**拡張する（既存の保存/コピー/proxy ロジックは変更しない）。
+
+### props 追加（すべて optional。既存呼び出し・既存テストを壊さない）
+```ts
+type DreamShareCardProps = {
+  imageUrl?: string | null;   // 変更: 必須 → optional（AI画像なし対応）
+  title: string;
+  recordedAt: string;
+  emotionLabels: string[];
+  imageAlt: string;
+  onImageError?: () => void;
+  profileName?: string;       // 追加
+  profileEmoji?: string;      // 追加（avatar_emoji）
+  profileColor?: string;      // 追加（アクセント色）
+};
+```
+
+### プロフィール識別の意匠
+- カード本体（`<section ref={cardRef}>`）内、YumeTreeヘッダー行の下・日付/タイトルの近くに**プロフィールチップ**を追加: `{profileEmoji} {profileName}`。
+- `profileColor` をチップの枠線/背景アクセントに使う（`color` は hex 文字列。`${profileColor}22` 等でごく薄い背景。6桁hex前提は既存 `ForestPreviewWidget` と同じ運用）。
+- `profileName` / `profileEmoji` が未指定のときはチップを描画しない（後方互換）。
+- 夢タイトル（`title`）はそのまま。プロフィールは別要素として添え、「誰の夢か」を明示する（例: チップ「🐱 ねこさん」＋タイトル「星空を走る夢」）。
+
+### AI画像なしフォールバック意匠（`imageUrl` が空/未指定のとき）
+- 現状の `<div className="relative aspect-square">` 内の `<Image>` を条件分岐する:
+  - `imageUrl` あり → 従来通り `<Image>`（proxy 保存ロジックもそのまま）
+  - `imageUrl` なし → **フォールバック意匠**: `profileColor` ベースのグラデーション背景＋中央に大きめ `avatar_emoji`（無ければ 🌙 等の既定絵文字）＋（任意で）夢タイトルの控えめ表示。写真がなくても「らしさ」が出る**静的CSS意匠**（新規AI生成は呼ばない＝課金・遅延ゼロ）。
+- `handleSave` は既に `const img = card.querySelector("img"); if (img) {…}` とガードしているため、img が無い（フォールバック）ときは画像差し替えをスキップして `toPng(card)` に直行する。**保存ロジック本体の変更は不要**（この事実を実装時に確認する）。
+- **`imageUrl` を optional 化することに伴う要注意点（実装時に必ず対処）**:
+  - コンポーネント冒頭の `const proxyUrl = /api/image-proxy?url=${encodeURIComponent(imageUrl)}` は現在 `imageUrl` を無条件参照している。optional 化後は `imageUrl` がある場合のみ計算する（`handleSave` 内で算出、または `imageUrl ? … : undefined`）。
+  - `handleSave` 内の `SAFE_DATA_PREFIXES.some((p) => imageUrl.startsWith(p))` と `imageUrl.startsWith("https://")` は `if (img)` ブロック内なので実行時は `imageUrl` が存在するが、TypeScript の型は narrowing が必要。`if (img && imageUrl)` などで明示的に絞る。
+
+## 4. フロントエンド: `dream/[id]/page.tsx` の配置整理
+
+現状はカードが `generatedImageUrl ?` の真ブランチでしか描画されない。AI画像なしの夢でもカードを出すため、次のように整理する:
+
+- `DreamShareCard` を `generatedImageUrl` の有無に関わらず**常に描画**し、`imageUrl={generatedImageUrl}`（null可）と `profile*` props を渡す。
+- profile props は `dream.dream_profile`（§2で include されるようになる）から渡す: `profileName={dream.dream_profile?.name}` / `profileEmoji={dream.dream_profile?.avatar_emoji}` / `profileColor={dream.dream_profile?.color}`。
+- 「🎨 画像を生成する / 描き直す」ボタン（既存の `handleGenerateImage`・枚数表示・エラー表示）は**残す**。カードの下（または画像がないときはカード内フォールバックの近く）に配置し、ユーザーが引き続きAI画像を生成できるようにする。
+- 既存の imageError / imageQuota 表示は維持する。
+
+## 5. テスト方針
+
+### バックエンド（RSpec request spec）
+- `show` のレスポンスに `dream_profile`（id/name/avatar_emoji/color/active）が含まれることを検証する1ケースを追加（既存の dreams request spec があればそこへ）。
+- `dream_profile` が nil の夢でも 200 で壊れないことを1ケース。
+- Docker内で実行（`docker compose` の backend-test サービス。ホストRubyはgem未導入）。
+
+### フロントエンド（既存 `DreamShareCard.test.tsx` を拡張）
+既存の `DEFAULT_PROPS`・モック（`html-to-image`/`next/image`/`react-hot-toast`）はそのまま活かし、以下を追加:
+1. `profileName`/`profileEmoji` を渡すとカードに「🐱 ねこさん」相当が表示される
+2. profile props 未指定のとき、プロフィールチップが描画されない（後方互換）
+3. `imageUrl` 未指定（フォールバック）のとき、`<img>` が描画されず、フォールバック意匠（大アバター等）が表示される
+4. `imageUrl` 未指定でも「画像として保存」が `toPng` を呼べる（img 差し替えをスキップして保存に到達する）
+- 既存の全テスト（約490行）が引き続き緑であることを確認（後方互換の担保）。
+
+## 6. 検証方針
+
+### 完成条件
+1. `show` が `dream_profile` を返す（RSpec緑）
+2. `DreamShareCard` がプロフィール識別を表示し、AI画像なしの夢でもカード生成・保存できる
+3. `dream/[id]/page.tsx` でカードが画像有無に関わらず表示され、profile props が渡る
+4. `yarn jest` 全緑 ＋ `tsc --noEmit` 新規型エラーなし ＋ backend RSpec 緑
+
+### 手動QA（デプロイ後のスマホ実機）
+- [ ] AI画像ありの夢: カードにプロフィールチップが出る／保存できる
+- [ ] AI画像なしの夢: フォールバック意匠のカードが出る／保存できる
+- [ ] スマホ幅でカードが横にはみ出さない・長いプロフィール名/夢タイトルで崩れない
+- [ ] アーカイブ済みプロフィールの夢でもプロフィール名が出る
+- [ ] 「画像を生成する」導線が引き続き機能する
+
+## 7. 境界
+
+**触る**: `backend/app/controllers/dreams_controller.rb`（`show` に include 1つ）/ `frontend/app/components/DreamShareCard.tsx`（props追加・意匠）/ `frontend/app/dream/[id]/page.tsx`（配置整理）/ テスト（既存拡張＋backend 1件）。
+
+**触らない**: 新規エンドポイント・ルーティング・migration・DBスキーマ・Stripe・OpenAI API・認証ゲート・`DreamShareCard` の保存/コピー/proxy コアロジック・他の画面。公開シェアURL・別アカウント共有は今回のMVPスコープ外（将来 `shareable` フラグ案として温存）。

--- a/docs/superpowers/specs/2026-07-13-dream-share-card-profile-design.md
+++ b/docs/superpowers/specs/2026-07-13-dream-share-card-profile-design.md
@@ -57,7 +57,7 @@ end
 ```
 
 - `dream_profile_json_options` は既存の private メソッド（`{ only: [:id, :name, :avatar_emoji, :color, :active] }`）をそのまま再利用（新しいシリアライズ定義を作らない）。
-- `dream_profile_id` が NULL の夢（理論上は NOT NULL 化済みだが防御的に）や、アーカイブ済みプロフィールに属する夢でも安全に動く（`dream_profile` が nil のときは include が nil を返すだけ）。
+- `dream_profile_id` はDBで NOT NULL 化済みのため、通常のアプリ経路では `dream_profile` が nil の夢は作れない。アーカイブ済みプロフィールに属する夢は関連を保持したまま同じ軽量情報を返す。
 - N+1 回避: `set_dream_and_authorize_user` は単一レコード取得なので `includes` 不要（1レコードの関連ロードは1クエリ追加のみ）。
 - 認可: `show` は既に `set_dream_and_authorize_user` で current_user の夢に限定済み。`dream_profile` も同一ユーザーの所有物なので情報漏洩なし。
 
@@ -101,14 +101,16 @@ type DreamShareCardProps = {
 
 - `DreamShareCard` を `generatedImageUrl` の有無に関わらず**常に描画**し、`imageUrl={generatedImageUrl}`（null可）と `profile*` props を渡す。
 - profile props は `dream.dream_profile`（§2で include されるようになる）から渡す: `profileName={dream.dream_profile?.name}` / `profileEmoji={dream.dream_profile?.avatar_emoji}` / `profileColor={dream.dream_profile?.color}`。
+- 既存の `handleImageLoadError` は表示できない画像を検出すると `generatedImageUrl` を `null` に戻すため、期限切れ・読込失敗時も同じフォールバックカードへ切り替わる。エラー文はカード付近に残して再生成可能であることを示す。
 - 「🎨 画像を生成する / 描き直す」ボタン（既存の `handleGenerateImage`・枚数表示・エラー表示）は**残す**。カードの下（または画像がないときはカード内フォールバックの近く）に配置し、ユーザーが引き続きAI画像を生成できるようにする。
 - 既存の imageError / imageQuota 表示は維持する。
+- 既存の「リンクをコピー」は挙動を変更しない。コピー先は認証付き夢詳細URLのままであり、公開共有URLではないことをMVP境界として扱う。
 
 ## 5. テスト方針
 
 ### バックエンド（RSpec request spec）
 - `show` のレスポンスに `dream_profile`（id/name/avatar_emoji/color/active）が含まれることを検証する1ケースを追加（既存の dreams request spec があればそこへ）。
-- `dream_profile` が nil の夢でも 200 で壊れないことを1ケース。
+- `dream_profile_id` はDBの NOT NULL 制約で保証されるため、成立しない nil 関連のテストは追加しない。既存の他ユーザー夢への認可テストを回帰確認する。
 - Docker内で実行（`docker compose` の backend-test サービス。ホストRubyはgem未導入）。
 
 ### フロントエンド（既存 `DreamShareCard.test.tsx` を拡張）

--- a/frontend/__tests__/components/DreamDetailPage.test.tsx
+++ b/frontend/__tests__/components/DreamDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, within, fireEvent } from "@testing-library/react";
 import DreamDetailPage from "@/app/dream/[id]/page";
 
 jest.mock("react", () => {
@@ -177,6 +177,106 @@ describe("DreamDetailPage", () => {
 
     const shareCard = screen.getByTestId("dream-share-card");
     expect(shareCard.contains(dreamImgs[0])).toBe(true);
+  });
+
+  it("画像がない夢でもシェアカードとフォールバックが表示される", () => {
+    useDream.mockReturnValue({
+      dream: {
+        id: 3,
+        title: "画像なしの夢",
+        content: "本文テスト",
+        created_at: "2025-01-01T00:00:00.000Z",
+        updated_at: "2025-01-01T00:00:00.000Z",
+        userId: 1,
+        emotions: [],
+        analysis_json: { emotion_tags: [] },
+      },
+      error: null,
+      isLoading: false,
+      isUpdating: false,
+      updateDream: jest.fn(),
+      deleteDream: jest.fn(),
+    });
+
+    render(<DreamDetailPage params={{ id: "3" } as never} />);
+
+    expect(screen.getByTestId("dream-share-card")).toBeTruthy();
+    expect(screen.getByTestId("dream-share-card-fallback")).toBeTruthy();
+  });
+
+  it("dream.dream_profile の名前・絵文字がシェアカードに表示される", () => {
+    useDream.mockReturnValue({
+      dream: {
+        id: 4,
+        title: "プロフィール付きの夢",
+        content: "本文テスト",
+        created_at: "2025-01-01T00:00:00.000Z",
+        updated_at: "2025-01-01T00:00:00.000Z",
+        userId: 1,
+        emotions: [],
+        analysis_json: { emotion_tags: [] },
+        dream_profile: {
+          id: 10,
+          name: "ねこさん",
+          avatar_emoji: "🐱",
+          color: "#f97316",
+          active: true,
+        },
+      },
+      error: null,
+      isLoading: false,
+      isUpdating: false,
+      updateDream: jest.fn(),
+      deleteDream: jest.fn(),
+    });
+
+    render(<DreamDetailPage params={{ id: "4" } as never} />);
+
+    const shareCard = screen.getByTestId("dream-share-card");
+    const chip = within(shareCard).getByTestId("profile-chip");
+    expect(chip.textContent).toContain("ねこさん");
+    expect(chip.textContent).toContain("🐱");
+  });
+
+  it("画像の onError で既存エラー文が表示され、フォールバックへ切り替わる", () => {
+    const AI_IMAGE_URL =
+      "https://oaidalleapiprodscus.blob.core.windows.net/private/img-error-test.png";
+
+    useDream.mockReturnValue({
+      dream: {
+        id: 5,
+        title: "期限切れ画像の夢",
+        content: "本文テスト",
+        created_at: "2025-01-01T00:00:00.000Z",
+        updated_at: "2025-01-01T00:00:00.000Z",
+        userId: 1,
+        emotions: [],
+        analysis_json: { emotion_tags: [] },
+        generated_image_url: AI_IMAGE_URL,
+      },
+      error: null,
+      isLoading: false,
+      isUpdating: false,
+      updateDream: jest.fn(),
+      deleteDream: jest.fn(),
+    });
+
+    render(<DreamDetailPage params={{ id: "5" } as never} />);
+
+    const shareCardBefore = screen.getByTestId("dream-share-card");
+    const img = within(shareCardBefore).getByRole("img");
+    fireEvent.error(img);
+
+    expect(
+      screen.getByText(
+        "ほぞんずみ の ゆめのえ の きげん が きれました。もういちど かいてみてください。"
+      )
+    ).toBeTruthy();
+
+    const shareCardAfter = screen.getByTestId("dream-share-card");
+    expect(
+      within(shareCardAfter).getByTestId("dream-share-card-fallback")
+    ).toBeTruthy();
   });
 
   it("does not render dream content inside the share card", () => {

--- a/frontend/__tests__/components/DreamShareCard.test.tsx
+++ b/frontend/__tests__/components/DreamShareCard.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import DreamShareCard from "@/app/components/DreamShareCard";
 import * as htmlToImage from "html-to-image";
 
@@ -504,6 +504,70 @@ describe("DreamShareCard", () => {
         expect(toast.error).toHaveBeenCalledWith("画像の保存に失敗しました");
       });
       expect(htmlToImage.toPng).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("プロフィール識別", () => {
+    it("profileName/profileEmoji/profileColorを渡すとカードにプロフィールチップが表示される", () => {
+      render(
+        <DreamShareCard
+          {...DEFAULT_PROPS}
+          profileName="ねこさん"
+          profileEmoji="🐱"
+          profileColor="#f97316"
+        />
+      );
+      const card = screen.getByTestId("dream-share-card");
+      const chip = within(card).getByTestId("profile-chip");
+      expect(chip.textContent).toContain("🐱");
+      expect(chip.textContent).toContain("ねこさん");
+    });
+
+    it("profile propsを渡さない場合はプロフィールチップを描画しない（後方互換）", () => {
+      render(<DreamShareCard {...DEFAULT_PROPS} />);
+      expect(screen.queryByTestId("profile-chip")).toBeNull();
+    });
+  });
+
+  describe("AI画像なしフォールバック", () => {
+    it("imageUrlがnullの場合はimgを描画せず既定アバターのフォールバックを表示する", () => {
+      render(<DreamShareCard {...DEFAULT_PROPS} imageUrl={null} />);
+      expect(screen.queryByRole("img")).toBeNull();
+      const fallback = screen.getByTestId("dream-share-card-fallback");
+      expect(fallback.textContent).toContain("🌙");
+    });
+
+    it("imageUrlがnullでprofileEmoji指定時はそのアバターをフォールバックに表示する", () => {
+      render(
+        <DreamShareCard
+          {...DEFAULT_PROPS}
+          imageUrl={null}
+          profileEmoji="🐱"
+        />
+      );
+      const fallback = screen.getByTestId("dream-share-card-fallback");
+      expect(fallback.textContent).toContain("🐱");
+    });
+
+    it("imageUrlがnullでも保存ボタンからtoPngに到達し、画像proxyへfetchしない", async () => {
+      const mockFetch = jest.fn<typeof fetch>();
+      global.fetch = mockFetch as unknown as typeof fetch;
+      jest.mocked(htmlToImage.toPng).mockResolvedValue("data:image/png;base64,abc");
+      const mockAnchor = { href: "", download: "", click: jest.fn() };
+      jest
+        .spyOn(document, "createElement")
+        .mockImplementation((tag: string) => {
+          if (tag === "a") return mockAnchor as unknown as HTMLElement;
+          return realCreateElement(tag as keyof HTMLElementTagNameMap) as HTMLElement;
+        });
+
+      render(<DreamShareCard {...DEFAULT_PROPS} imageUrl={null} />);
+      fireEvent.click(screen.getByTestId("save-image-button"));
+
+      await waitFor(() => {
+        expect(htmlToImage.toPng).toHaveBeenCalled();
+      });
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/app/components/DreamShareCard.tsx
+++ b/frontend/app/components/DreamShareCard.tsx
@@ -8,13 +8,19 @@ import { Download, Link } from "lucide-react";
 import { EmotionTag } from "./EmotionTag";
 
 type DreamShareCardProps = {
-  imageUrl: string;
+  imageUrl?: string | null;
   title: string;
   recordedAt: string;
   emotionLabels: string[];
   imageAlt: string;
   onImageError?: () => void;
+  profileName?: string;
+  profileEmoji?: string;
+  profileColor?: string;
 };
+
+// AI画像・プロフィールアバターがどちらも無いときのフォールバック絵文字
+const DEFAULT_AVATAR_EMOJI = "🌙";
 
 function formatDate(dateInput: string): string {
   const date = new Date(dateInput);
@@ -61,12 +67,13 @@ export default function DreamShareCard({
   emotionLabels,
   imageAlt,
   onImageError,
+  profileName,
+  profileEmoji,
+  profileColor,
 }: DreamShareCardProps) {
   const formattedDate = formatDate(recordedAt);
   const cardRef = useRef<HTMLElement>(null);
   const [isSaving, setIsSaving] = useState(false);
-
-  const proxyUrl = `/api/image-proxy?url=${encodeURIComponent(imageUrl)}`;
 
   const handleCopyLink = async () => {
     try {
@@ -90,12 +97,13 @@ export default function DreamShareCard({
     let objectUrl: string | null = null;
 
     try {
-      if (img) {
+      if (img && imageUrl) {
         if (SAFE_DATA_PREFIXES.some((p) => imageUrl.startsWith(p))) {
           // png / jpeg / webp base64 data URL は同一オリジン扱い。tainted canvas が発生しないためそのまま使う
           await waitForImageReady(img);
         } else if (imageUrl.startsWith("https://")) {
           // https: URL は same-origin proxy 経由で差し替え（CORS / tainted canvas 回避）
+          const proxyUrl = `/api/image-proxy?url=${encodeURIComponent(imageUrl)}`;
           const res = await fetch(proxyUrl);
           if (!res.ok) throw new Error("proxy fetch failed");
           const blob = await res.blob();
@@ -151,15 +159,34 @@ export default function DreamShareCard({
         className="mt-6 overflow-hidden rounded-lg border border-sky-200/70 bg-gradient-to-br from-sky-50 via-white to-amber-50 text-slate-900 shadow-lg"
       >
         <div className="relative aspect-square overflow-hidden bg-slate-100">
-          <Image
-            src={imageUrl}
-            alt={`${imageAlt} シェアカード`}
-            fill
-            sizes="(max-width: 768px) 100vw, 768px"
-            className="object-cover"
-            unoptimized
-            onError={onImageError}
-          />
+          {imageUrl ? (
+            <Image
+              src={imageUrl}
+              alt={`${imageAlt} シェアカード`}
+              fill
+              sizes="(max-width: 768px) 100vw, 768px"
+              className="object-cover"
+              unoptimized
+              onError={onImageError}
+            />
+          ) : (
+            <div
+              data-testid="dream-share-card-fallback"
+              className="flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center"
+              style={{
+                background: profileColor
+                  ? `linear-gradient(135deg, ${profileColor}33, ${profileColor}0d)`
+                  : "linear-gradient(135deg, #bae6fd, #fef3c7)",
+              }}
+            >
+              <span className="text-7xl leading-none" aria-hidden="true">
+                {profileEmoji || DEFAULT_AVATAR_EMOJI}
+              </span>
+              <p className="max-w-full truncate text-sm font-medium text-slate-600">
+                {title}
+              </p>
+            </div>
+          )}
         </div>
 
         <div className="space-y-4 p-5">
@@ -169,6 +196,22 @@ export default function DreamShareCard({
             </p>
             <p className="text-xs font-semibold text-slate-500">ユメツリー</p>
           </div>
+
+          {profileName && profileEmoji && (
+            <div
+              data-testid="profile-chip"
+              className="inline-flex min-w-0 max-w-full items-center gap-1.5 self-start rounded-full border px-3 py-1 text-sm font-semibold text-slate-700"
+              style={{
+                backgroundColor: profileColor ? `${profileColor}22` : "#f1f5f9",
+                borderColor: profileColor ? `${profileColor}55` : "#e2e8f0",
+              }}
+            >
+              <span aria-hidden="true" className="shrink-0">
+                {profileEmoji}
+              </span>
+              <span className="min-w-0 truncate">{profileName}</span>
+            </div>
+          )}
 
           <div>
             {formattedDate && (

--- a/frontend/app/dream/[id]/page.tsx
+++ b/frontend/app/dream/[id]/page.tsx
@@ -314,19 +314,22 @@ export default function DreamDetailPage({
             description="とどいた メールの リンクを ひらいてから、もういちど かいてみてね。"
           />
         )}
+        <DreamShareCard
+          imageUrl={generatedImageUrl}
+          title={dream.title}
+          recordedAt={dream.created_at}
+          emotionLabels={displayTags}
+          imageAlt={copy.imageAlt}
+          onImageError={handleImageLoadError}
+          profileName={dream.dream_profile?.name}
+          profileEmoji={dream.dream_profile?.avatar_emoji}
+          profileColor={dream.dream_profile?.color}
+        />
         {generatedImageUrl ? (
-          <div className="space-y-2">
+          <div className="space-y-2 mt-2">
             {imageError && (
               <p className="text-xs text-destructive">{imageError}</p>
             )}
-            <DreamShareCard
-              imageUrl={generatedImageUrl}
-              title={dream.title}
-              recordedAt={dream.created_at}
-              emotionLabels={displayTags}
-              imageAlt={copy.imageAlt}
-              onImageError={handleImageLoadError}
-            />
             <div className="flex justify-end">
               <button
                 type="button"
@@ -339,7 +342,7 @@ export default function DreamDetailPage({
             </div>
           </div>
         ) : (
-          <div className="flex flex-col items-center gap-3 py-6 rounded-xl border border-dashed border-border bg-muted/20">
+          <div className="flex flex-col items-center gap-3 py-6">
             <button
               type="button"
               onClick={handleGenerateImage}

--- a/frontend/e2e/dream-detail-flow.spec.ts
+++ b/frontend/e2e/dream-detail-flow.spec.ts
@@ -89,7 +89,7 @@ test.describe("夢詳細の閲覧・編集・再分析・保存フロー", () =>
 
     // タイトルが表示されていることを確認
     await expect(
-      page.getByRole("heading", { name: "テストの夢" })
+      page.getByRole("heading", { level: 1, name: "テストの夢" })
     ).toBeVisible();
 
     // 「ゆめの おはなし」セクションに夢の内容が表示されていることを確認
@@ -135,7 +135,7 @@ test.describe("夢詳細の閲覧・編集・再分析・保存フロー", () =>
     // 「やめる」をクリックすると閲覧モードに戻ることを確認
     await page.getByRole("button", { name: "やめる" }).click();
     await expect(
-      page.getByRole("heading", { name: "テストの夢" })
+      page.getByRole("heading", { level: 1, name: "テストの夢" })
     ).toBeVisible();
     await expect(
       page.getByRole("button", { name: /✏️ なおす/ })
@@ -321,7 +321,7 @@ test.describe("夢詳細の閲覧・編集・再分析・保存フロー", () =>
 
     // 保存後に閲覧モードへ戻り、更新後のタイトルが表示されていることを確認
     await expect(
-      page.getByRole("heading", { name: "変更後のタイトル" })
+      page.getByRole("heading", { level: 1, name: "変更後のタイトル" })
     ).toBeVisible();
     await expect(
       page.getByRole("button", { name: /✏️ なおす/ })


### PR DESCRIPTION
## Summary
世界観MVP**第2弾**（第1弾は「今週のゆめニュース」PR #423）。既存の `DreamShareCard`（PNG保存・リンクコピー・image-proxy・iOS共有・約490行のテスト）を**プロフィール対応**に拡張し、**AI画像がない夢でもカードを生成・保存**できるようにした。

- **調査結論**: シェアカード機能自体は既に実装済みで、欠けていたのは「プロフィール別」の要素だった。ゼロから作らず既存資産を拡張。
- 設計仕様: `docs/superpowers/specs/2026-07-13-dream-share-card-profile-design.md` / 実装計画: `docs/superpowers/plans/2026-07-13-dream-share-card-profile.md`

## 変更点（3タスク）
- **Task 1（backend）**: `GET /dreams/:id`（`DreamsController#show`）が軽量 `dream_profile`（id/name/avatar_emoji/color/active）を返すようにした。既存 `dream_profile_json_options` を再利用（新規エンドポイント・migrationなし）。+ RSpec
- **Task 2（DreamShareCard）**: `imageUrl` を optional 化＋ `profileName`/`profileEmoji`/`profileColor` を追加。プロフィール識別チップ＋AI画像なし時のグラデ＋大アバターのフォールバック意匠。保存/proxy/iOS/コピーのコアロジックは非変更（型narrowingとproxyUrl条件化のみ）。+ テスト
- **Task 3（夢詳細ページ）**: カードを画像有無に関わらず常時表示に整理し、`dream.dream_profile` から props を渡す。画像生成CTA・枚数・エラー表示は維持。期限切れ画像は既存 `handleImageLoadError` でURL破棄→同じカードのフォールバックへ切替。+ テスト

## 実装プロセス（Subagent-Driven Development）
- Task 1〜3: 各タスクで実装subagent＋タスクレビュー（Spec準拠✅ / 品質Approved、Critical/Important指摘なし）
- 全体レビュー（whole-branch, opus）: **Ready to merge = Yes**、Critical/Important指摘なし（Minor 3点はすべて意図的/装飾のみ）

## Test plan
- [x] `cd frontend && npx jest` — 52 suites / **387 tests 全緑**
- [x] `cd frontend && npx tsc --noEmit` — 変更ソース3ファイルに新規型エラーなし
- [x] backend `docker compose run --rm backend-test bundle exec rspec spec/requests/dreams_spec.rb` — **88 examples, 0 failures**
- [x] `git diff --check` 通過
- [ ] スマホ実機QA（375px）: プロフィールチップ表示・AI画像なしフォールバック・保存・アーカイブ済みプロフィールの夢での名前表示 — デプロイ後に確認予定

## 境界
新規エンドポイント・ルーティング・migration・DBスキーマ・Stripe・OpenAI・認証ゲートには触れない。公開シェアURL・別アカウント共有はMVPスコープ外。