### PR TITLE
refactor: 森詳細page.tsxのヘルパー4関数をforestProfileUtils.tsへ分離

### DIFF
--- a/frontend/__tests__/components/ForestProfilePage.test.tsx
+++ b/frontend/__tests__/components/ForestProfilePage.test.tsx
@@ -4,7 +4,7 @@ import {
   isValidForestProfileId,
   normalizeDreamProfilesResponse,
   normalizeProfileDreamsResponse,
-} from "@/app/forest/[profileId]/page";
+} from "@/app/forest/[profileId]/forestProfileUtils";
 
 function profile(overrides: Partial<DreamProfile> = {}): DreamProfile {
   return {

--- a/frontend/app/forest/[profileId]/forestProfileUtils.ts
+++ b/frontend/app/forest/[profileId]/forestProfileUtils.ts
@@ -1,0 +1,26 @@
+import type { Dream, DreamProfile } from "@/app/types";
+
+export function isValidForestProfileId(profileId: number): boolean {
+  return Number.isInteger(profileId) && profileId > 0;
+}
+
+export function normalizeDreamProfilesResponse(value: unknown): DreamProfile[] | null {
+  if (Array.isArray(value)) return value as DreamProfile[];
+
+  console.error("Unexpected dream profiles response for forest detail", value);
+  return null;
+}
+
+export function normalizeProfileDreamsResponse(value: unknown): Dream[] {
+  if (Array.isArray(value)) return value as Dream[];
+
+  console.error("Unexpected dreams response for forest detail", value);
+  return [];
+}
+
+export function findActiveForestProfile(
+  profiles: DreamProfile[],
+  profileId: number
+): DreamProfile | null {
+  return profiles.find((p) => p.id === profileId && !p.archived) ?? null;
+}

--- a/frontend/app/forest/[profileId]/page.tsx
+++ b/frontend/app/forest/[profileId]/page.tsx
@@ -30,31 +30,12 @@ import ForestGuide from "@/app/components/forest/ForestGuide";
 import SeasonalParticles from "@/app/components/forest/SeasonalParticles";
 import FruitLegend from "@/app/components/forest/FruitLegend";
 import ParticleField from "@/app/components/forest/ParticleField";
-
-export function isValidForestProfileId(profileId: number): boolean {
-  return Number.isInteger(profileId) && profileId > 0;
-}
-
-export function normalizeDreamProfilesResponse(value: unknown): DreamProfile[] | null {
-  if (Array.isArray(value)) return value as DreamProfile[];
-
-  console.error("Unexpected dream profiles response for forest detail", value);
-  return null;
-}
-
-export function normalizeProfileDreamsResponse(value: unknown): Dream[] {
-  if (Array.isArray(value)) return value as Dream[];
-
-  console.error("Unexpected dreams response for forest detail", value);
-  return [];
-}
-
-export function findActiveForestProfile(
-  profiles: DreamProfile[],
-  profileId: number
-): DreamProfile | null {
-  return profiles.find((p) => p.id === profileId && !p.archived) ?? null;
-}
+import {
+  isValidForestProfileId,
+  normalizeDreamProfilesResponse,
+  normalizeProfileDreamsResponse,
+  findActiveForestProfile,
+} from "./forestProfileUtils";
 
 // ---- 実タップで開く夢プレビューモーダル -----------------------------------
 function DreamPreviewModal({


### PR DESCRIPTION
## Summary
`frontend/app/forest/[profileId]/page.tsx` が export していたヘルパー4関数（`isValidForestProfileId` / `normalizeDreamProfilesResponse` / `normalizeProfileDreamsResponse` / `findActiveForestProfile`）を兄弟モジュール `forestProfileUtils.ts` へ移動し、pageを **default export のみ**に整理。ロジック変更なし（純粋な移動＋import更新）。

## 経緯（正直な位置づけ）
- 6月時点の記録では「page.tsxの任意named exportで `next build` の型チェックが失敗する」とされていたが、**現行 Next 16.2.7 では再現しない**ことを確認した（main素の状態で `next build` 成功・`.next/types` 生成後の `tsc --noEmit` もforest関連エラーなし）。
- そのため本PRは**ビルド修正ではなく規約整理**: App Routerのpageファイルに任意exportを置くのは過去に実際にビルドを壊した footgun であり、Next側の制約が再厳格化しても壊れない構造にしておく。デザインシステム#4（森画面刷新）がこのファイルを触る前の前捌きも兼ねる。

## Test plan
- [x] `ForestProfilePage.test.tsx` 6/6緑（importを `forestProfileUtils` へ変更）
- [x] `npx jest` 全体 52 suites / 387 tests 緑
- [x] `npx next build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)