### PR TITLE
feat: 夢の部屋（額縁の壁）を追加

### DIFF
--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -23,7 +23,7 @@ class DreamsController < ApplicationController
     # generated_image_url は base64 で最大 1MB になるため一覧では SELECT 時点で除外する。
     # as_json(only:) だけでは ActiveRecord が SELECT * でロードするためメモリに乗る。
     # 詳細画面（show）でのみ返す。
-    index_columns = %i[id title content created_at analysis_json analysis_status analyzed_at user_id dream_profile_id]
+    index_columns = %i[id title content created_at analysis_json analysis_status analyzed_at user_id dream_profile_id image_generated_at]
     initial_scope = current_user.dreams.select(index_columns).order(created_at: :desc)
     filter_params = params.permit(:query, :start_date, :end_date, :dream_profile_id, emotion_ids: [])
     @dreams = DreamFilterQuery.new(initial_scope, filter_params).call.includes(:emotions, :dream_profile)

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -366,6 +366,36 @@ RSpec.describe 'Dreams API', type: :request do
         )
       end
 
+      it 'image_generated_at を含める（部屋のギャラリー用）' do
+        dream = create(
+          :dream,
+          user: user,
+          image_generated_at: Time.current,
+          generated_image_url: 'data:image/png;base64,ZmFrZQ=='
+        )
+
+        authenticated_get('/dreams', user)
+
+        json_response = JSON.parse(response.body)
+        returned_dream = json_response.find { |item| item['id'] == dream.id }
+        expect(returned_dream).to have_key('image_generated_at')
+        expect(returned_dream['image_generated_at']).to be_present
+      end
+
+      it 'generated_image_url は一覧に含めない（軽量化を維持）' do
+        create(
+          :dream,
+          user: user,
+          image_generated_at: Time.current,
+          generated_image_url: 'data:image/png;base64,ZmFrZQ=='
+        )
+
+        authenticated_get('/dreams', user)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response.first).not_to have_key('generated_image_url')
+      end
+
       context 'フィルタリング' do
         it 'emotion_idsパラメーターでフィルタリングできる' do
           dream_with_emotion = create(:dream, user: user)

--- a/docs/superpowers/plans/2026-07-17-dream-room.md
+++ b/docs/superpowers/plans/2026-07-17-dream-room.md
@@ -1,0 +1,1192 @@
+# 夢の部屋（額縁の壁）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** プロフィールごとのAI生成夢画像を「額縁の壁」として振り返れる新規ページ `/room/[profileId]` を追加する。
+
+**Architecture:** `GET /dreams`（一覧API）に`image_generated_at`を1列追加するだけで既存の軽量方針（`generated_image_url`は一覧から除外）を維持する。フロントは`getDreamsForProfile`で取得した夢のうち画像生成済みのものを`image_generated_at`降順（同時刻は`id`降順）で並べ、最大6件を「額縁」として表示する。各額縁の画像本体は`GET /dreams/:id`を直列でlazy-fetchし、取得できた額縁から順にフェードインする。新規ルートのため認証ゲート4箇所（`AuthContext.tsx`・`proxy.ts`・`lib/site.ts`・`proxy.ts`の`config.matcher`）に登録し、`proxy.ts`はNext.jsの特殊ファイル制約を守るため判定ロジックを通常モジュール`lib/protectedRoutes.ts`へ切り出す。入り口は森の詳細ページとTreePreviewSheetの2箇所。
+
+**Tech Stack:** Rails 7.2 / RSpec request specs（Docker） / Next.js 16 App Router / React / TypeScript / Tailwind v4 / framer-motion / Jest + Testing Library。
+
+**Source spec:** `docs/superpowers/specs/2026-07-17-dream-room-design.md`
+
+## Global Constraints
+
+- 額縁は最大6枚。`image_generated_at`降順、同時刻は`id`降順でタイブレークする（`MAX_FRAMES = 6`）。
+- 各額縁の画像取得は`GET /dreams/:id`を**直列**（`for...of` + `await`。並列`Promise.all`ではない）でlazy-fetchする。
+- 1件の取得失敗は他の額縁の取得を止めない。失敗した額縁は`loading`のまま止まらず`error`状態にし、「もういちど」ボタンで再試行できる（**非表示にはしない**）。
+- ページ離脱時は`AbortController`で未解決フェッチを中断し、`AbortError`時は`state`更新を行わない。
+- 空状態は2分岐: 夢0件→`/dream/new`、夢はあるが画像0件→最新夢の詳細（`dreams[0].id`）。いずれも`/home`に戻すだけにしない。
+- `generated_image_url`は一覧APIに含めない（既存の軽量方針を維持）。新規エンドポイント・migration・DBスキーマ変更は追加しない。
+- 画像のオンスクリーン表示は`next/image`に`unoptimized`+`onError`を渡すだけの既存パターン（`DreamShareCard`と同様）を再利用し、`/api/image-proxy`は使わない（保存機能を持たないため不要）。
+- `proxy.ts`はNext.jsの特殊ファイル（`proxy`関数と`config`のみexport可）のため、認証判定用の定数・関数は`frontend/lib/protectedRoutes.ts`へ切り出す。`config.matcher`は静的解析が必要なため**既存のリテラル配列定義を維持**する（`protectedRoutes.ts`から動的導出しない）。
+- 新規ルート`/room`は`AuthContext.tsx`の`AUTH_VERIFY_PATH_PREFIXES`・`lib/protectedRoutes.ts`の`PROTECTED_PAGE_PREFIXES`・`lib/site.ts`の`NON_INDEXABLE_PATH_PREFIXES`・`proxy.ts`の`config.matcher`の**4箇所全て**に登録し、登録漏れを1つのテストで検出できるようにする。
+- 新規ナビタブは追加しない（`BottomTabBar`は4枚＋FABで満席）。7枚目以降のページングは対象外。
+- 開発開始条件（satisfied）: PR #428がCI全緑・Codex指摘なしで`main`へマージ済み（`cfa440a`）。本プランは最新`origin/main`起点のworktreeで実行する。
+
+---
+
+## File Structure
+
+- Modify: `backend/app/controllers/dreams_controller.rb` — `index`の`index_columns`に`image_generated_at`追加
+- Modify: `backend/spec/requests/dreams_spec.rb` — indexの軽量性テスト2件追加
+- Create: `frontend/lib/protectedRoutes.ts` — `PROTECTED_PAGE_PREFIXES`・`isProtectedPage`
+- Modify: `frontend/proxy.ts` — `isProtectedPage`判定を`lib/protectedRoutes.ts`参照に置換、`config.matcher`に`/room/:path*`追加
+- Modify: `frontend/context/AuthContext.tsx` — `AUTH_VERIFY_PATH_PREFIXES`をexport化＋`/room`追加
+- Modify: `frontend/lib/site.ts` — `NON_INDEXABLE_PATH_PREFIXES`に`/room`追加
+- Create: `frontend/__tests__/lib/route-registration.test.ts` — 4箇所の登録漏れ検出テスト
+- Modify: `frontend/app/types.ts` — `Dream.image_generated_at`追加
+- Create: `frontend/app/room/[profileId]/page.tsx` — 夢の部屋ページ本体
+- Create: `frontend/__tests__/app/room/page.test.tsx` — 部屋ページのテスト
+- Modify: `frontend/app/forest/[profileId]/page.tsx` — ヘッダーに「へやを のぞく」リンク追加
+- Modify: `frontend/app/components/forest/TreePreviewSheet.tsx` — `onPeekRoom` prop＋ボタン追加
+- Modify: `frontend/__tests__/components/TreePreviewSheet.test.tsx` — 既存5箇所（`render`4件＋`rerender`1件）に`onPeekRoom`追加＋新規テスト1件
+- Modify: `frontend/app/components/forest/ForestScene.tsx` — `onPeekRoom`ハンドラ配線
+
+---
+
+### Task 1: 一覧APIに `image_generated_at` を追加
+
+**Files:**
+- Modify: `backend/app/controllers/dreams_controller.rb`
+- Modify: `backend/spec/requests/dreams_spec.rb`
+
+**Interfaces:**
+- Consumes: 既存`Dream`モデルの`image_generated_at`カラム（`datetime`、既存・migration不要）
+- Produces: `GET /dreams`のJSONレスポンスに`image_generated_at`（ISO8601文字列 or null）を含む。`generated_image_url`は引き続き含まない
+
+- [ ] **Step 1: 失敗するrequest specを書く**
+
+`backend/spec/requests/dreams_spec.rb`の`describe 'GET /dreams (index)'` > `context '認証済みユーザーの場合'`ブロック内、`'夢プロフィールの軽量情報を含める'`テストの直後に追加:
+
+```ruby
+      it 'image_generated_at を含める（部屋のギャラリー用）' do
+        dream = create(
+          :dream,
+          user: user,
+          image_generated_at: Time.current,
+          generated_image_url: 'data:image/png;base64,ZmFrZQ=='
+        )
+
+        authenticated_get('/dreams', user)
+
+        json_response = JSON.parse(response.body)
+        returned_dream = json_response.find { |item| item['id'] == dream.id }
+        expect(returned_dream).to have_key('image_generated_at')
+        expect(returned_dream['image_generated_at']).to be_present
+      end
+
+      it 'generated_image_url は一覧に含めない（軽量化を維持）' do
+        create(
+          :dream,
+          user: user,
+          image_generated_at: Time.current,
+          generated_image_url: 'data:image/png;base64,ZmFrZQ=='
+        )
+
+        authenticated_get('/dreams', user)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response.first).not_to have_key('generated_image_url')
+      end
+```
+
+Run:
+
+```bash
+docker compose run --rm --no-deps backend-test bundle exec rspec spec/requests/dreams_spec.rb
+```
+
+Expected: 新しい2件が`image_generated_at`未実装のためFAIL（1件目は`have_key`失敗、2件目は元々`generated_image_url`が無いので実は先にPASSする可能性がある — その場合は1件目の失敗のみで正しい。両方観察して記録する）。
+
+- [ ] **Step 2: `index_columns`に列を追加**
+
+`backend/app/controllers/dreams_controller.rb`の`index`アクション:
+
+```ruby
+    index_columns = %i[id title content created_at analysis_json analysis_status analyzed_at user_id dream_profile_id image_generated_at]
+```
+
+（既存の`%i[id title content created_at analysis_json analysis_status analyzed_at user_id dream_profile_id]`に`image_generated_at`を追加するだけ。他の行は変更しない）
+
+- [ ] **Step 3: 実行して確認**
+
+```bash
+docker compose run --rm --no-deps backend-test bundle exec rspec spec/requests/dreams_spec.rb
+```
+
+Expected: PASS。既存の認可・一覧・月別・フィルタリングテストも含め全緑。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add backend/app/controllers/dreams_controller.rb backend/spec/requests/dreams_spec.rb
+git commit -m "feat: 一覧APIにimage_generated_atを追加（夢の部屋のギャラリー用）"
+```
+
+---
+
+### Task 2: 認証ゲート4箇所への `/room` 登録＋登録漏れ検出テスト
+
+**Files:**
+- Create: `frontend/lib/protectedRoutes.ts`
+- Modify: `frontend/proxy.ts`
+- Modify: `frontend/context/AuthContext.tsx`
+- Modify: `frontend/lib/site.ts`
+- Create: `frontend/__tests__/lib/route-registration.test.ts`
+
+**Interfaces:**
+- Produces: `export const PROTECTED_PAGE_PREFIXES: string[]`・`export function isProtectedPage(pathname: string): boolean`（`frontend/lib/protectedRoutes.ts`）。Task 3のRoom pageは直接この関数を使わない（`proxy.ts`のミドルウェアが使う）が、後続タスクは`/room`パスがこの一覧に含まれることに依存する
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`frontend/__tests__/lib/route-registration.test.ts` を新規作成:
+
+```ts
+import { AUTH_VERIFY_PATH_PREFIXES } from "@/context/AuthContext";
+import { PROTECTED_PAGE_PREFIXES } from "@/lib/protectedRoutes";
+import { NON_INDEXABLE_PATH_PREFIXES } from "@/lib/site";
+import { config } from "@/proxy";
+
+// 新規ログイン必須ページを追加したら、認証ゲート4箇所（AuthContext / protectedRoutes /
+// site.ts / proxy.tsのmatcher）すべてに登録されているかをここで機械的に検証する。
+// 1箇所でも漏れると /login への意図しないリダイレクトや、ログイン済みなのに
+// ログイン要求が一瞬出るなどの不具合につながる。
+describe("認証ゲート登録: /room", () => {
+  it("AuthContext.AUTH_VERIFY_PATH_PREFIXES に /room が含まれる", () => {
+    expect(AUTH_VERIFY_PATH_PREFIXES).toContain("/room");
+  });
+
+  it("lib/protectedRoutes.PROTECTED_PAGE_PREFIXES に /room が含まれる", () => {
+    expect(PROTECTED_PAGE_PREFIXES).toContain("/room");
+  });
+
+  it("lib/site.NON_INDEXABLE_PATH_PREFIXES に /room が含まれる", () => {
+    expect(NON_INDEXABLE_PATH_PREFIXES).toContain("/room");
+  });
+
+  it("proxy.ts の config.matcher に /room/:path* が含まれる", () => {
+    expect(config.matcher).toContain("/room/:path*");
+  });
+});
+```
+
+Run:
+
+```bash
+cd frontend && npx jest __tests__/lib/route-registration.test.ts
+```
+
+Expected: `@/lib/protectedRoutes`が存在しないためモジュール解決エラーでFAIL（他の3件も`/room`未登録のためFAILするはず）。
+
+- [ ] **Step 2: `lib/protectedRoutes.ts`を新規作成**
+
+```ts
+// proxy.ts（Next.jsの特殊ファイル。proxy関数とconfigのみexport可）から
+// 判定ロジックを切り出した通常モジュール。テストから直接importできるようにする。
+export const PROTECTED_PAGE_PREFIXES = [
+  "/home",
+  "/dream",
+  "/forest",
+  "/insights",
+  "/settings",
+  "/room",
+];
+
+export function isProtectedPage(pathname: string): boolean {
+  return PROTECTED_PAGE_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+```
+
+- [ ] **Step 3: `proxy.ts`を書き換え**
+
+`frontend/proxy.ts`の先頭import群に追加:
+
+```ts
+import { isProtectedPage } from "./lib/protectedRoutes";
+```
+
+`isProtectedPage`という名前がローカル変数と衝突するため、既存の以下の行:
+
+```ts
+  const isProtectedPage =
+    pathname.startsWith("/home") ||
+    pathname.startsWith("/dream") ||
+    pathname.startsWith("/forest") ||
+    pathname.startsWith("/insights") ||
+    pathname.startsWith("/settings");
+```
+
+を次に置き換える:
+
+```ts
+  const pageIsProtected = isProtectedPage(pathname);
+```
+
+その後、同ファイル内の`isProtectedPage`（変数としての参照、2箇所）を`pageIsProtected`に置き換える:
+
+```ts
+  if (!token && pageIsProtected) {
+```
+
+```ts
+      } else if (!response.ok && pageIsProtected) {
+```
+
+最後に`config.matcher`（**リテラル配列のまま**、動的導出しない）に1行追加:
+
+```ts
+export const config = {
+  // matcher にはミドルウェアを適用したいパスを指定
+  matcher: [
+    "/home/:path*",
+    "/dream/:path*",
+    "/forest/:path*",
+    "/insights/:path*",
+    "/settings/:path*",
+    "/room/:path*",
+    "/login",
+    "/register",
+  ],
+};
+```
+
+- [ ] **Step 4: `AuthContext.tsx`を書き換え**
+
+`frontend/context/AuthContext.tsx`の以下の行:
+
+```ts
+const AUTH_VERIFY_PATH_PREFIXES = [
+  "/home",
+  "/dream",
+  "/forest",
+  "/insights",
+  "/settings",
+  "/subscription",
+  "/register",
+];
+```
+
+を次に置き換える（`export`を追加し`/room`を追加。他の要素・順序は維持）:
+
+```ts
+export const AUTH_VERIFY_PATH_PREFIXES = [
+  "/home",
+  "/dream",
+  "/forest",
+  "/insights",
+  "/settings",
+  "/subscription",
+  "/register",
+  "/room",
+];
+```
+
+- [ ] **Step 5: `lib/site.ts`を書き換え**
+
+`frontend/lib/site.ts`の`NON_INDEXABLE_PATH_PREFIXES`配列に1行追加:
+
+```ts
+export const NON_INDEXABLE_PATH_PREFIXES = [
+  "/api/", // APIエンドポイント
+  "/home", // ログイン後トップ
+  "/dream", // 夢の詳細・新規・月別（ユーザーデータ）
+  "/my-dreams", // 夢一覧（ユーザーデータ）
+  "/insights", // きもちインサイト（認証）
+  "/forest", // 夢の森（認証）
+  "/room", // 夢の部屋（認証）
+  "/profiles", // プロフィール（認証）
+  "/settings", // 設定（認証）
+  "/subscription", // サブスク管理・決済リダイレクト（認証）
+  "/verify-email", // メールアドレス確認（トークン付きリンク・公開だが個別URL）
+  "/debug", // 開発用デバッグページ
+] as const;
+```
+
+- [ ] **Step 6: 実行して確認**
+
+```bash
+cd frontend && npx jest __tests__/lib/route-registration.test.ts
+```
+
+Expected: PASS。もし`@/proxy`のimportで`next/server`解決エラーが出た場合（未検証の組み合わせ）、このプロジェクトは`next/jest`プリセットを使用しているため通常は解決されるはずだが、解決しない場合はテストの`config`取得方法を「`fs.readFileSync`でソースを読みリテラル配列を正規表現抽出する」方式に変更してよい（ロジックの本質的な検証内容は変えない）。
+
+- [ ] **Step 7: 既存テストへの回帰確認＋コミット**
+
+```bash
+cd frontend && npx jest __tests__/app/seo.test.ts
+```
+
+Expected: PASS（`NON_INDEXABLE_PATH_PREFIXES`に要素を追加しただけなので影響なし）。
+
+```bash
+git add frontend/lib/protectedRoutes.ts frontend/proxy.ts frontend/context/AuthContext.tsx frontend/lib/site.ts frontend/__tests__/lib/route-registration.test.ts
+git commit -m "feat: /roomルートを認証ゲート4箇所に登録し登録漏れ検出テストを追加"
+```
+
+---
+
+### Task 3: 夢の部屋ページ本体
+
+**Files:**
+- Modify: `frontend/app/types.ts`
+- Create: `frontend/app/room/[profileId]/page.tsx`
+- Create: `frontend/__tests__/app/room/page.test.tsx`
+
+**Interfaces:**
+- Consumes: `getDreamProfiles()`・`getDreamsForProfile(profileId)`・`apiClient.get<Dream>(url, { signal })`（すべて`@/lib/apiClient`既存）、`useAuth()`（`@/context/AuthContext`既存）
+- Produces: `export default function DreamRoomPage()`（`/room/[profileId]`ルート）。Task 4の入り口リンクはこのルートへ`router.push`/`<Link href>`する
+
+- [ ] **Step 1: `Dream`型に`image_generated_at`を追加**
+
+`frontend/app/types.ts`の`Dream`interface、`generated_image_url?: string;`の直後に追加:
+
+```ts
+  generated_image_url?: string;
+  image_generated_at?: string;
+```
+
+- [ ] **Step 2: 失敗するテストを書く**
+
+`frontend/__tests__/app/room/page.test.tsx` を新規作成:
+
+```tsx
+import React from "react";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
+import DreamRoomPage from "@/app/room/[profileId]/page";
+import type { Dream, DreamProfile } from "@/app/types";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({
+    alt,
+    fill,
+    unoptimized,
+    sizes,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & {
+    fill?: boolean;
+    unoptimized?: boolean;
+    sizes?: string;
+  }) => <img alt={alt} {...props} />,
+}));
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: jest.fn() }),
+  useParams: () => ({ profileId: "1" }),
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("@/app/loading", () => ({
+  __esModule: true,
+  default: () => <div>Loading</div>,
+}));
+
+const mockGetDreamProfiles = jest.fn();
+const mockGetDreamsForProfile = jest.fn();
+const mockApiGet = jest.fn();
+jest.mock("@/lib/apiClient", () => ({
+  __esModule: true,
+  default: { get: (...args: unknown[]) => mockApiGet(...args) },
+  getDreamProfiles: (...args: unknown[]) => mockGetDreamProfiles(...args),
+  getDreamsForProfile: (...args: unknown[]) => mockGetDreamsForProfile(...args),
+}));
+
+function makeProfile(overrides: Partial<DreamProfile> = {}): DreamProfile {
+  return {
+    id: 1,
+    name: "ねこさん",
+    avatar_emoji: "🐱",
+    color: "#f97316",
+    relationship: "self",
+    active: true,
+    position: 0,
+    archived: false,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeDream(id: number, overrides: Partial<Dream> = {}): Dream {
+  return {
+    id,
+    title: `夢${id}`,
+    userId: 1,
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseAuth.mockReturnValue({ authStatus: "authenticated" });
+});
+
+describe("DreamRoomPage: 並び順と件数上限", () => {
+  it("image_generated_at 降順（同時刻は id 降順）で並び、6件を超える分は表示しない", async () => {
+    const profile = makeProfile();
+    const dreams = [
+      makeDream(1, { image_generated_at: "2026-07-01T00:00:00Z" }),
+      makeDream(2, { image_generated_at: "2026-07-05T00:00:00Z" }),
+      makeDream(3, { image_generated_at: "2026-07-05T00:00:00Z" }), // 2と同時刻・idが大きい方が先
+      makeDream(4, { image_generated_at: "2026-07-03T00:00:00Z" }),
+      makeDream(5, { image_generated_at: "2026-07-02T00:00:00Z" }),
+      makeDream(6, { image_generated_at: "2026-07-04T00:00:00Z" }),
+      makeDream(7, { image_generated_at: "2026-07-06T00:00:00Z" }), // 7件目、最新なので入るが8件目相当は除外確認用に不要
+    ];
+    mockGetDreamProfiles.mockResolvedValue([profile]);
+    mockGetDreamsForProfile.mockResolvedValue(dreams);
+    mockApiGet.mockImplementation((url: string) => {
+      const id = Number(url.split("/").pop());
+      return Promise.resolve({
+        ...dreams.find((d) => d.id === id),
+        generated_image_url: `https://img.example/${id}.png`,
+      });
+    });
+
+    render(<DreamRoomPage />);
+
+    // 表示順は 7,3,2,6,4,5 の6件（idが大きい=1で作成された方が新しい前提のfixtureなので、
+    // 実際の期待順は image_generated_at 降順: 7(07-06) > 3(07-05,id大) > 2(07-05,id小) > 6(07-04) > 4(07-03) > 5(07-02)
+    for (const id of [7, 3, 2, 6, 4, 5]) {
+      await screen.findByTestId(`room-frame-${id}`);
+    }
+    expect(screen.queryByTestId("room-frame-1")).not.toBeInTheDocument(); // 07-01が最古のため6件に入らない
+  });
+});
+
+describe("DreamRoomPage: 逐次取得と部分失敗", () => {
+  it("1件の取得が失敗しても他の額縁の取得を続け、失敗額縁に再試行ボタンを出す", async () => {
+    const profile = makeProfile();
+    const dreams = [
+      makeDream(3, { image_generated_at: "2026-07-03T00:00:00Z" }),
+      makeDream(2, { image_generated_at: "2026-07-02T00:00:00Z" }),
+      makeDream(1, { image_generated_at: "2026-07-01T00:00:00Z" }),
+    ];
+    mockGetDreamProfiles.mockResolvedValue([profile]);
+    mockGetDreamsForProfile.mockResolvedValue(dreams);
+    mockApiGet.mockImplementation((url: string) => {
+      if (url === "/dreams/2") return Promise.reject(new Error("network error"));
+      const id = Number(url.split("/").pop());
+      return Promise.resolve({
+        ...dreams.find((d) => d.id === id),
+        generated_image_url: `https://img.example/${id}.png`,
+      });
+    });
+
+    render(<DreamRoomPage />);
+
+    const frame3 = await screen.findByTestId("room-frame-3");
+    await waitFor(() => expect(within(frame3).getByAltText("夢3")).toBeInTheDocument());
+
+    const frame2 = await screen.findByTestId("room-frame-2");
+    await waitFor(() =>
+      expect(within(frame2).getByRole("button", { name: "もういちど" })).toBeInTheDocument()
+    );
+
+    const frame1 = await screen.findByTestId("room-frame-1");
+    await waitFor(() => expect(within(frame1).getByAltText("夢1")).toBeInTheDocument());
+  });
+
+  it("失敗した額縁で「もういちど」を押すと再フェッチされ画像が表示される", async () => {
+    const profile = makeProfile();
+    const dreams = [makeDream(2, { image_generated_at: "2026-07-02T00:00:00Z" })];
+    mockGetDreamProfiles.mockResolvedValue([profile]);
+    mockGetDreamsForProfile.mockResolvedValue(dreams);
+    mockApiGet
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce({
+        ...dreams[0],
+        generated_image_url: "https://img.example/2.png",
+      });
+
+    render(<DreamRoomPage />);
+
+    const frame2 = await screen.findByTestId("room-frame-2");
+    const retryButton = await waitFor(() =>
+      within(frame2).getByRole("button", { name: "もういちど" })
+    );
+    fireEvent.click(retryButton);
+
+    await waitFor(() =>
+      expect(within(screen.getByTestId("room-frame-2")).getByAltText("夢2")).toBeInTheDocument()
+    );
+  });
+
+  it("unmount後にAbortErrorで解決しても例外を投げない", async () => {
+    const profile = makeProfile();
+    const dreams = [makeDream(1, { image_generated_at: "2026-07-01T00:00:00Z" })];
+    mockGetDreamProfiles.mockResolvedValue([profile]);
+    mockGetDreamsForProfile.mockResolvedValue(dreams);
+
+    let rejectSlow: (e: unknown) => void = () => {};
+    mockApiGet.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectSlow = reject;
+        })
+    );
+
+    const { unmount } = render(<DreamRoomPage />);
+    await waitFor(() => expect(mockApiGet).toHaveBeenCalled());
+
+    unmount();
+
+    const abortError = new Error("aborted");
+    abortError.name = "AbortError";
+    expect(() => rejectSlow(abortError)).not.toThrow();
+  });
+});
+
+describe("DreamRoomPage: 空状態", () => {
+  it("夢が0件のとき「ゆめを きろくする」を /dream/new へのリンクで表示する", async () => {
+    const profile = makeProfile();
+    mockGetDreamProfiles.mockResolvedValue([profile]);
+    mockGetDreamsForProfile.mockResolvedValue([]);
+
+    render(<DreamRoomPage />);
+
+    const link = await screen.findByRole("link", { name: /ゆめを きろくする/ });
+    expect(link).toHaveAttribute("href", "/dream/new");
+  });
+
+  it("夢はあるが画像が0件のとき「ゆめのえを つくる」を最新夢の詳細へのリンクで表示する", async () => {
+    const profile = makeProfile();
+    const dreams = [
+      makeDream(2, { created_at: "2026-07-02T00:00:00Z" }),
+      makeDream(1, { created_at: "2026-07-01T00:00:00Z" }),
+    ];
+    mockGetDreamProfiles.mockResolvedValue([profile]);
+    mockGetDreamsForProfile.mockResolvedValue(dreams);
+
+    render(<DreamRoomPage />);
+
+    const link = await screen.findByRole("link", { name: /ゆめのえを つくる/ });
+    expect(link).toHaveAttribute("href", "/dream/2");
+  });
+});
+
+describe("DreamRoomPage: 見出し・アクセシビリティ", () => {
+  it("長いプロフィール名でも見出しがtruncateクラスを持つ", async () => {
+    const profile = makeProfile({ name: "とてもながいなまえのぷろふぃーるだよたとえばこんなかんじ" });
+    mockGetDreamProfiles.mockResolvedValue([profile]);
+    mockGetDreamsForProfile.mockResolvedValue([]);
+
+    render(<DreamRoomPage />);
+
+    const heading = await screen.findByRole("heading", { level: 1 });
+    expect(heading.className).toEqual(expect.stringContaining("truncate"));
+  });
+
+  it("額縁画像のaltは夢タイトルである", async () => {
+    const profile = makeProfile();
+    const dreams = [makeDream(1, { title: "星空の夢", image_generated_at: "2026-07-01T00:00:00Z" })];
+    mockGetDreamProfiles.mockResolvedValue([profile]);
+    mockGetDreamsForProfile.mockResolvedValue(dreams);
+    mockApiGet.mockResolvedValue({ ...dreams[0], generated_image_url: "https://img.example/1.png" });
+
+    render(<DreamRoomPage />);
+
+    await waitFor(() => expect(screen.getByAltText("星空の夢")).toBeInTheDocument());
+  });
+});
+```
+
+Run:
+
+```bash
+cd frontend && npx jest __tests__/app/room/page.test.tsx
+```
+
+Expected: `@/app/room/[profileId]/page`が存在しないためモジュール解決エラーでFAIL。
+
+- [ ] **Step 3: `frontend/app/room/[profileId]/page.tsx` を新規作成**
+
+```tsx
+"use client";
+
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import Image from "next/image";
+import { ChevronLeft } from "lucide-react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { useAuth } from "@/context/AuthContext";
+import Loading from "@/app/loading";
+import apiClient, { getDreamProfiles, getDreamsForProfile } from "@/lib/apiClient";
+import type { Dream, DreamProfile } from "@/app/types";
+
+const MAX_FRAMES = 6;
+
+function isValidRoomProfileId(profileId: number): boolean {
+  return Number.isInteger(profileId) && profileId > 0;
+}
+
+function normalizeDreamProfilesResponse(value: unknown): DreamProfile[] | null {
+  if (Array.isArray(value)) return value as DreamProfile[];
+  console.error("Unexpected dream profiles response for dream room", value);
+  return null;
+}
+
+function normalizeProfileDreamsResponse(value: unknown): Dream[] {
+  if (Array.isArray(value)) return value as Dream[];
+  console.error("Unexpected dreams response for dream room", value);
+  return [];
+}
+
+function findActiveProfile(profiles: DreamProfile[], profileId: number): DreamProfile | null {
+  return profiles.find((p) => p.id === profileId && !p.archived) ?? null;
+}
+
+// image_generated_at 降順。同時刻は id 降順でタイブレークし、最大 MAX_FRAMES 件に絞る。
+function selectFramesSource(dreams: Dream[]): Dream[] {
+  return dreams
+    .filter((d): d is Dream & { image_generated_at: string } => !!d.image_generated_at)
+    .sort((a, b) => {
+      const diff = new Date(b.image_generated_at).getTime() - new Date(a.image_generated_at).getTime();
+      return diff !== 0 ? diff : b.id - a.id;
+    })
+    .slice(0, MAX_FRAMES);
+}
+
+type FrameStatus = "loading" | "loaded" | "error";
+type Frame = { dream: Dream; status: FrameStatus; imageUrl?: string };
+
+export default function DreamRoomPage() {
+  const { authStatus } = useAuth();
+  const router = useRouter();
+  const params = useParams();
+  const rawProfileId = params.profileId;
+  const profileId = Number(rawProfileId);
+  const reduceMotion = useReducedMotion();
+
+  const [profile, setProfile] = useState<DreamProfile | null>(null);
+  const [dreams, setDreams] = useState<Dream[]>([]);
+  const [frames, setFrames] = useState<Frame[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    if (!isValidRoomProfileId(profileId)) {
+      console.error("Invalid room profileId", rawProfileId);
+      router.replace("/forest");
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const [profilesResponse, dreamsResponse]: [unknown, unknown] = await Promise.all([
+        getDreamProfiles(),
+        getDreamsForProfile(profileId),
+      ]);
+      const allProfiles = normalizeDreamProfilesResponse(profilesResponse);
+      if (!allProfiles) {
+        router.replace("/forest");
+        return;
+      }
+      const found = findActiveProfile(allProfiles, profileId);
+      if (!found) {
+        router.replace("/forest");
+        return;
+      }
+      setProfile(found);
+      setDreams(normalizeProfileDreamsResponse(dreamsResponse));
+    } catch (error) {
+      console.error("Failed to load dream room", error);
+      router.replace("/forest");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [profileId, rawProfileId, router]);
+
+  useEffect(() => {
+    if (authStatus === "unauthenticated") {
+      router.push("/login");
+      return;
+    }
+    if (authStatus === "authenticated") load();
+  }, [authStatus, load, router]);
+
+  // dreamsが確定してから初めて計算される。参照はdreamsが変わらない限り安定。
+  const framesSource = useMemo(() => selectFramesSource(dreams), [dreams]);
+
+  const fetchFrame = useCallback(async (dream: Dream, signal: AbortSignal) => {
+    try {
+      const detail = await apiClient.get<Dream>(`/dreams/${dream.id}`, { signal });
+      if (signal.aborted) return;
+      setFrames((prev) =>
+        prev.map((f) =>
+          f.dream.id === dream.id ? { ...f, status: "loaded", imageUrl: detail.generated_image_url } : f
+        )
+      );
+    } catch (error) {
+      if ((error as Error)?.name === "AbortError" || signal.aborted) return;
+      setFrames((prev) => prev.map((f) => (f.dream.id === dream.id ? { ...f, status: "error" } : f)));
+    }
+  }, []);
+
+  // framesSource（画像を持つ夢、最大6件）が確定したら、額縁を「loading」で並べてから
+  // 直列でlazy-fetchする。空配列のときは何もしない＝空状態の判定はframesSourceで行う
+  // （framesの非同期更新に依存すると、初回レンダーで一瞬「画像0件」に見える一拍のズレが
+  // 起きるため、判定は同期的なframesSourceを使う）。
+  useEffect(() => {
+    if (framesSource.length === 0) return;
+
+    setFrames(framesSource.map((dream) => ({ dream, status: "loading" as const })));
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    (async () => {
+      for (const dream of framesSource) {
+        if (controller.signal.aborted) return;
+        await fetchFrame(dream, controller.signal);
+      }
+    })();
+
+    return () => {
+      controller.abort();
+    };
+  }, [framesSource, fetchFrame]);
+
+  const retryFrame = useCallback(
+    (dreamId: number) => {
+      const frame = frames.find((f) => f.dream.id === dreamId);
+      if (!frame) return;
+      setFrames((prev) => prev.map((f) => (f.dream.id === dreamId ? { ...f, status: "loading" } : f)));
+      const controller = abortRef.current ?? new AbortController();
+      fetchFrame(frame.dream, controller.signal);
+    },
+    [frames, fetchFrame]
+  );
+
+  if (authStatus === "checking" || isLoading) return <Loading />;
+  if (!profile) return null;
+
+  const latestDream = dreams[0] ?? null;
+
+  return (
+    <div
+      className="relative min-h-screen pb-24 text-white"
+      style={{ background: `linear-gradient(180deg, ${profile.color}33, rgba(10,8,30,0.96) 55%)` }}
+    >
+      <header className="sticky top-0 z-10 bg-black/20 backdrop-blur-md">
+        <div className="container mx-auto flex h-14 max-w-3xl items-center px-4">
+          <Link
+            href={`/forest/${profile.id}`}
+            className="flex min-h-[44px] shrink-0 items-center px-1 text-white/80 hover:text-white"
+          >
+            <ChevronLeft className="mr-1 h-5 w-5" /> へやから でる
+          </Link>
+          <h1 className="ml-3 min-w-0 flex-1 truncate text-lg font-bold">
+            {profile.avatar_emoji} {profile.name} の おへや
+          </h1>
+        </div>
+      </header>
+
+      <main className="container relative z-[2] mx-auto max-w-3xl px-4 pt-8">
+        {dreams.length === 0 ? (
+          <div className="mt-10 flex flex-col items-center gap-4 text-center">
+            <span className="text-6xl" aria-hidden="true">
+              🛏️
+            </span>
+            <p className="text-lg font-bold text-white/90">まだ ゆめが きろくされていないよ</p>
+            <Link
+              href="/dream/new"
+              className="mt-2 rounded-full px-5 py-2 text-sm font-bold text-white shadow-lg"
+              style={{ background: "linear-gradient(135deg, #7c3aed, #38bdf8)" }}
+            >
+              ゆめを きろくする
+            </Link>
+          </div>
+        ) : framesSource.length === 0 ? (
+          <div className="mt-10 flex flex-col items-center gap-4 text-center">
+            <span className="text-6xl" aria-hidden="true">
+              🖼️
+            </span>
+            <p className="text-lg font-bold text-white/90">まだ えが かざられていないよ</p>
+            {latestDream && (
+              <Link
+                href={`/dream/${latestDream.id}`}
+                className="mt-2 rounded-full px-5 py-2 text-sm font-bold text-white shadow-lg"
+                style={{ background: "linear-gradient(135deg, #7c3aed, #38bdf8)" }}
+              >
+                ゆめのえを つくる
+              </Link>
+            )}
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            {frames.map((frame) => (
+              <FrameCard
+                key={frame.dream.id}
+                frame={frame}
+                profileColor={profile.color}
+                reduceMotion={!!reduceMotion}
+                onOpen={() => router.push(`/dream/${frame.dream.id}`)}
+                onRetry={() => retryFrame(frame.dream.id)}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function FrameCard({
+  frame,
+  profileColor,
+  reduceMotion,
+  onOpen,
+  onRetry,
+}: {
+  frame: Frame;
+  profileColor: string;
+  reduceMotion: boolean;
+  onOpen: () => void;
+  onRetry: () => void;
+}) {
+  return (
+    <div data-testid={`room-frame-${frame.dream.id}`}>
+      <AnimatePresence mode="wait">
+        {frame.status === "loaded" && frame.imageUrl ? (
+          <motion.button
+            key="loaded"
+            type="button"
+            onClick={onOpen}
+            initial={reduceMotion ? undefined : { opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.3 }}
+            className="relative aspect-square w-full overflow-hidden rounded-2xl border-4"
+            style={{ borderColor: `${profileColor}88` }}
+          >
+            <Image
+              src={frame.imageUrl}
+              alt={frame.dream.title || "ラベルなし"}
+              fill
+              sizes="(max-width: 640px) 45vw, 220px"
+              className="object-cover"
+              unoptimized
+            />
+          </motion.button>
+        ) : frame.status === "error" ? (
+          <div
+            className="flex aspect-square flex-col items-center justify-center gap-2 rounded-2xl border-4 border-dashed p-2 text-center"
+            style={{ borderColor: `${profileColor}55` }}
+          >
+            <span className="text-2xl" aria-hidden="true">
+              💔
+            </span>
+            <button
+              type="button"
+              onClick={onRetry}
+              className="rounded-full bg-white/10 px-3 py-1 text-xs font-bold text-white/80 hover:bg-white/20"
+            >
+              もういちど
+            </button>
+          </div>
+        ) : (
+          <div
+            className="aspect-square animate-pulse rounded-2xl border-4"
+            style={{ borderColor: `${profileColor}33`, background: `${profileColor}11` }}
+            aria-hidden="true"
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: 実行して確認**
+
+```bash
+cd frontend && npx jest __tests__/app/room/page.test.tsx
+```
+
+Expected: PASS。もし`useReducedMotion`のモック不足等で個別ケースが落ちる場合、`jest.setup.ts`の既存グローバルモック（`framer-motion`関連）を確認し、必要なら`jest.mock("framer-motion", ...)`をテストファイルに追加して`useReducedMotion`が`false`を返すようにする（既存の森系テストの流儀に合わせる）。
+
+- [ ] **Step 5: 型チェック＋コミット**
+
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | grep -E "app/room|app/types.ts" || echo "変更ファイルにtscエラーなし"
+```
+
+Expected: 出力が「変更ファイルにtscエラーなし」のみ。
+
+```bash
+git add frontend/app/types.ts "frontend/app/room/[profileId]/page.tsx" frontend/__tests__/app/room/page.test.tsx
+git commit -m "feat: 夢の部屋ページ（額縁の壁）を追加"
+```
+
+---
+
+### Task 4: 森からの入り口2箇所
+
+**Files:**
+- Modify: `frontend/app/forest/[profileId]/page.tsx`
+- Modify: `frontend/app/components/forest/TreePreviewSheet.tsx`
+- Modify: `frontend/__tests__/components/TreePreviewSheet.test.tsx`
+- Modify: `frontend/app/components/forest/ForestScene.tsx`
+
+**Interfaces:**
+- Consumes: Task 3で作った`/room/[profileId]`ルート
+- Produces: なし（末端の導線追加）
+
+- [ ] **Step 1: 森詳細ページのヘッダーにリンクを追加**
+
+`frontend/app/forest/[profileId]/page.tsx`の`<header>`ブロック（既存の`<div className="container mx-auto flex h-14 max-w-3xl items-center px-4">...</div>`の閉じタグの直後、`</header>`の直前）に新しい行を追加:
+
+既存:
+```tsx
+      <header className="sticky top-0 z-10 bg-black/20 backdrop-blur-md">
+        <div className="container mx-auto flex h-14 max-w-3xl items-center px-4">
+          <Link href="/forest" className="flex min-h-[44px] items-center px-1 text-white/80 hover:text-white">
+            <ChevronLeft className="mr-1 h-5 w-5" /> もりに もどる
+          </Link>
+          <h1 className="ml-3 whitespace-nowrap text-lg font-bold">
+            {profile.avatar_emoji} {profile.name} の き
+          </h1>
+          <span
+            className="ml-auto rounded-full px-3 py-1 text-[13px] font-black"
+            style={{
+              background: `${profile.color}22`,
+              border: `1px solid ${profile.color}66`,
+              color: profile.color,
+            }}
+          >
+            {lvl.name}（{lvl.reading}）
+          </span>
+        </div>
+      </header>
+```
+
+変更後（末尾に1ブロック追加、既存行は非変更）:
+```tsx
+      <header className="sticky top-0 z-10 bg-black/20 backdrop-blur-md">
+        <div className="container mx-auto flex h-14 max-w-3xl items-center px-4">
+          <Link href="/forest" className="flex min-h-[44px] items-center px-1 text-white/80 hover:text-white">
+            <ChevronLeft className="mr-1 h-5 w-5" /> もりに もどる
+          </Link>
+          <h1 className="ml-3 whitespace-nowrap text-lg font-bold">
+            {profile.avatar_emoji} {profile.name} の き
+          </h1>
+          <span
+            className="ml-auto rounded-full px-3 py-1 text-[13px] font-black"
+            style={{
+              background: `${profile.color}22`,
+              border: `1px solid ${profile.color}66`,
+              color: profile.color,
+            }}
+          >
+            {lvl.name}（{lvl.reading}）
+          </span>
+        </div>
+        <div className="container mx-auto flex max-w-3xl justify-end px-4 pb-2">
+          <Link
+            href={`/room/${profile.id}`}
+            className="rounded-full border border-white/20 bg-white/5 px-3 py-1 text-xs font-bold text-white/80 hover:bg-white/10"
+          >
+            🖼️ へやを のぞく
+          </Link>
+        </div>
+      </header>
+```
+
+- [ ] **Step 2: `TreePreviewSheet`に`onPeekRoom`を追加（失敗するテストを先に書く）**
+
+`frontend/__tests__/components/TreePreviewSheet.test.tsx`には`<TreePreviewSheet ... />`を渡す呼び出しが**5箇所**ある（61行目`render`、71行目`rerender`、92行目・118行目・135行目の`render`）。すべてに`onPeekRoom={jest.fn()}`を追加する（`onOpen={jest.fn()}`の直後に1行追加、他は変更しない）。最初の2箇所（`render`と直後の`rerender`）はどちらも同じ`<TreePreviewSheet>`要素なので両方に追加する:
+
+```tsx
+    const { rerender } = render(
+      <TreePreviewSheet
+        profile={profile({ id: 1, name: "自分" })}
+        onOpen={jest.fn()}
+        onPeekRoom={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(await screen.findByText(/前の木のゆめ/)).toBeInTheDocument();
+
+    rerender(
+      <TreePreviewSheet
+        profile={profile({ id: 2, name: "家族", dreams_count: 2 })}
+        onOpen={jest.fn()}
+        onPeekRoom={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+```
+
+残り3箇所（92行目・118行目・135行目）も同様に`onOpen={jest.fn()}`の直後へ`onPeekRoom={jest.fn()}`を1行追加する。加えて、ファイル末尾（最後の`});`の直前）に新規テストを追加:
+
+```tsx
+
+  it("「へやを のぞく」を押すと onPeekRoom が呼ばれる", async () => {
+    mockedGetDreamsForProfile.mockResolvedValueOnce([]);
+    const handlePeekRoom = jest.fn();
+
+    render(
+      <TreePreviewSheet
+        profile={profile({ id: 3, name: "ふたり" })}
+        onOpen={jest.fn()}
+        onPeekRoom={handlePeekRoom}
+        onClose={jest.fn()}
+      />
+    );
+
+    const button = await screen.findByRole("button", { name: /へやを のぞく/ });
+    button.click();
+
+    expect(handlePeekRoom).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 3, name: "ふたり" })
+    );
+  });
+```
+
+Run:
+
+```bash
+cd frontend && npx jest __tests__/components/TreePreviewSheet.test.tsx
+```
+
+Expected: 新規テストがボタン未実装のためFAIL。既存4件は`onPeekRoom`が未定義のprop型のためTypeScriptエラーになる可能性があるが、Jest実行自体はランタイムでは通ることがある（tscは後段Stepで確認する）。
+
+- [ ] **Step 3: `TreePreviewSheet.tsx`を実装**
+
+`frontend/app/components/forest/TreePreviewSheet.tsx`の`TreePreviewSheetProps`:
+
+```ts
+interface TreePreviewSheetProps {
+  profile: DreamProfile | null;
+  onOpen: (profile: DreamProfile) => void;
+  onPeekRoom: (profile: DreamProfile) => void;
+  onClose: () => void;
+}
+```
+
+関数シグネチャ:
+
+```tsx
+export default function TreePreviewSheet({ profile, onOpen, onPeekRoom, onClose }: TreePreviewSheetProps) {
+```
+
+既存の「この きを 見る ›」ボタンの直後（`</button>`の後、`</motion.div>`の前）に追加:
+
+```tsx
+          <button
+            onClick={() => onPeekRoom(profile)}
+            className="mt-2 w-full rounded-[13px] border border-white/15 bg-white/5 py-2 text-[13px] font-bold text-white/70 hover:bg-white/10"
+          >
+            🖼️ へやを のぞく
+          </button>
+```
+
+- [ ] **Step 4: `ForestScene.tsx`に配線を追加**
+
+`frontend/app/components/forest/ForestScene.tsx`の`<TreePreviewSheet>`呼び出し:
+
+```tsx
+      <TreePreviewSheet
+        profile={selected}
+        onOpen={(p) => router.push(`/forest/${p.id}`)}
+        onPeekRoom={(p) => router.push(`/room/${p.id}`)}
+        onClose={() => setSelectedId(null)}
+      />
+```
+
+- [ ] **Step 5: 実行して確認**
+
+```bash
+cd frontend && npx jest __tests__/components/TreePreviewSheet.test.tsx __tests__/components/ForestScene.test.tsx __tests__/components/ForestProfilePage.test.tsx
+```
+
+Expected: 全てPASS。
+
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | grep -E "TreePreviewSheet|ForestScene|forest/\[profileId\]/page" || echo "変更ファイルにtscエラーなし"
+```
+
+Expected: 「変更ファイルにtscエラーなし」。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add "frontend/app/forest/[profileId]/page.tsx" frontend/app/components/forest/TreePreviewSheet.tsx frontend/__tests__/components/TreePreviewSheet.test.tsx frontend/app/components/forest/ForestScene.tsx
+git commit -m "feat: 森詳細画面とTreePreviewSheetに夢の部屋への入り口を追加"
+```
+
+---
+
+### Task 5: 全体検証・手動QA
+
+**Files:** なし（検証のみ）
+
+- [ ] **Step 1: フロント対象テスト**
+
+```bash
+cd frontend && npx jest __tests__/app/room/page.test.tsx __tests__/lib/route-registration.test.ts __tests__/components/TreePreviewSheet.test.tsx __tests__/components/ForestScene.test.tsx __tests__/components/ForestProfilePage.test.tsx __tests__/app/seo.test.ts
+```
+
+Expected: 全てPASS。
+
+- [ ] **Step 2: フロント全体・型検査**
+
+```bash
+cd frontend && npx jest
+cd frontend && npx tsc --noEmit
+```
+
+Expected: 既存スイートを含めて全PASS。`tsc`は新規型エラーなし（既存の`__tests__`配下の既知のjest-mock型ノイズは対象外）。
+
+- [ ] **Step 3: backend対象spec**
+
+```bash
+docker compose run --rm --no-deps backend-test bundle exec rspec spec/requests/dreams_spec.rb
+```
+
+Expected: PASS。
+
+- [ ] **Step 4: 静的差分確認**
+
+```bash
+git diff --check
+git status --short
+```
+
+変更が本プラン対象ファイル＋設計・計画ドキュメントのみであることを確認する。
+
+- [ ] **Step 5: 手動QA（デプロイ後のスマホ実機・375px幅）**
+
+- [ ] 森詳細ページから「へやを のぞく」で`/room/:id`に遷移できる
+- [ ] `TreePreviewSheet`の「へやを のぞく」でも同様に遷移できる
+- [ ] AI画像を複数持つプロフィール: 額縁が新しい順（`image_generated_at`降順）に並び、6枚を超えても6枚までしか出ない
+- [ ] 額縁タップで夢詳細へ遷移する
+- [ ] 夢が0件のプロフィール: 「ゆめを きろくする」→`/dream/new`
+- [ ] 夢はあるが画像0件のプロフィール: 「ゆめのえを つくる」→最新夢の詳細
+- [ ] 375px幅で額縁グリッドが横にはみ出さない
+- [ ] 長いプロフィール名でヘッダーが崩れない（truncate）
+- [ ] キーボードのTab移動で額縁にフォーカスが移り、Enterで開ける
+- [ ] `prefers-reduced-motion`をONにした状態でフェードイン演出が止まる
+- [ ] 「へやから でる」で森詳細に戻れる
+
+## Done Criteria
+
+- `GET /dreams`が`image_generated_at`を返し、`generated_image_url`は返さない（RSpec緑）。
+- `/room/[profileId]`が額縁の壁として画像を降順・最大6枚で表示し、1件の取得失敗が他に波及しない。
+- ページ離脱後の遅延解決が状態更新エラーを起こさない。
+- `/room`が認証ゲート4箇所すべてに登録されており、専用テストで検証されている。
+- 森詳細ページ・TreePreviewSheetの2箇所から`/room`へ遷移できる。
+- フロントJest・tsc・backend RSpec・手動QAが完了している。

--- a/docs/superpowers/specs/2026-07-17-dream-room-design.md
+++ b/docs/superpowers/specs/2026-07-17-dream-room-design.md
@@ -105,12 +105,12 @@ const withImages = dreams
 新規ルート追加時は以下3箇所への登録が必須（過去の`/insights`追加時の教訓）。今回はテストで登録漏れを構造的に検出できるようにする。
 
 - `frontend/context/AuthContext.tsx`: `AUTH_VERIFY_PATH_PREFIXES`に`/room`を追加。**この定数を`export`する**（現状非export）
-- `frontend/proxy.ts`: `isProtectedPage`判定に`/room`を追加。現状は関数内のインライン`pathname.startsWith(...)`チェーンで外部からテストできないため、**`AUTH_VERIFY_PATH_PREFIXES`と同じ形の`export const PROTECTED_PAGE_PREFIXES`を切り出し**、`isProtectedPage`はそれを参照するよう書き換える（ロジック変更なし、ミニマルなテスト容易性向上のリファクタ）。`config.matcher`にも`"/room/:path*"`を追加
+- `frontend/proxy.ts`: `isProtectedPage`判定に`/room`を追加。ただし`proxy.ts`はNext.jsの特殊ファイル（`proxy`関数と`config`のみをexportする規約）のため、**判定用の定数・関数はここに独自exportせず、新規の通常モジュール`frontend/lib/protectedRoutes.ts`へ切り出す**（`export const PROTECTED_PAGE_PREFIXES = [...]`＋`export function isProtectedPage(pathname: string): boolean`）。`proxy.ts`はこのモジュールから`isProtectedPage`をimportして使うだけにする（ロジック変更なし）。`config.matcher`は静的解析が必要なため、`protectedRoutes.ts`から動的導出せず**既存のリテラル配列定義を維持**した上で`"/room/:path*"`を追加する
 - `frontend/lib/site.ts`: `NON_INDEXABLE_PATH_PREFIXES`に`/room`を追加（既にexport済み）
 
 ### 登録漏れ検出テスト
 
-新規`frontend/__tests__/lib/route-registration.test.ts`で、`AUTH_VERIFY_PATH_PREFIXES`・`PROTECTED_PAGE_PREFIXES`・`NON_INDEXABLE_PATH_PREFIXES`・`proxy.ts`の`config.matcher`をまとめてimportし、`"/room"`（および`config.matcher`は`"/room/:path*"`）が全てに含まれることを1つのテストファイルで検証する。既存`__tests__/app/seo.test.ts`の`it.each`パターンを踏襲。
+新規`frontend/__tests__/lib/route-registration.test.ts`で、`AUTH_VERIFY_PATH_PREFIXES`（`AuthContext.tsx`）・`PROTECTED_PAGE_PREFIXES`（`lib/protectedRoutes.ts`）・`NON_INDEXABLE_PATH_PREFIXES`（`lib/site.ts`）・`proxy.ts`の`config.matcher`をまとめてimportし、`"/room"`（および`config.matcher`は`"/room/:path*"`）が全てに含まれることを1つのテストファイルで検証する。`config.matcher`はリテラル維持のため、このテストが唯一の「4箇所目との整合」を人手に頼らず検出する仕組みになる。既存`__tests__/app/seo.test.ts`の`it.each`パターンを踏襲。
 
 ## 6. テスト方針
 
@@ -141,6 +141,6 @@ const withImages = dreams
 
 ## 8. 境界
 
-**触る**: `backend/app/controllers/dreams_controller.rb`（`index_columns`に1列追加）/ `frontend/app/room/[profileId]/page.tsx`（新規）/ `frontend/app/types.ts`（`Dream.image_generated_at`追加）/ `frontend/app/forest/[profileId]/page.tsx`（入り口リンク追加）/ `frontend/app/components/forest/TreePreviewSheet.tsx`・`ForestScene.tsx`（入り口リンク追加）/ `frontend/context/AuthContext.tsx`・`frontend/proxy.ts`・`frontend/lib/site.ts`（認証ゲート登録＋テスト容易性のためのexport化）/ テスト（新規＋`dreams_spec.rb`拡張）。
+**触る**: `backend/app/controllers/dreams_controller.rb`（`index_columns`に1列追加）/ `frontend/app/room/[profileId]/page.tsx`（新規）/ `frontend/app/types.ts`（`Dream.image_generated_at`追加）/ `frontend/app/forest/[profileId]/page.tsx`（入り口リンク追加）/ `frontend/app/components/forest/TreePreviewSheet.tsx`・`ForestScene.tsx`（入り口リンク追加）/ `frontend/context/AuthContext.tsx`・`frontend/proxy.ts`・`frontend/lib/site.ts`（認証ゲート登録）/ `frontend/lib/protectedRoutes.ts`（新規・`isProtectedPage`判定の切り出し）/ テスト（新規＋`dreams_spec.rb`拡張）。
 
 **触らない**: migration・DBスキーマ・新規APIエンドポイント・Stripe・OpenAI・`DreamShareCard`本体・「もりの一覧」`/forest`・BottomTabBar（新規タブは追加しない）・7枚目以降のページング（将来PR）。

--- a/docs/superpowers/specs/2026-07-17-dream-room-design.md
+++ b/docs/superpowers/specs/2026-07-17-dream-room-design.md
@@ -1,0 +1,146 @@
+# 夢の部屋（額縁の壁）設計仕様
+
+- 日付: 2026-07-17
+- 対象: YumeTree フロントエンド（Next.js 16 + Tailwind v4）＋ バックエンド（Rails 7.2, 最小追加）
+- 位置づけ: `phase5-dream-profiles-design.md` の将来アイディア「夢の部屋: プロフィールごとに夢ワールドを持つ箱庭UI」。
+  世界観MVP**最終候補**（第1弾: 今週のゆめニュース #423／第2弾: プロフィール別シェアカード #424）。
+
+## 0. コンセプト・差別化軸
+
+「夢の森」＝プロフィールの**成長と感情の可視化**（木・実・季節）に対し、「夢の部屋」＝**AI生成画像のギャラリー**。
+現状、AI生成画像は夢詳細画面でしか見られず、見返す場所がない。部屋はその子専用の「額縁の壁」として、生成済みの絵を集めて振り返れる場所にする。
+
+## 1. スコープ（決定事項）
+
+- 最大**6枚**の額縁。`image_generated_at`の新しい順（同時刻は`id desc`でタイブレーク）。
+- 各額縁の画像は`GET /dreams/:id`を**順次**（直列）lazy-fetchし、取得できた額縁から順にフェードインする演出。
+- 額縁タップで`/dream/${id}`（夢詳細）へ遷移。
+- 「もっと見る」（7枚目以降のページング）は**スコープ外**（将来PR）。
+- 入り口は2箇所、いずれも既存「森」画面から:
+  1. 森詳細ページ（`/forest/[profileId]/page.tsx`）のヘッダー行に「へやを のぞく」リンクを追加
+  2. `TreePreviewSheet`のCTA列に同様のリンクを追加（`router.push(\`/room/${profile.id}\`)`）
+- 新規ナビタブは追加しない（`BottomTabBar`は4枚＋FABで満席のため）。
+
+## 2. バックエンド変更（最小・追加のみ）
+
+`backend/app/controllers/dreams_controller.rb#index`の`index_columns`に`image_generated_at`を1列追加する。
+
+現状:
+```ruby
+index_columns = %i[id title content created_at analysis_json analysis_status analyzed_at user_id dream_profile_id]
+```
+
+変更後:
+```ruby
+index_columns = %i[id title content created_at analysis_json analysis_status analyzed_at user_id dream_profile_id image_generated_at]
+```
+
+- `generated_image_url`（base64・最大1MB/枚）は**引き続き一覧から除外**。既存の「一覧は軽量に保つ」設計方針を維持する。
+- 新規エンドポイント・migration・DBスキーマ変更なし（`image_generated_at`列・部分インデックスは既存）。
+- フロントは既存`getDreamsForProfile(profileId)`（`GET /dreams?dream_profile_id=X`）をそのまま使い、`image_generated_at`が入っている夢だけを抽出する。
+
+## 3. フロントエンド: 新規ルート `app/room/[profileId]/page.tsx`
+
+`app/forest/[profileId]/page.tsx`と同じ`useParams`／`getDreamProfiles`＋`getDreamsForProfile`パターンを踏襲する。
+
+### 3-1. データ取得とソート
+
+```ts
+const dreams = await getDreamsForProfile(profileId); // 既存: created_at desc
+const withImages = dreams
+  .filter((d) => d.image_generated_at)
+  .sort((a, b) => {
+    const diff = new Date(b.image_generated_at!).getTime() - new Date(a.image_generated_at!).getTime();
+    return diff !== 0 ? diff : b.id - a.id; // 同時刻は id desc でタイブレーク
+  })
+  .slice(0, 6);
+```
+
+`Dream`型に`image_generated_at?: string`を追加する（`generated_image_url?: string`の隣）。
+
+### 3-2. 額縁ごとの逐次lazy-fetch
+
+- マウント時に`AbortController`を1つ生成し、`useEffect`のクリーンアップで`abort()`する。
+- `withImages`を**直列**（`for...of` + `await`）でループし、各夢について`apiClient.get<Dream>(\`/dreams/${id}\`, { signal: controller.signal })`を呼び、`generated_image_url`を取得できた額縁から`state`を更新してフェードイン表示する。
+- 各フェッチは独立した`try/catch`:
+  - 成功 → その額縁の状態を`{ status: "loaded", imageUrl }`にする
+  - 失敗（Abort以外）→ その額縁の状態を`{ status: "error" }`にする。**ループは止めず次の額縁へ進む**
+  - `AbortError`（unmount起因）→ 状態更新を行わない（`if (controller.signal.aborted) return;`を各`setState`前に置く）
+
+### 3-3. 額縁の表示状態
+
+| 状態 | 表示 |
+|---|---|
+| `loading`（取得中/未着手） | プレースホルダー枠（額縁のシルエット＋ぼんやりした光） |
+| `loaded` | `next/image`（`unoptimized`＋`onError`）で画像表示。タップで`/dream/${id}`へ |
+| `error` | ひび割れた額縁の意匠＋「もういちど」ボタン（その額縁だけ再フェッチ。**非表示にはしない**——記録が消えたように見えるのを避ける） |
+
+### 3-4. 空状態（2分岐）
+
+- **夢が0件**（`dreams.length === 0`）: 「まだ ゆめが きろくされていないよ」＋「ゆめを きろくする」ボタン → `/dream/new`
+- **夢はあるが画像が0件**（`dreams.length > 0` かつ `withImages.length === 0`）: 「まだ えが かざられていないよ」＋「ゆめのえを つくる」ボタン → 最新の夢（`dreams[0].id`、既存`created_at desc`順の先頭）の詳細 `/dream/${dreams[0].id}`
+
+いずれも`/home`へ戻すだけの導線にはしない。
+
+### 3-5. 画像表示パターンの再利用
+
+新しい画像表示ロジックは作らない。`DreamShareCard`のオンスクリーン表示と同じ構成——`next/image`に`unoptimized`props＋`onError`ハンドラを渡すだけの素の表示——を踏襲する。`/api/image-proxy`はcanvas書き出し（PNG保存）専用であり、額縁は保存機能を持たないため使用しない。
+
+### 3-6. 意匠・アクセシビリティ
+
+- 壁紙: `profile.color`ベースのグラデーション＋簡単な窓・床のCSS意匠（新規画像アセットは使わない）
+- ヘッダー: 「へやから でる」→ `/forest/${profileId}`、`{avatar_emoji} {name} の おへや`（長い名前は`truncate`）
+- 額縁グリッド: 375px幅で崩れない（2列グリッド等、実装時に確定）
+- 各額縁は`<button>`要素にしてキーボードのTab移動・Enterキー操作に対応、フォーカスリング表示
+- 画像の`alt`は夢タイトル（空なら「ラベルなし」等のフォールバック）
+- `useReducedMotion()`（既存森コンポーネントと同じ流儀）でフェードイン演出を無効化
+
+## 4. 入り口の実装箇所
+
+- `app/forest/[profileId]/page.tsx`: ヘッダー行（「もりに もどる」の並び）に「へやを のぞく」リンクを追加。`router.push(\`/room/${profileId}\`)`。
+- `app/components/forest/TreePreviewSheet.tsx`: 既存の「この きを 見る ›」ボタンの下（またはとなり）に「へやを のぞく」ボタンを追加。`onOpen`とは別の新規ハンドラ（例: `onPeekRoom`）を親（`ForestScene.tsx`）から渡し、`router.push(\`/room/${p.id}\`)`する。
+
+## 5. 認証ゲート登録（新規ルートのため必須・3箇所）
+
+新規ルート追加時は以下3箇所への登録が必須（過去の`/insights`追加時の教訓）。今回はテストで登録漏れを構造的に検出できるようにする。
+
+- `frontend/context/AuthContext.tsx`: `AUTH_VERIFY_PATH_PREFIXES`に`/room`を追加。**この定数を`export`する**（現状非export）
+- `frontend/proxy.ts`: `isProtectedPage`判定に`/room`を追加。現状は関数内のインライン`pathname.startsWith(...)`チェーンで外部からテストできないため、**`AUTH_VERIFY_PATH_PREFIXES`と同じ形の`export const PROTECTED_PAGE_PREFIXES`を切り出し**、`isProtectedPage`はそれを参照するよう書き換える（ロジック変更なし、ミニマルなテスト容易性向上のリファクタ）。`config.matcher`にも`"/room/:path*"`を追加
+- `frontend/lib/site.ts`: `NON_INDEXABLE_PATH_PREFIXES`に`/room`を追加（既にexport済み）
+
+### 登録漏れ検出テスト
+
+新規`frontend/__tests__/lib/route-registration.test.ts`で、`AUTH_VERIFY_PATH_PREFIXES`・`PROTECTED_PAGE_PREFIXES`・`NON_INDEXABLE_PATH_PREFIXES`・`proxy.ts`の`config.matcher`をまとめてimportし、`"/room"`（および`config.matcher`は`"/room/:path*"`）が全てに含まれることを1つのテストファイルで検証する。既存`__tests__/app/seo.test.ts`の`it.each`パターンを踏襲。
+
+## 6. テスト方針
+
+### バックエンド（RSpec request spec）
+
+`dreams_spec.rb`の`GET /dreams (index)`に以下2点をアサートする新規ケースを追加:
+1. `image_generated_at`がレスポンスに含まれる（画像生成済みの夢を用意して値を検証）
+2. `generated_image_url`キー自体がレスポンスに存在しない（`json_response.first).not_to have_key('generated_image_url')`）— 一覧の軽量性を担保する既存方針の回帰防止
+
+### フロントエンド（component test, 新規 `__tests__/app/room/page.test.tsx` 相当）
+
+- 額縁が`image_generated_at`降順（同時刻は`id`降順）で並ぶこと
+- 6枚を超える画像持ち夢がある場合、先頭6件のみ表示されること
+- 逐次lazy-fetchで、取得成功した額縁から順に画像が表示されること
+- 1件の`GET /dreams/:id`が失敗しても、他の額縁の取得・表示が続行されること。失敗した額縁に「もういちど」ボタンが表示され、クリックでその額縁だけ再フェッチされること
+- unmount後（ページ離脱後）に遅れて解決するfetchが、状態更新を行わないこと（`AbortController`のモックまたはunmount後のPromise解決タイミングを検証）
+- 空状態2分岐: 夢0件→「ゆめを きろくする」（`/dream/new`へのリンク）／画像0件→「ゆめのえを つくる」（最新夢詳細へのリンク）
+- 長いプロフィール名で見出しが`truncate`されること
+- 額縁の`alt`属性が夢タイトルであること
+
+### ルート登録（新規, §5参照）
+
+`route-registration.test.ts`で3箇所＋matcherの整合を検証。
+
+## 7. 開発開始条件
+
+**PR #428（backend gem 6件の一括更新）がCI全緑・Codex指摘なしで`main`へマージされた後**、最新の`origin/main`から新規worktreeを作成して着手する（現worktreeは設計docのみをコミットする）。
+
+## 8. 境界
+
+**触る**: `backend/app/controllers/dreams_controller.rb`（`index_columns`に1列追加）/ `frontend/app/room/[profileId]/page.tsx`（新規）/ `frontend/app/types.ts`（`Dream.image_generated_at`追加）/ `frontend/app/forest/[profileId]/page.tsx`（入り口リンク追加）/ `frontend/app/components/forest/TreePreviewSheet.tsx`・`ForestScene.tsx`（入り口リンク追加）/ `frontend/context/AuthContext.tsx`・`frontend/proxy.ts`・`frontend/lib/site.ts`（認証ゲート登録＋テスト容易性のためのexport化）/ テスト（新規＋`dreams_spec.rb`拡張）。
+
+**触らない**: migration・DBスキーマ・新規APIエンドポイント・Stripe・OpenAI・`DreamShareCard`本体・「もりの一覧」`/forest`・BottomTabBar（新規タブは追加しない）・7枚目以降のページング（将来PR）。

--- a/frontend/__tests__/app/room/page.test.tsx
+++ b/frontend/__tests__/app/room/page.test.tsx
@@ -1,0 +1,216 @@
+import React from "react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import DreamRoomPage from "@/app/room/[profileId]/page";
+import type { Dream, DreamProfile } from "@/app/types";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({
+    alt,
+    fill: _fill,
+    unoptimized: _unoptimized,
+    sizes: _sizes,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & {
+    fill?: boolean;
+    unoptimized?: boolean;
+    sizes?: string;
+  }) => <img alt={alt} {...props} />,
+}));
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+const mockRouter = { push: mockPush, replace: mockReplace };
+jest.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+  useParams: () => ({ profileId: "1" }),
+}));
+
+const mockUseAuth = jest.fn<() => { authStatus: string }>();
+jest.mock("@/context/AuthContext", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("@/app/loading", () => ({
+  __esModule: true,
+  default: () => <div>Loading</div>,
+}));
+
+const mockGetDreamProfiles = jest.fn<() => Promise<DreamProfile[]>>();
+const mockGetDreamsForProfile = jest.fn<(profileId: number) => Promise<Dream[]>>();
+const mockApiGet = jest.fn<
+  (url: string, options?: { signal?: AbortSignal }) => Promise<Dream>
+>();
+jest.mock("@/lib/apiClient", () => ({
+  __esModule: true,
+  default: {
+    get: (url: string, options?: { signal?: AbortSignal }) =>
+      mockApiGet(url, options),
+  },
+  getDreamProfiles: () => mockGetDreamProfiles(),
+  getDreamsForProfile: (profileId: number) => mockGetDreamsForProfile(profileId),
+}));
+
+function makeProfile(overrides: Partial<DreamProfile> = {}): DreamProfile {
+  return {
+    id: 1,
+    name: "ねこさん",
+    avatar_emoji: "🐱",
+    color: "#f97316",
+    relationship: "self",
+    active: true,
+    position: 0,
+    archived: false,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeDream(id: number, overrides: Partial<Dream> = {}): Dream {
+  return {
+    id,
+    title: `夢${id}`,
+    userId: 1,
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function detailFor(dream: Dream): Dream {
+  return { ...dream, generated_image_url: `https://img.example/${dream.id}.png` };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseAuth.mockReturnValue({ authStatus: "authenticated" });
+  mockGetDreamProfiles.mockResolvedValue([makeProfile()]);
+});
+
+it("image_generated_at降順・同時刻はid降順で最大6枚を並べる", async () => {
+  const dreams = [
+    makeDream(1, { image_generated_at: "2026-07-01T00:00:00Z" }),
+    makeDream(2, { image_generated_at: "2026-07-05T00:00:00Z" }),
+    makeDream(3, { image_generated_at: "2026-07-05T00:00:00Z" }),
+    makeDream(4, { image_generated_at: "2026-07-03T00:00:00Z" }),
+    makeDream(5, { image_generated_at: "2026-07-02T00:00:00Z" }),
+    makeDream(6, { image_generated_at: "2026-07-04T00:00:00Z" }),
+    makeDream(7, { image_generated_at: "2026-07-06T00:00:00Z" }),
+  ];
+  mockGetDreamsForProfile.mockResolvedValue(dreams);
+  mockApiGet.mockImplementation((url: string) => {
+    const dream = dreams.find((item) => url === `/dreams/${item.id}`)!;
+    return Promise.resolve(detailFor(dream));
+  });
+
+  render(<DreamRoomPage />);
+
+  await screen.findByAltText("夢5");
+  expect(screen.getAllByTestId(/room-frame-/).map((node) => node.dataset.testid)).toEqual([
+    "room-frame-7",
+    "room-frame-3",
+    "room-frame-2",
+    "room-frame-6",
+    "room-frame-4",
+    "room-frame-5",
+  ]);
+  expect(screen.queryByTestId("room-frame-1")).not.toBeInTheDocument();
+});
+
+it("画像詳細を1枚ずつ直列取得する", async () => {
+  const dreams = [
+    makeDream(2, { image_generated_at: "2026-07-02T00:00:00Z" }),
+    makeDream(1, { image_generated_at: "2026-07-01T00:00:00Z" }),
+  ];
+  mockGetDreamsForProfile.mockResolvedValue(dreams);
+  let resolveFirst!: (dream: Dream) => void;
+  mockApiGet
+    .mockImplementationOnce(() => new Promise<Dream>((resolve) => { resolveFirst = resolve; }))
+    .mockResolvedValueOnce(detailFor(dreams[1]));
+
+  render(<DreamRoomPage />);
+
+  await waitFor(() => expect(mockApiGet).toHaveBeenCalledTimes(1));
+  expect(mockApiGet).toHaveBeenNthCalledWith(1, "/dreams/2", expect.any(Object));
+
+  await act(async () => resolveFirst(detailFor(dreams[0])));
+  await waitFor(() => expect(mockApiGet).toHaveBeenCalledTimes(2));
+  expect(mockApiGet).toHaveBeenNthCalledWith(2, "/dreams/1", expect.any(Object));
+});
+
+it("1枚の失敗後も次を取得し、失敗額縁だけ再試行できる", async () => {
+  const dreams = [
+    makeDream(2, { image_generated_at: "2026-07-02T00:00:00Z" }),
+    makeDream(1, { image_generated_at: "2026-07-01T00:00:00Z" }),
+  ];
+  mockGetDreamsForProfile.mockResolvedValue(dreams);
+  mockApiGet
+    .mockRejectedValueOnce(new Error("network error"))
+    .mockResolvedValueOnce(detailFor(dreams[1]))
+    .mockResolvedValueOnce(detailFor(dreams[0]));
+
+  render(<DreamRoomPage />);
+
+  const failedFrame = await screen.findByTestId("room-frame-2");
+  const retry = await within(failedFrame).findByRole("button", { name: "もういちど" });
+  expect(await screen.findByAltText("夢1")).toBeInTheDocument();
+
+  fireEvent.click(retry);
+  expect(await screen.findByAltText("夢2")).toBeInTheDocument();
+  expect(mockApiGet).toHaveBeenCalledTimes(3);
+});
+
+it("ページ離脱時に進行中の画像取得signalを中断する", async () => {
+  const dream = makeDream(1, { image_generated_at: "2026-07-01T00:00:00Z" });
+  mockGetDreamsForProfile.mockResolvedValue([dream]);
+  mockApiGet.mockImplementation(() => new Promise(() => {}));
+
+  const { unmount } = render(<DreamRoomPage />);
+  await waitFor(() => expect(mockApiGet).toHaveBeenCalled());
+  const signal = mockApiGet.mock.calls[0][1]?.signal as AbortSignal;
+
+  unmount();
+  expect(signal.aborted).toBe(true);
+});
+
+it("夢が0件なら夢の記録へのCTAを表示する", async () => {
+  mockGetDreamsForProfile.mockResolvedValue([]);
+  render(<DreamRoomPage />);
+
+  expect(await screen.findByRole("link", { name: "ゆめを きろくする" })).toHaveAttribute(
+    "href",
+    "/dream/new"
+  );
+});
+
+it("夢はあるが画像0件なら最新夢の画像生成へのCTAを表示する", async () => {
+  mockGetDreamsForProfile.mockResolvedValue([makeDream(2), makeDream(1)]);
+  render(<DreamRoomPage />);
+
+  expect(await screen.findByRole("link", { name: "ゆめのえを つくる" })).toHaveAttribute(
+    "href",
+    "/dream/2"
+  );
+});
+
+it("長いプロフィール名をtruncateし、画像altとキーボード操作を提供する", async () => {
+  const profile = makeProfile({ name: "とてもながいなまえのぷろふぃーるだよ" });
+  const dream = makeDream(1, {
+    title: "星空の夢",
+    image_generated_at: "2026-07-01T00:00:00Z",
+  });
+  mockGetDreamProfiles.mockResolvedValue([profile]);
+  mockGetDreamsForProfile.mockResolvedValue([dream]);
+  mockApiGet.mockResolvedValue(detailFor(dream));
+
+  render(<DreamRoomPage />);
+
+  expect((await screen.findByRole("heading", { level: 1 })).className).toContain("truncate");
+  expect(await screen.findByAltText("星空の夢")).toBeInTheDocument();
+  const frameButton = screen.getByRole("button", { name: "星空の夢をひらく" });
+  frameButton.focus();
+  fireEvent.keyDown(frameButton, { key: "Enter", code: "Enter" });
+  fireEvent.click(frameButton);
+  expect(mockPush).toHaveBeenCalledWith("/dream/1");
+});

--- a/frontend/__tests__/components/TreePreviewSheet.test.tsx
+++ b/frontend/__tests__/components/TreePreviewSheet.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import TreePreviewSheet from "@/app/components/forest/TreePreviewSheet";
 import type { Dream, DreamProfile } from "@/app/types";
 import { getDreamsForProfile } from "@/lib/apiClient";
@@ -62,6 +62,7 @@ describe("TreePreviewSheet", () => {
       <TreePreviewSheet
         profile={profile({ id: 1, name: "自分" })}
         onOpen={jest.fn()}
+        onPeekRoom={jest.fn()}
         onClose={jest.fn()}
       />
     );
@@ -72,6 +73,7 @@ describe("TreePreviewSheet", () => {
       <TreePreviewSheet
         profile={profile({ id: 2, name: "家族", dreams_count: 2 })}
         onOpen={jest.fn()}
+        onPeekRoom={jest.fn()}
         onClose={jest.fn()}
       />
     );
@@ -93,6 +95,7 @@ describe("TreePreviewSheet", () => {
       <TreePreviewSheet
         profile={profile({ id: 1, name: "自分" })}
         onOpen={jest.fn()}
+        onPeekRoom={jest.fn()}
         onClose={jest.fn()}
       />
     );
@@ -119,6 +122,7 @@ describe("TreePreviewSheet", () => {
       <TreePreviewSheet
         profile={profile({ id: 1, name: "自分" })}
         onOpen={jest.fn()}
+        onPeekRoom={jest.fn()}
         onClose={jest.fn()}
       />
     );
@@ -136,6 +140,7 @@ describe("TreePreviewSheet", () => {
       <TreePreviewSheet
         profile={profile({ id: 1, name: "自分" })}
         onOpen={jest.fn()}
+        onPeekRoom={jest.fn()}
         onClose={jest.fn()}
       />
     );
@@ -146,6 +151,31 @@ describe("TreePreviewSheet", () => {
 
     await waitFor(() => {
       expect(screen.queryByText("さいきんの ゆめ：")).not.toBeInTheDocument();
+    });
+  });
+
+  it("「へやを のぞく」を押すと選択プロフィールを渡す", async () => {
+    mockedGetDreamsForProfile.mockResolvedValueOnce([]);
+    const onPeekRoom = jest.fn();
+
+    render(
+      <TreePreviewSheet
+        profile={profile({ id: 3, name: "ふたり" })}
+        onOpen={jest.fn()}
+        onPeekRoom={onPeekRoom}
+        onClose={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("よみこんでいるよ…")).not.toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /へやを のぞく/ }));
+
+    await waitFor(() => {
+      expect(onPeekRoom).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 3, name: "ふたり" })
+      );
     });
   });
 });

--- a/frontend/__tests__/lib/route-registration.test.ts
+++ b/frontend/__tests__/lib/route-registration.test.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import path from "node:path";
+import { AUTH_VERIFY_PATH_PREFIXES } from "@/context/AuthContext";
+import { PROTECTED_PAGE_PREFIXES } from "@/lib/protectedRoutes";
+import { NON_INDEXABLE_PATH_PREFIXES } from "@/lib/site";
+
+describe("認証ゲート登録: /room", () => {
+  it("AuthContext.AUTH_VERIFY_PATH_PREFIXES に /room が含まれる", () => {
+    expect(AUTH_VERIFY_PATH_PREFIXES).toContain("/room");
+  });
+
+  it("lib/protectedRoutes.PROTECTED_PAGE_PREFIXES に /room が含まれる", () => {
+    expect(PROTECTED_PAGE_PREFIXES).toContain("/room");
+  });
+
+  it("lib/site.NON_INDEXABLE_PATH_PREFIXES に /room が含まれる", () => {
+    expect(NON_INDEXABLE_PATH_PREFIXES).toContain("/room");
+  });
+
+  it("proxy.ts の config.matcher に /room/:path* が含まれる", () => {
+    const proxySource = fs.readFileSync(path.join(process.cwd(), "proxy.ts"), "utf8");
+    const matcherSource = proxySource.match(/matcher:\s*\[([\s\S]*?)\]/)?.[1];
+
+    expect(matcherSource).toBeDefined();
+    expect(matcherSource).toContain('"/room/:path*"');
+  });
+});

--- a/frontend/app/components/forest/ForestScene.tsx
+++ b/frontend/app/components/forest/ForestScene.tsx
@@ -408,6 +408,7 @@ export default function ForestScene({ profiles }: { profiles: DreamProfile[] }) 
       <TreePreviewSheet
         profile={selected}
         onOpen={(p) => router.push(`/forest/${p.id}`)}
+        onPeekRoom={(p) => router.push(`/room/${p.id}`)}
         onClose={() => setSelectedId(null)}
       />
     </div>

--- a/frontend/app/components/forest/TreePreviewSheet.tsx
+++ b/frontend/app/components/forest/TreePreviewSheet.tsx
@@ -11,6 +11,7 @@ import { getDreamsForProfile } from "@/lib/apiClient";
 interface TreePreviewSheetProps {
   profile: DreamProfile | null;
   onOpen: (profile: DreamProfile) => void;
+  onPeekRoom: (profile: DreamProfile) => void;
   onClose: () => void;
 }
 
@@ -38,7 +39,7 @@ function dreamEmotions(dream: Dream): NonNullable<Dream["emotions"]> {
  *  - 直近の夢（title, emotions）は getDreamsForProfile() で lazy-fetch する。
  *    ネットワーク負荷が気になるなら、ForestScene 側でプリフェッチして渡してもよい。
  */
-export default function TreePreviewSheet({ profile, onOpen, onClose }: TreePreviewSheetProps) {
+export default function TreePreviewSheet({ profile, onOpen, onPeekRoom, onClose }: TreePreviewSheetProps) {
   const [recentDream, setRecentDream] = useState<Dream | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -126,6 +127,13 @@ export default function TreePreviewSheet({ profile, onOpen, onClose }: TreePrevi
             className="w-full rounded-[13px] py-2.5 text-[14.5px] font-black text-white"
           >
             この きを 見る ›
+          </button>
+          <button
+            type="button"
+            onClick={() => onPeekRoom(profile)}
+            className="mt-2 w-full rounded-[13px] border border-white/15 bg-white/5 py-2 text-[13px] font-bold text-white/70 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          >
+            🖼️ へやを のぞく
           </button>
         </motion.div>
       )}

--- a/frontend/app/forest/[profileId]/page.tsx
+++ b/frontend/app/forest/[profileId]/page.tsx
@@ -225,6 +225,14 @@ export default function ForestProfilePage() {
             {lvl.name}（{lvl.reading}）
           </span>
         </div>
+        <div className="container mx-auto flex max-w-3xl justify-end px-4 pb-2">
+          <Link
+            href={`/room/${profile.id}`}
+            className="rounded-full border border-white/20 bg-white/5 px-3 py-1 text-xs font-bold text-white/80 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          >
+            🖼️ へやを のぞく
+          </Link>
+        </div>
       </header>
 
       {/* 実の色の凡例トグル */}

--- a/frontend/app/room/[profileId]/page.tsx
+++ b/frontend/app/room/[profileId]/page.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import Loading from "@/app/loading";
+import type { Dream, DreamProfile } from "@/app/types";
+import { useAuth } from "@/context/AuthContext";
+import apiClient, {
+  getDreamProfiles,
+  getDreamsForProfile,
+} from "@/lib/apiClient";
+
+const MAX_FRAMES = 6;
+
+type Frame = {
+  dream: Dream;
+  status: "loading" | "loaded" | "error";
+  imageUrl?: string;
+};
+
+function selectFrameDreams(dreams: Dream[]): Dream[] {
+  return dreams
+    .filter((dream): dream is Dream & { image_generated_at: string } =>
+      Boolean(dream.image_generated_at)
+    )
+    .sort((a, b) => {
+      const timeDifference =
+        new Date(b.image_generated_at).getTime() -
+        new Date(a.image_generated_at).getTime();
+      return timeDifference || b.id - a.id;
+    })
+    .slice(0, MAX_FRAMES);
+}
+
+export default function DreamRoomPage() {
+  const { authStatus } = useAuth();
+  const params = useParams();
+  const router = useRouter();
+  const reduceMotion = useReducedMotion();
+  const rawProfileId = params.profileId;
+  const profileId = Number(rawProfileId);
+
+  const [profile, setProfile] = useState<DreamProfile | null>(null);
+  const [dreams, setDreams] = useState<Dream[]>([]);
+  const [frames, setFrames] = useState<Frame[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const frameAbortRef = useRef<AbortController | null>(null);
+
+  const loadRoom = useCallback(async () => {
+    if (!Number.isInteger(profileId) || profileId <= 0) {
+      router.replace("/forest");
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const [profiles, profileDreams] = await Promise.all([
+        getDreamProfiles(),
+        getDreamsForProfile(profileId),
+      ]);
+      const selectedProfile = Array.isArray(profiles)
+        ? profiles.find((candidate) =>
+            candidate.id === profileId && !candidate.archived
+          )
+        : null;
+
+      if (!selectedProfile || !Array.isArray(profileDreams)) {
+        router.replace("/forest");
+        return;
+      }
+
+      setProfile(selectedProfile);
+      setDreams(profileDreams);
+    } catch (error) {
+      console.error("Failed to load dream room", error);
+      router.replace("/forest");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [profileId, router]);
+
+  useEffect(() => {
+    if (authStatus === "unauthenticated") {
+      router.push("/login");
+      return;
+    }
+    if (authStatus === "authenticated") void loadRoom();
+  }, [authStatus, loadRoom, router]);
+
+  const frameDreams = useMemo(() => selectFrameDreams(dreams), [dreams]);
+
+  const fetchFrame = useCallback(async (dream: Dream, signal: AbortSignal) => {
+    try {
+      const detail = await apiClient.get<Dream>(`/dreams/${dream.id}`, { signal });
+      if (signal.aborted) return;
+
+      setFrames((current) =>
+        current.map((frame) =>
+          frame.dream.id === dream.id
+            ? detail.generated_image_url
+              ? { ...frame, status: "loaded", imageUrl: detail.generated_image_url }
+              : { ...frame, status: "error", imageUrl: undefined }
+            : frame
+        )
+      );
+    } catch (error) {
+      if (signal.aborted || (error as Error)?.name === "AbortError") return;
+      setFrames((current) =>
+        current.map((frame) =>
+          frame.dream.id === dream.id
+            ? { ...frame, status: "error", imageUrl: undefined }
+            : frame
+        )
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    if (frameDreams.length === 0) {
+      setFrames([]);
+      return;
+    }
+
+    const controller = new AbortController();
+    frameAbortRef.current = controller;
+    setFrames(frameDreams.map((dream) => ({ dream, status: "loading" })));
+
+    void (async () => {
+      for (const dream of frameDreams) {
+        if (controller.signal.aborted) return;
+        await fetchFrame(dream, controller.signal);
+      }
+    })();
+
+    return () => {
+      controller.abort();
+      if (frameAbortRef.current === controller) frameAbortRef.current = null;
+    };
+  }, [fetchFrame, frameDreams]);
+
+  const retryFrame = useCallback(
+    (dream: Dream) => {
+      const controller = frameAbortRef.current;
+      if (!controller || controller.signal.aborted) return;
+      setFrames((current) =>
+        current.map((frame) =>
+          frame.dream.id === dream.id
+            ? { ...frame, status: "loading", imageUrl: undefined }
+            : frame
+        )
+      );
+      void fetchFrame(dream, controller.signal);
+    },
+    [fetchFrame]
+  );
+
+  const markFrameError = useCallback((dreamId: number) => {
+    setFrames((current) =>
+      current.map((frame) =>
+        frame.dream.id === dreamId
+          ? { ...frame, status: "error", imageUrl: undefined }
+          : frame
+      )
+    );
+  }, []);
+
+  if (authStatus === "checking" || isLoading) return <Loading />;
+  if (!profile) return null;
+
+  return (
+    <div
+      className="relative min-h-screen overflow-hidden pb-24 text-white"
+      style={{
+        background: `linear-gradient(180deg, ${profile.color}44 0%, rgba(28, 20, 48, 0.98) 62%, #140f24 62%)`,
+      }}
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute right-6 top-24 h-28 w-20 rounded-t-full border-4 border-white/20 bg-sky-200/20 shadow-[inset_0_0_30px_rgba(255,255,255,0.12)] sm:right-12"
+      />
+
+      <header className="sticky top-0 z-10 bg-black/20 backdrop-blur-md">
+        <div className="container mx-auto flex h-14 max-w-3xl items-center px-4">
+          <Link
+            href={`/forest/${profile.id}`}
+            className="flex min-h-[44px] shrink-0 items-center px-1 text-white/80 hover:text-white"
+          >
+            <ChevronLeft className="mr-1 h-5 w-5" /> へやから でる
+          </Link>
+          <h1 className="ml-3 min-w-0 flex-1 truncate text-lg font-bold">
+            {profile.avatar_emoji} {profile.name} の おへや
+          </h1>
+        </div>
+      </header>
+
+      <main className="container relative z-[2] mx-auto max-w-3xl px-4 pt-8">
+        {dreams.length === 0 ? (
+          <RoomEmptyState
+            icon="🛏️"
+            message="まだ ゆめが きろくされていないよ"
+            href="/dream/new"
+            action="ゆめを きろくする"
+          />
+        ) : frameDreams.length === 0 ? (
+          <RoomEmptyState
+            icon="🖼️"
+            message="まだ えが かざられていないよ"
+            href={`/dream/${dreams[0].id}`}
+            action="ゆめのえを つくる"
+          />
+        ) : (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            {frames.map((frame) => (
+              <FrameCard
+                key={frame.dream.id}
+                frame={frame}
+                profileColor={profile.color}
+                reduceMotion={Boolean(reduceMotion)}
+                onOpen={() => router.push(`/dream/${frame.dream.id}`)}
+                onRetry={() => retryFrame(frame.dream)}
+                onImageError={() => markFrameError(frame.dream.id)}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function RoomEmptyState({
+  icon,
+  message,
+  href,
+  action,
+}: {
+  icon: string;
+  message: string;
+  href: string;
+  action: string;
+}) {
+  return (
+    <div className="mt-10 flex flex-col items-center gap-4 text-center">
+      <span className="text-6xl" aria-hidden="true">{icon}</span>
+      <p className="text-lg font-bold text-white/90">{message}</p>
+      <Link
+        href={href}
+        className="mt-2 rounded-full bg-gradient-to-br from-violet-600 to-sky-400 px-5 py-2 text-sm font-bold text-white shadow-lg"
+      >
+        {action}
+      </Link>
+    </div>
+  );
+}
+
+function FrameCard({
+  frame,
+  profileColor,
+  reduceMotion,
+  onOpen,
+  onRetry,
+  onImageError,
+}: {
+  frame: Frame;
+  profileColor: string;
+  reduceMotion: boolean;
+  onOpen: () => void;
+  onRetry: () => void;
+  onImageError: () => void;
+}) {
+  return (
+    <div data-testid={`room-frame-${frame.dream.id}`}>
+      <AnimatePresence mode="wait">
+        {frame.status === "loaded" && frame.imageUrl ? (
+          <motion.button
+            key="loaded"
+            type="button"
+            onClick={onOpen}
+            initial={reduceMotion ? false : { opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: reduceMotion ? 0 : 0.3 }}
+            className="relative aspect-square w-full overflow-hidden rounded-2xl border-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-violet-950"
+            style={{ borderColor: `${profileColor}88` }}
+            aria-label={`${frame.dream.title || "ラベルなし"}をひらく`}
+          >
+            <Image
+              src={frame.imageUrl}
+              alt={frame.dream.title || "ラベルなし"}
+              fill
+              sizes="(max-width: 640px) 45vw, 220px"
+              className="object-cover"
+              unoptimized
+              onError={onImageError}
+            />
+          </motion.button>
+        ) : frame.status === "error" ? (
+          <div
+            key="error"
+            className="flex aspect-square flex-col items-center justify-center gap-2 rounded-2xl border-4 border-dashed p-2 text-center"
+            style={{ borderColor: `${profileColor}55` }}
+          >
+            <span className="text-2xl" aria-hidden="true">💔</span>
+            <button
+              type="button"
+              onClick={onRetry}
+              className="rounded-full bg-white/10 px-3 py-1 text-xs font-bold text-white/80 hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+            >
+              もういちど
+            </button>
+          </div>
+        ) : (
+          <div
+            key="loading"
+            className="aspect-square animate-pulse rounded-2xl border-4 motion-reduce:animate-none"
+            style={{ borderColor: `${profileColor}33`, background: `${profileColor}11` }}
+            aria-label={`${frame.dream.title || "ラベルなし"}を読み込み中`}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/frontend/app/types.ts
+++ b/frontend/app/types.ts
@@ -74,6 +74,7 @@ export interface Dream {
   analysis_status?: string;
   analyzed_at?: string;
   generated_image_url?: string;
+  image_generated_at?: string;
 }
 export type LoginCredentials = {
   email: string;

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -28,7 +28,7 @@ type AuthContextType = {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 const AUTH_HINT_KEY = "dreamjournal_auth_hint";
-const AUTH_VERIFY_PATH_PREFIXES = [
+export const AUTH_VERIFY_PATH_PREFIXES = [
   "/home",
   "/dream",
   "/forest",
@@ -36,6 +36,7 @@ const AUTH_VERIFY_PATH_PREFIXES = [
   "/settings",
   "/subscription",
   "/register",
+  "/room",
 ];
 
 function hasAuthHint(): boolean {

--- a/frontend/lib/protectedRoutes.ts
+++ b/frontend/lib/protectedRoutes.ts
@@ -1,0 +1,14 @@
+export const PROTECTED_PAGE_PREFIXES = [
+  "/home",
+  "/dream",
+  "/forest",
+  "/insights",
+  "/settings",
+  "/room",
+];
+
+export function isProtectedPage(pathname: string): boolean {
+  return PROTECTED_PAGE_PREFIXES.some((prefix) =>
+    pathname === prefix || pathname.startsWith(`${prefix}/`)
+  );
+}

--- a/frontend/lib/site.ts
+++ b/frontend/lib/site.ts
@@ -20,6 +20,7 @@ export const NON_INDEXABLE_PATH_PREFIXES = [
   "/my-dreams", // 夢一覧（ユーザーデータ）
   "/insights", // きもちインサイト（認証）
   "/forest", // 夢の森（認証）
+  "/room", // 夢の部屋（認証）
   "/profiles", // プロフィール（認証）
   "/settings", // 設定（認証）
   "/subscription", // サブスク管理・決済リダイレクト（認証）

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { shouldAllowAuthPageForUser } from "./lib/authPageRedirect";
+import { isProtectedPage } from "./lib/protectedRoutes";
 
 const API_PREFIX_PATTERN = /\/api\/v1\/?$/;
 
@@ -45,12 +46,7 @@ export async function proxy(request: NextRequest) {
 
   const isAuthPage =
     pathname.startsWith("/login") || pathname.startsWith("/register");
-  const isProtectedPage =
-    pathname.startsWith("/home") ||
-    pathname.startsWith("/dream") ||
-    pathname.startsWith("/forest") ||
-    pathname.startsWith("/insights") ||
-    pathname.startsWith("/settings");
+  const pageIsProtected = isProtectedPage(pathname);
 
   // Only these pages render MorpheusLoginRequired for unauthenticated users.
   // Every other protected page still redirects to /login.
@@ -59,7 +55,7 @@ export async function proxy(request: NextRequest) {
     pathname === "/insights" ||
     pathname.startsWith("/dream/month");
 
-  if (!token && isProtectedPage) {
+  if (!token && pageIsProtected) {
     // Let the page render its in-app login guidance instead of forcing an
     // immediate redirect. Protected data is still guarded by backend APIs.
     return NextResponse.next();
@@ -82,7 +78,7 @@ export async function proxy(request: NextRequest) {
         // Logged in, and on an auth page -> redirect to home.
         // Trial users are allowed through /register so they can convert in-place.
         return NextResponse.redirect(new URL("/home", request.url));
-      } else if (!response.ok && isProtectedPage) {
+      } else if (!response.ok && pageIsProtected) {
         // Invalid token on a protected page: clear the stale cookie, then let
         // the client show the Morpheus login-required guidance.
         const res = NextResponse.next();
@@ -105,6 +101,7 @@ export const config = {
     "/forest/:path*",
     "/insights/:path*",
     "/settings/:path*",
+    "/room/:path*",
     "/login",
     "/register",
   ],


### PR DESCRIPTION
## Summary
世界観MVP最終候補「夢の部屋（額縁の壁）」。プロフィールごとのAI生成夢画像を振り返れる新規ページ `/room/[profileId]` を追加する。既存の「夢の森」＝成長・感情の可視化に対し、「夢の部屋」＝AI生成画像のギャラリーとして役割を分ける。

設計仕様: `docs/superpowers/specs/2026-07-17-dream-room-design.md` / 実装計画: `docs/superpowers/plans/2026-07-17-dream-room.md`

## 変更範囲
- **backend**: `GET /dreams`（一覧API）に `image_generated_at` を1列追加（`generated_image_url` は引き続き除外し軽量方針を維持）。新規エンドポイント・migrationなし
- **frontend**:
  - `/room/[profileId]` 新規ページ: 最大6枚の額縁を `image_generated_at` 降順（同時刻は `id` 降順）で表示。各額縁の画像は `GET /dreams/:id` を直列でlazy-fetch、1件の失敗が他をブロックしない（再試行ボタン付き）、`AbortController` によるページ離脱時の安全な中断
  - 空状態2分岐（夢0件→記録CTA／画像0件→最新夢への生成CTA）、いずれも `/home` に戻すだけにしない
  - 新規ルートのため認証ゲート4箇所（`AuthContext.tsx` / `lib/protectedRoutes.ts`（新規・`proxy.ts`のNext.js特殊ファイル制約に対応した分離） / `lib/site.ts` / `proxy.ts`の`config.matcher`）に登録し、登録漏れ検出テストを追加
  - 森詳細ページ・`TreePreviewSheet` の2箇所に入り口リンクを追加

## 実装の経緯
設計・計画は事前にbrainstorming→writing-plansで作成済み。実装（Task 1〜4）は、計画作成セッションが利用上限に達したため別セッションが引き継いで完了。マージ前にコントローラーセッションが独立して全ての報告内容を再検証済み（diff精査・全テスト自力再実行・`next build`確認）。実装は計画に対して複数箇所で改善が見られた（詳細は最終レビュー参照）。

## Test plan
- [x] 対象フロントテスト: 6 suites / 47 tests 全緑
- [x] フロント全体: `npx jest` — 54 suites / 400 tests 全緑
- [x] backend: `docker compose run --rm backend-test bundle exec rspec spec/requests/dreams_spec.rb` — 90 examples, 0 failures
- [x] `npx next build` 成功（`/room/[profileId]` ルート生成確認、`page.tsx`に不正named exportなし）
- [x] `git diff --check` 問題なし
- [x] 最終whole-branchレビュー（opus）: Ready to merge = Yes、Critical/Important指摘なし（Minor2件は実害なしと確認済み）
- [ ] **未実施**: デプロイ後のスマホ実機QA（375px幅でのレイアウト崩れ・キーボード操作・`prefers-reduced-motion`の実機確認）

## 境界
新規バックエンドエンドポイント・migration・DBスキーマ変更・Stripe・OpenAI呼び出し・`DreamShareCard`本体・`/forest`一覧・`BottomTabBar`には触れていない。