### PR TITLE
feat: homeの夢一覧にグリッド／リスト表示切替を追加

### DIFF
--- a/docs/superpowers/plans/2026-07-18-home-desktop-view-toggle.md
+++ b/docs/superpowers/plans/2026-07-18-home-desktop-view-toggle.md
@@ -1,0 +1,51 @@
+# Home 夢一覧 グリッド／リスト表示切替 実装計画
+
+**Goal:** `/home`の既存夢一覧に、現行グリッドを維持したまま1列リストへ切り替えられるデスクトップUIを追加する。
+
+**Source spec:** `docs/superpowers/specs/2026-07-18-home-desktop-view-toggle-design.md`
+
+## Task 1: `DreamList`を2レイアウト対応にする
+
+対象:
+
+- `frontend/app/components/DreamList.tsx`
+- `frontend/__tests__/components/DreamList.test.js`
+
+手順:
+
+1. `DreamListProps`へ`viewMode?: "grid" | "list"`を追加する。
+2. 既定値を`grid`にする。
+3. 現行グリッドクラスと1列リストクラスを条件分岐する。
+4. テストから判定できる`data-view-mode`をコンテナへ付ける。
+5. グリッド既定値、リスト指定、入力順維持のテストを追加する。
+6. `DreamList.test.js`を実行する。
+
+## Task 2: `/home`へ切替UIを追加する
+
+対象:
+
+- `frontend/app/home/page.tsx`
+- `frontend/__tests__/app/home/page.test.tsx`
+
+手順:
+
+1. `LayoutGrid`、`List`をimportする。
+2. `DreamViewMode` stateを`grid`初期値で追加する。
+3. `!loading && !errorMessage && dreams.length > 0`のとき、一覧直前に`md`以上の切替UIを表示する。
+4. `DreamList`へ`viewMode`を渡す。
+5. homeテストのDreamList mockで受け取ったmodeを可視化する。
+6. 初期グリッドとリスト切替、ARIA状態をテストする。
+
+## Task 3: 回帰検証
+
+1. 対象Jestを実行する。
+2. フロント全Jestを実行する。
+3. `npm run build`を実行する。
+4. `git diff --check`と対象外ファイルがないことを確認する。
+
+## 完了条件
+
+- 現行の既定表示に変化がない。
+- デスクトップで1列リストへ切り替えられる。
+- 検索・プロフィール絞り込み・空状態・カード遷移に回帰がない。
+- AppShellや新規ルートを追加していない。

--- a/docs/superpowers/specs/2026-07-18-home-desktop-view-toggle-design.md
+++ b/docs/superpowers/specs/2026-07-18-home-desktop-view-toggle-design.md
@@ -1,0 +1,67 @@
+# Home 夢一覧 グリッド／リスト表示切替 設計仕様
+
+- 日付: 2026-07-18
+- 対象: `frontend/app/home/page.tsx`、`frontend/app/components/DreamList.tsx`
+- 起点: `origin/main` `6c0d8fd`（PR #429マージ済み）
+
+## 1. 目的
+
+`/home`へ一本化済みの夢一覧に、デスクトップ利用者が情報密度を選べる「グリッド／リスト」表示切替を追加する。
+
+現行`DreamList`はすでに`auto-fill`と`minmax(280px, 1fr)`によるレスポンシブグリッドである。そのため新しいカードUIや専用一覧ページは作らず、現行グリッドを既定値として維持し、1列リスト表示を選べるようにする。
+
+## 2. 決定事項
+
+- 表示モードは`"grid" | "list"`の2種類。
+- 初期値は常に`grid`。現行表示を変えない。
+- `/home`がstateを所有し、`DreamList`へ`viewMode` propとして渡す。
+- 切替UIは夢一覧の直前に配置し、`md`以上かつ夢が1件以上あるときだけ表示する。
+- グリッドは現行クラスを維持する。
+- リストは1列の縦積みとし、`DreamCard`本体は変更しない。
+- 選択状態はセッション内のReact stateのみ。localStorageやURLには保存しない。
+- ローディング、エラー、空状態では切替UIを表示しない。
+
+## 3. UI・アクセシビリティ
+
+- `LayoutGrid`と`List`（lucide-react）を使用する。
+- 2ボタンを`role="group"`、`aria-label="夢の表示形式"`でまとめる。
+- 各ボタンに`aria-label`（`グリッド表示`／`リスト表示`）と`aria-pressed`を付ける。
+- 選択中は`bg-primary/10 text-primary`、未選択は`text-muted-foreground`。
+- `focus-visible`リングと44px相当の操作領域を確保する。
+- モバイルでは現行グリッドが実質1列になるため、切替UIを隠して操作を増やさない。
+
+## 4. コンポーネント境界
+
+### `home/page.tsx`
+
+- `DreamViewMode` stateを追加する。
+- 一覧直前に切替UIを描画する。
+- `DreamList`へ`viewMode`を渡す。
+
+### `DreamList.tsx`
+
+- `viewMode?: "grid" | "list"`を追加し、既定値を`grid`にする。
+- データ、並び順、空状態の分岐は変更しない。
+- コンテナクラスだけを表示モードで切り替える。
+
+## 5. テスト
+
+- `DreamList`のprop省略時にグリッドになる。
+- `viewMode="list"`で1列レイアウトになる。
+- どちらの表示でも入力順とカード内容を維持する。
+- `/home`の初期状態はグリッドボタンが選択済み。
+- リストボタン操作で`DreamList`へ`list`が渡る。
+- 空状態・検索・プロフィールフィルターの既存テストを回帰確認する。
+
+## 6. スコープ外
+
+- `AppShell`新設
+- `/dreams`新設
+- `/my-dreams`変更
+- `SearchBar`、`ProfileFilterChips`、`DreamCard`の変更
+- 表示設定の永続化
+- 取得API、認証、決済、分析処理の変更
+
+## 7. 作業ツリー方針
+
+主worktreeには未完了の`lg:`→`2xl:`変更があるため触らない。`origin/main` `6c0d8fd`から作成した専用worktree、ブランチ`codex/home-desktop-view-toggle`だけで実装する。

--- a/frontend/__tests__/app/home/page.test.tsx
+++ b/frontend/__tests__/app/home/page.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import HomePage from "@/app/home/page";
 import type { Dream, DreamProfile } from "@/app/types";
 
@@ -86,7 +86,12 @@ jest.mock("@/app/components/ProfileFilterChips", () => ({
 }));
 jest.mock("@/app/components/DreamList", () => ({
   __esModule: true,
-  default: () => <div>DreamList</div>,
+  default: ({ viewMode }: { viewMode: string }) => (
+    <div>
+      DreamList
+      <span data-testid="dream-list-view-mode">{viewMode}</span>
+    </div>
+  ),
 }));
 jest.mock("@/app/components/DreamCardSkeleton", () => ({
   __esModule: true,
@@ -187,5 +192,26 @@ describe("HomePage: WeeklyDreamNewsWidgetへのデータ受け渡し", () => {
     expect(screen.queryByTestId("weekly-widget-dream-ids")).not.toBeInTheDocument();
 
     consoleErrorSpy.mockRestore();
+  });
+
+  it("グリッド表示を既定値にし、リスト表示へ切り替えられる", async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes("start_date=")) return Promise.resolve([dream(201)]);
+      return Promise.resolve([dream(100)]);
+    });
+
+    render(<HomePage />);
+
+    expect(await screen.findByTestId("dream-list-view-mode")).toHaveTextContent("grid");
+    const gridButton = screen.getByRole("button", { name: "グリッド表示" });
+    const listButton = screen.getByRole("button", { name: "リスト表示" });
+    expect(gridButton).toHaveAttribute("aria-pressed", "true");
+    expect(listButton).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(listButton);
+
+    expect(screen.getByTestId("dream-list-view-mode")).toHaveTextContent("list");
+    expect(gridButton).toHaveAttribute("aria-pressed", "false");
+    expect(listButton).toHaveAttribute("aria-pressed", "true");
   });
 });

--- a/frontend/__tests__/components/DreamList.test.js
+++ b/frontend/__tests__/components/DreamList.test.js
@@ -80,6 +80,24 @@ describe("DreamList (integration with DreamCard)", () => {
     ).toBeInTheDocument();
   });
 
+  it("uses the existing grid layout by default", () => {
+    render(<DreamList dreams={[makeDream()]} />);
+
+    const list = screen.getByTestId("dream-list");
+    expect(list).toHaveAttribute("data-view-mode", "grid");
+    expect(list).toHaveClass("grid");
+    expect(list.className).toContain("grid-cols-[repeat(auto-fill,minmax(280px,1fr))]");
+  });
+
+  it("uses a single-column layout in list mode", () => {
+    render(<DreamList dreams={[makeDream()]} viewMode="list" />);
+
+    const list = screen.getByTestId("dream-list");
+    expect(list).toHaveAttribute("data-view-mode", "list");
+    expect(list).toHaveClass("flex", "flex-col");
+    expect(list).not.toHaveClass("grid");
+  });
+
   it("renders a single item properly", () => {
     // Arrange
     const dreams = [makeDream({ id: 7, title: "単体" })];

--- a/frontend/app/components/DreamList.tsx
+++ b/frontend/app/components/DreamList.tsx
@@ -12,6 +12,8 @@ import MorpheusImage from "./MorpheusImage";
 interface DreamListProps {
   dreams: Dream[];
   onDelete?: (id: number) => void;
+  /** 夢カードの表示形式。省略時は現行どおりグリッド表示 */
+  viewMode?: "grid" | "list";
   /** 文字・日付・感情での検索が有効かどうか（空表示メッセージを切り替えるために使用） */
   isSearchActive?: boolean;
   /** プロフィール切り替え中かどうか（空表示メッセージを切り替えるために使用） */
@@ -84,6 +86,7 @@ const moonPhases = [
 
 const DreamList = ({
   dreams,
+  viewMode = "grid",
   isSearchActive = false,
   isProfileFilterActive = false,
   ageGroup,
@@ -93,10 +96,16 @@ const DreamList = ({
   return (
     <>
       <motion.div
+        data-testid="dream-list"
+        data-view-mode={viewMode}
         variants={container}
         initial="hidden"
         animate="show"
-        className="w-full grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4 p-4"
+        className={
+          viewMode === "grid"
+            ? "grid w-full grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4 p-4"
+            : "flex w-full flex-col gap-3 p-4"
+        }
       >
         {dreams.length === 0 ? (
           shouldShowProfileEmpty ? (

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
+import { LayoutGrid, List } from "lucide-react";
 import { Dream, Emotion, AgeGroup, DreamProfile } from "@/app/types";
 import { useAuth } from "@/context/AuthContext";
 import apiClient from "@/lib/apiClient";
@@ -24,6 +25,8 @@ import { MorpheusGuideHome } from "@/app/components/MorpheusGuide";
 import MorpheusHero from "@/app/components/MorpheusHero";
 import MorpheusLoginRequired from "@/app/components/MorpheusLoginRequired";
 import Loading from "../loading";
+
+type DreamViewMode = "grid" | "list";
 
 /**
  * 年齢帯別ウェルカムコピー
@@ -133,6 +136,7 @@ export default function HomePage() {
   const [weeklyNewsDreams, setWeeklyNewsDreams] = useState<Dream[]>([]);
   const [weeklyNewsLoading, setWeeklyNewsLoading] = useState(true);
   const [weeklyNewsError, setWeeklyNewsError] = useState(false);
+  const [dreamViewMode, setDreamViewMode] = useState<DreamViewMode>("grid");
 
   const fetchDreams = useCallback(async () => {
     if (authStatus !== "authenticated") {
@@ -416,6 +420,43 @@ export default function HomePage() {
           />
         )}
 
+        {!loading && !errorMessage && dreams.length > 0 && (
+          <div className="hidden w-full items-center justify-end px-4 pt-2 md:flex">
+            <div
+              role="group"
+              aria-label="夢の表示形式"
+              className="flex overflow-hidden rounded-xl border border-border bg-card shadow-sm"
+            >
+              <button
+                type="button"
+                aria-label="グリッド表示"
+                aria-pressed={dreamViewMode === "grid"}
+                onClick={() => setDreamViewMode("grid")}
+                className={`grid min-h-11 min-w-11 place-items-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
+                  dreamViewMode === "grid"
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground hover:bg-muted"
+                }`}
+              >
+                <LayoutGrid className="h-4 w-4" aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                aria-label="リスト表示"
+                aria-pressed={dreamViewMode === "list"}
+                onClick={() => setDreamViewMode("list")}
+                className={`grid min-h-11 min-w-11 place-items-center border-l border-border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
+                  dreamViewMode === "list"
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground hover:bg-muted"
+                }`}
+              >
+                <List className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+        )}
+
         {/* ローディング中: スケルトンカードを表示 */}
         {loading && <DreamListSkeleton count={6} />}
         {/* エラーメッセージがある場合は表示 */}
@@ -426,6 +467,7 @@ export default function HomePage() {
         {!loading && !errorMessage && (
           <DreamList
             dreams={dreams}
+            viewMode={dreamViewMode}
             isSearchActive={isTextSearchActive}
             isProfileFilterActive={isProfileFilterActive}
             ageGroup={user?.age_group}


### PR DESCRIPTION
## 概要

`/home` の夢一覧に、デスクトップ向けのグリッド／リスト表示切替を追加します。

## 変更内容

- 現行のレスポンシブグリッドを既定表示として維持
- `md` 以上でグリッド／1列リストの切替ボタンを表示
- `DreamList` に `viewMode` propを追加
- `aria-label`、`aria-pressed`、44px操作領域、フォーカスリングを追加
- 設計仕様書と実装計画を追加

## 背景・理由

夢一覧は過去の方針どおり `/home` に一本化されています。新しい `/dreams` ページやAppShellは作らず、既存の検索・プロフィール絞り込み・カードUIを維持したまま、デスクトップ利用時の情報密度だけを選択できる最小変更にしています。

## 影響範囲

- 初期表示は従来と同じグリッドのため、既存利用者の表示は変わりません
- モバイルでは切替UIを表示せず、従来どおり実質1列です
- API、認証、検索条件、プロフィール絞り込み、決済、AI分析には変更ありません

## 検証

- `npx jest __tests__/components/DreamList.test.js __tests__/app/home/page.test.tsx` — 15件通過
- `npx jest` — 54スイート、403件通過
- `npm run build` — 成功
- `git diff --check` — 問題なし