### PR TITLE
feat: モバイル主要4画面のUI体験を改善

### DIFF
--- a/frontend/__tests__/app/home/page.test.tsx
+++ b/frontend/__tests__/app/home/page.test.tsx
@@ -104,6 +104,7 @@ jest.mock("@/app/components/DreamStatsWidget", () => ({
 jest.mock("@/app/components/DreamStreakBadge", () => ({
   __esModule: true,
   default: () => <div>DreamStreakBadge</div>,
+  calculateDreamStreak: () => ({ current: 0, longest: 0 }),
 }));
 jest.mock("@/app/components/MorpheusGuide", () => ({
   __esModule: true,

--- a/frontend/__tests__/components/BottomTabBar.test.tsx
+++ b/frontend/__tests__/components/BottomTabBar.test.tsx
@@ -43,9 +43,9 @@ describe("BottomTabBar", () => {
 
   it("ログイン時に4タブと記録FABを描画する", () => {
     render(<BottomTabBar />);
-    expect(screen.getByRole("link", { name: "おうち" })).toHaveAttribute("href", "/home");
+    expect(screen.getByRole("link", { name: "ホーム" })).toHaveAttribute("href", "/home");
+    expect(screen.getByRole("link", { name: "きもち" })).toHaveAttribute("href", "/insights");
     expect(screen.getByRole("link", { name: "もり" })).toHaveAttribute("href", "/forest");
-    expect(screen.getByRole("link", { name: "マイ夢" })).toHaveAttribute("href", "/my-dreams");
     expect(screen.getByRole("link", { name: "設定" })).toHaveAttribute("href", "/settings");
     expect(screen.getByRole("button", { name: "夢をきろくする" })).toBeInTheDocument();
   });
@@ -54,7 +54,7 @@ describe("BottomTabBar", () => {
     mockUsePathname.mockReturnValue("/forest");
     render(<BottomTabBar />);
     expect(screen.getByRole("link", { name: "もり" })).toHaveAttribute("aria-current", "page");
-    expect(screen.getByRole("link", { name: "おうち" })).not.toHaveAttribute("aria-current");
+    expect(screen.getByRole("link", { name: "ホーム" })).not.toHaveAttribute("aria-current");
   });
 
   it("ログイン時に body へ has-bottom-nav を付与する", () => {

--- a/frontend/__tests__/components/DreamEntryLauncher.test.tsx
+++ b/frontend/__tests__/components/DreamEntryLauncher.test.tsx
@@ -58,6 +58,7 @@ const makeAuthValue = (): AuthValue =>
 
 const startRecording = jest.fn(() => Promise.resolve());
 const stopRecording = jest.fn();
+const cancelRecording = jest.fn();
 let capturedOnBlobReady: ((blob: Blob) => Promise<void> | void) | null = null;
 
 const openSheet = () => {
@@ -76,6 +77,7 @@ beforeEach(() => {
       error: null,
       startRecording,
       stopRecording,
+      cancelRecording,
     } as ReturnType<typeof useVoiceRecorder>;
   });
 });
@@ -124,6 +126,18 @@ describe("DreamEntryLauncher", () => {
     // 2回目: 録音を始める
     fireEvent.click(screen.getByRole("button", { name: /はなしはじめる/ }));
     expect(startRecording).toHaveBeenCalledTimes(1);
+  });
+
+  it("voiceFirstでは起動ボタンの1回目で録音を始める", () => {
+    currentUser = { trial_user: false, premium: false };
+    render(
+      <DreamEntryLauncher buttonLabel="ゆめを のこす" voiceFirst />
+    );
+
+    openSheet();
+
+    expect(startRecording).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("dialog", { name: "音声で記録" })).toBeInTheDocument();
   });
 
   it("トライアルユーザーは録音完了後に残り0回のCTAへ切り替わる", async () => {

--- a/frontend/__tests__/hooks/useVoiceRecorder.test.tsx
+++ b/frontend/__tests__/hooks/useVoiceRecorder.test.tsx
@@ -115,4 +115,20 @@ describe("useVoiceRecorder", () => {
     expect(constructorOptions).toHaveLength(1);
     expect(result.current.isRecording).toBe(true);
   });
+
+  it("録音をキャンセルした場合は解析用Blobを渡さない", async () => {
+    const onBlobReady = jest.fn();
+    const { result } = renderHook(() => useVoiceRecorder({ onBlobReady }));
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    act(() => {
+      result.current.cancelRecording();
+    });
+
+    expect(result.current.isRecording).toBe(false);
+    expect(onBlobReady).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/app/components/BottomTabBar.tsx
+++ b/frontend/app/components/BottomTabBar.tsx
@@ -3,7 +3,13 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect } from "react";
-import { House, Trees, Moon, Settings, type LucideIcon } from "lucide-react";
+import {
+  ChartNoAxesColumnIncreasing,
+  House,
+  Settings,
+  Trees,
+  type LucideIcon,
+} from "lucide-react";
 
 import { useAuth } from "@/context/AuthContext";
 import DreamEntryLauncher from "./DreamEntryLauncher";
@@ -11,11 +17,11 @@ import DreamEntryLauncher from "./DreamEntryLauncher";
 type Tab = { href: string; label: string; icon: LucideIcon };
 
 const LEFT_TABS: Tab[] = [
-  { href: "/home", label: "おうち", icon: House },
-  { href: "/forest", label: "もり", icon: Trees },
+  { href: "/home", label: "ホーム", icon: House },
+  { href: "/insights", label: "きもち", icon: ChartNoAxesColumnIncreasing },
 ];
 const RIGHT_TABS: Tab[] = [
-  { href: "/my-dreams", label: "マイ夢", icon: Moon },
+  { href: "/forest", label: "もり", icon: Trees },
   { href: "/settings", label: "設定", icon: Settings },
 ];
 
@@ -74,8 +80,8 @@ export default function BottomTabBar(): React.JSX.Element | null {
         <div className="flex flex-1 items-start justify-center">
           <DreamEntryLauncher
             buttonLabel="夢をきろくする"
-            buttonClassName="-mt-6 h-14 w-14 justify-center rounded-full bg-primary text-primary-foreground shadow-lg [&>span]:sr-only"
-            showSparkles
+            buttonClassName="-mt-6 h-14 w-14 justify-center rounded-full bg-gradient-to-br from-sky-400 to-sky-600 text-white shadow-[0_10px_24px_rgba(14,165,233,0.42)] [&>span]:sr-only"
+            voiceFirst
           />
         </div>
 

--- a/frontend/app/components/DreamEntryLauncher.tsx
+++ b/frontend/app/components/DreamEntryLauncher.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Loader2, Mic, Pencil, Sparkles, Square, X } from "lucide-react";
 
 import type { AnalysisResult } from "@/app/types";
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 
 import { Button, type ButtonProps } from "./ui/button";
 import { TRIAL_AUDIO_LIMIT } from "./TrialBanner";
+import MorpheusAvatar from "./MorpheusAvatar";
 
 type DreamEntryLauncherProps = {
   buttonLabel: string;
@@ -22,6 +23,8 @@ type DreamEntryLauncherProps = {
   buttonClassName?: string;
   helperText?: string;
   showSparkles?: boolean;
+  /** 中央FABなど、1タップで録音を開始する導線 */
+  voiceFirst?: boolean;
 };
 
 export default function DreamEntryLauncher({
@@ -31,6 +34,7 @@ export default function DreamEntryLauncher({
   buttonClassName,
   helperText,
   showSparkles = false,
+  voiceFirst = false,
 }: DreamEntryLauncherProps) {
   const router = useRouter();
   const { user, login } = useAuth();
@@ -39,6 +43,7 @@ export default function DreamEntryLauncher({
   const [status, setStatus] = useState<
     "idle" | "confirming" | "preparing" | "recording"
   >("idle");
+  const [recordingSeconds, setRecordingSeconds] = useState(0);
 
   // お試しユーザー（課金前）だけ音声の残り回数を表示・制限する
   const isTrial = user?.trial_user === true && !user?.premium;
@@ -88,21 +93,27 @@ export default function DreamEntryLauncher({
     [handleAnalysisResult, login, user]
   );
 
-  const { isRecording, error, startRecording, stopRecording } =
+  const {
+    isRecording,
+    error,
+    startRecording,
+    stopRecording,
+    cancelRecording,
+  } =
     useVoiceRecorder({
       onBlobReady: handleBlobReady,
     });
 
   const closeSheet = useCallback(() => {
     if (isProcessing) return;
-    // 録音中にシートを閉じるとマイクがバックグラウンドで動き続けるため、先に停止する
+    // 閉じる操作では録音を破棄し、解析完了後の画面遷移と競合させない
     if (isRecording) {
-      stopRecording();
+      cancelRecording();
     }
     // 次に開いたときに「かくにん中」が残らないよう待機状態へ戻す
     setStatus("idle");
     setIsOpen(false);
-  }, [isProcessing, isRecording, stopRecording]);
+  }, [cancelRecording, isProcessing, isRecording]);
 
   useEffect(() => {
     if (isRecording) {
@@ -117,6 +128,20 @@ export default function DreamEntryLauncher({
       setStatus("idle");
     }
   }, [error]);
+
+  useEffect(() => {
+    if (!isRecording) {
+      setRecordingSeconds(0);
+      return undefined;
+    }
+
+    const startedAt = Date.now();
+    const timer = window.setInterval(() => {
+      setRecordingSeconds(Math.floor((Date.now() - startedAt) / 1000));
+    }, 250);
+
+    return () => window.clearInterval(timer);
+  }, [isRecording]);
 
   useEffect(() => {
     if (!isOpen) return undefined;
@@ -168,6 +193,27 @@ export default function DreamEntryLauncher({
     }
   };
 
+  const openLauncher = async () => {
+    setIsOpen(true);
+    if (!voiceFirst || audioLimitReached || isProcessing) return;
+
+    setStatus("preparing");
+    try {
+      await startRecording();
+    } catch {
+      setStatus("idle");
+    }
+  };
+
+  const formattedDuration = useMemo(() => {
+    const minutes = Math.floor(recordingSeconds / 60);
+    const seconds = recordingSeconds % 60;
+    return `${minutes}:${String(seconds).padStart(2, "0")}`;
+  }, [recordingSeconds]);
+
+  const showVoiceStage =
+    isOpen && (status === "preparing" || status === "recording" || isProcessing);
+
   return (
     <>
       <div className="w-full">
@@ -175,7 +221,7 @@ export default function DreamEntryLauncher({
           type="button"
           variant={buttonVariant}
           size={buttonSize}
-          onClick={() => setIsOpen(true)}
+          onClick={openLauncher}
           className={cn("gap-2 rounded-full", buttonClassName)}
         >
           {showSparkles ? <Sparkles className="h-5 w-5" /> : null}
@@ -186,7 +232,106 @@ export default function DreamEntryLauncher({
         ) : null}
       </div>
 
-      {isOpen ? (
+      {showVoiceStage ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="voice-stage-title"
+          className="fixed inset-0 z-[110] overflow-y-auto bg-[linear-gradient(180deg,#312e81_0%,#1e3a8a_55%,#075985_100%)] text-white"
+        >
+          <div className="relative mx-auto flex min-h-[100dvh] w-full max-w-xl flex-col items-center px-6 pb-[max(2.5rem,env(safe-area-inset-bottom))] pt-[max(1.25rem,env(safe-area-inset-top))] text-center">
+            <button
+              type="button"
+              onClick={closeSheet}
+              disabled={isProcessing}
+              aria-label="音声記録を閉じる"
+              className="absolute left-5 top-[max(1.25rem,env(safe-area-inset-top))] grid min-h-11 min-w-11 place-items-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white disabled:opacity-50"
+            >
+              <X className="h-5 w-5" />
+            </button>
+
+            <h2 id="voice-stage-title" className="mt-3 text-lg font-bold">
+              音声で記録
+            </h2>
+
+            <div className="mt-12">
+              <div className="relative">
+                <span className="absolute -inset-6 rounded-full bg-sky-300/20 blur-2xl" />
+                <MorpheusAvatar
+                  variant="voice"
+                  size={112}
+                  priority
+                  className="relative border-2 border-white/30 shadow-2xl ring-4 ring-white/10"
+                />
+              </div>
+              <p className="mt-5 text-sm font-medium text-sky-100">
+                {isProcessing
+                  ? "モルペウスが 夢をまとめているよ…"
+                  : status === "preparing"
+                    ? "マイクをじゅんびしているよ…"
+                    : "モルペウスが きいているよ…"}
+              </p>
+            </div>
+
+            <div className="mt-8 w-full rounded-3xl border border-white/20 bg-white/10 px-5 py-5 text-left shadow-xl backdrop-blur-sm">
+              <p className="text-[11px] font-bold uppercase tracking-[0.18em] text-sky-200">
+                {isProcessing ? "文字起こし・分析中" : "録音中"}
+              </p>
+              <p className="mt-2 text-sm leading-relaxed text-white/90">
+                {isProcessing
+                  ? "録音した声を文字にして、夢の内容と気持ちを整理しています。"
+                  : "思い出せるところから、そのまま話してね。文字起こしは録音を止めたあとに始まります。"}
+              </p>
+            </div>
+
+            <div
+              aria-label={isProcessing ? "音声を解析中" : "音声を録音中"}
+              className="mt-8 flex h-20 items-center justify-center gap-1.5"
+            >
+              {Array.from({ length: 18 }, (_, index) => (
+                <span
+                  key={index}
+                  className={`w-1.5 rounded-full bg-sky-300 ${
+                    isProcessing ? "animate-pulse" : "motion-safe:animate-[pulse_1s_ease-in-out_infinite]"
+                  }`}
+                  style={{
+                    height: `${20 + ((index * 17) % 46)}px`,
+                    animationDelay: `${index * 55}ms`,
+                  }}
+                />
+              ))}
+            </div>
+
+            <p className="mt-1 font-mono text-lg font-bold tabular-nums">
+              {isProcessing ? "解析中" : formattedDuration}
+            </p>
+
+            <button
+              type="button"
+              onClick={handleVoiceToggle}
+              disabled={isProcessing || status === "preparing"}
+              aria-label="録音を停止する"
+              className="mt-7 grid h-20 w-20 place-items-center rounded-full border-[7px] border-white bg-white shadow-[0_0_0_7px_rgba(255,255,255,0.18),0_16px_35px_rgba(0,0,0,0.28)] transition-transform active:scale-95 disabled:opacity-70"
+            >
+              {isProcessing || status === "preparing" ? (
+                <Loader2 className="h-8 w-8 animate-spin text-sky-600" />
+              ) : (
+                <Square className="h-8 w-8 fill-red-500 text-red-500" />
+              )}
+            </button>
+
+            {!isProcessing ? (
+              <Link
+                href="/dream/new"
+                onClick={closeSheet}
+                className="mt-auto min-h-11 pt-8 text-sm font-semibold text-sky-100 underline decoration-sky-200/50 underline-offset-4"
+              >
+                テキストで入力する
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      ) : isOpen ? (
         <div
           className="fixed inset-0 z-[100] bg-slate-950/45 backdrop-blur-sm"
           onClick={closeSheet}

--- a/frontend/app/components/DreamStreakBadge.tsx
+++ b/frontend/app/components/DreamStreakBadge.tsx
@@ -9,7 +9,10 @@ interface DreamStreakBadgeProps {
 }
 
 /** 連続記録日数を計算 */
-function calcStreak(dreams: Dream[]): { current: number; longest: number } {
+export function calculateDreamStreak(dreams: Dream[]): {
+  current: number;
+  longest: number;
+} {
   if (dreams.length === 0) return { current: 0, longest: 0 };
 
   // ユニークな日付を降順に並べる
@@ -75,7 +78,7 @@ function getMorpheusVariant(current: number): MorpheusImageVariant {
 export default function DreamStreakBadge({ dreams }: DreamStreakBadgeProps) {
   if (dreams.length === 0) return null;
 
-  const { current, longest } = calcStreak(dreams);
+  const { current, longest } = calculateDreamStreak(dreams);
   const moonProgress = Math.min(current, 30) / 30;
   const morpheusVariant = getMorpheusVariant(current);
 

--- a/frontend/app/dream/[id]/page.tsx
+++ b/frontend/app/dream/[id]/page.tsx
@@ -16,6 +16,7 @@ import { useAuth } from "../../../context/AuthContext";
 import { AgeGroup } from "@/app/types";
 import { MorpheusGuideDetail } from "@/app/components/MorpheusGuide";
 import StreamingAnalysis from "@/app/components/StreamingAnalysis";
+import { ChevronLeft, Sparkles } from "lucide-react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -262,7 +263,42 @@ export default function DreamDetailPage({
     dream.analysis_json?.analysis || dream.analysis_json?.text || "";
 
   return (
-    <div className="min-h-screen py-8 px-4 md:px-12 max-w-3xl mx-auto text-foreground">
+    <div className="min-h-screen px-4 pb-8 pt-0 text-foreground md:mx-auto md:max-w-3xl md:px-12 md:py-8">
+      <section
+        aria-label="夢のイメージ"
+        className="relative -mx-4 mb-6 h-60 overflow-hidden bg-gradient-to-br from-blue-900 via-violet-700 to-fuchsia-600 md:hidden"
+        style={
+          generatedImageUrl
+            ? {
+                backgroundImage: `linear-gradient(180deg, rgba(15,23,42,0.08), rgba(15,23,42,0.38)), url(${generatedImageUrl})`,
+                backgroundPosition: "center",
+                backgroundSize: "cover",
+              }
+            : undefined
+        }
+      >
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 opacity-80"
+          style={{
+            backgroundImage:
+              "radial-gradient(2px 2px at 18% 28%, white, transparent), radial-gradient(2px 2px at 74% 20%, #fde68a, transparent), radial-gradient(1.5px 1.5px at 48% 58%, white, transparent)",
+          }}
+        />
+        <button
+          type="button"
+          onClick={() => router.back()}
+          aria-label="前の画面に戻る"
+          className="absolute left-4 top-4 z-10 grid min-h-11 min-w-11 place-items-center rounded-full bg-slate-950/30 text-white backdrop-blur-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        >
+          <ChevronLeft className="h-6 w-6" />
+        </button>
+        <div className="absolute bottom-4 left-4 z-10 inline-flex items-center gap-1.5 rounded-full bg-slate-950/35 px-3 py-1.5 text-xs font-semibold text-white backdrop-blur-sm">
+          <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+          <span>{generatedImageUrl ? "AIが描いた夢" : "夢のイメージ"}</span>
+        </div>
+      </section>
+
       {/* ヘッダー：日付 */}
       <p className="text-sm text-muted-foreground mb-2" suppressHydrationWarning>
         {formatDate(dream.created_at)}

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -12,7 +12,9 @@ import { getJSTYearMonthKey, getJSTDateStr } from "@/lib/date";
 import DreamList from "@/app/components/DreamList";
 import { DreamListSkeleton } from "@/app/components/DreamCardSkeleton";
 import DreamStatsWidget from "@/app/components/DreamStatsWidget";
-import DreamStreakBadge from "@/app/components/DreamStreakBadge";
+import DreamStreakBadge, {
+  calculateDreamStreak,
+} from "@/app/components/DreamStreakBadge";
 import SearchBar from "@/app/components/SearchBar";
 import ProfileFilterChips from "@/app/components/ProfileFilterChips";
 import DreamEntryLauncher from "@/app/components/DreamEntryLauncher";
@@ -352,6 +354,14 @@ export default function HomePage() {
     dreams.length > 0 &&
     dreams.length < 5;
   const homeToneStyle = getToneClassByHour(new Date().getHours());
+  const currentStreak = calculateDreamStreak(dreams).current;
+  const todayLabel = new Date().toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+    timeZone: "Asia/Tokyo",
+  });
 
   return (
     <div
@@ -360,6 +370,28 @@ export default function HomePage() {
     >
       {/* メインセクション: ユーザー名の下に夢リストを表示 */}
       <section className="w-full lg:w-2/3 flex flex-col items-center px-3 md:px-6">
+        <div className="mb-4 flex w-full items-center justify-between gap-3 md:hidden">
+          <div className="min-w-0">
+            <p
+              className="text-xs font-medium text-muted-foreground"
+              suppressHydrationWarning
+            >
+              {todayLabel}
+            </p>
+            <h1 className="mt-1 truncate text-xl font-bold text-foreground">
+              おはよう、{user?.username ?? "あなた"}さん
+            </h1>
+          </div>
+          {currentStreak > 0 ? (
+            <div
+              aria-label={`${currentStreak}日連続記録中`}
+              className="inline-flex min-h-11 shrink-0 items-center gap-1.5 rounded-full border border-orange-200 bg-card px-3 text-sm font-bold text-orange-600 shadow-sm"
+            >
+              <span aria-hidden="true">🔥</span>
+              <span>{currentStreak}</span>
+            </div>
+          ) : null}
+        </div>
         {/* お試しユーザー向けバナー（残回数・本登録CTA） */}
         {user?.trial_user && (
           <TrialBanner
@@ -374,8 +406,8 @@ export default function HomePage() {
         <MorpheusHero
           expression="cheerful"
           variant="home"
-          title={user ? `${user.username}さん、おはよう！` : "おはよう！"}
-          message={`${copy.heading} ${copy.sub}`}
+          title={copy.heading}
+          message={copy.sub}
           className="w-full mb-4"
           action={
             <div className="max-w-md">
@@ -385,6 +417,7 @@ export default function HomePage() {
                 buttonClassName="min-h-14 w-full text-base font-bold shadow-lg shadow-primary/15"
                 helperText={copy.helper}
                 showSparkles
+                voiceFirst
               />
             </div>
           }
@@ -457,6 +490,21 @@ export default function HomePage() {
           </div>
         )}
 
+        {!loading && !errorMessage && dreams.length > 0 ? (
+          <div className="mt-5 flex w-full items-center justify-between px-4 md:hidden">
+            <h2 className="text-base font-bold text-foreground">
+              さいきんの ゆめ
+            </h2>
+            <button
+              type="button"
+              onClick={() => setIsSearchPanelOpen(true)}
+              className="min-h-11 rounded-xl px-2 text-sm font-semibold text-sky-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              夢をさがす
+            </button>
+          </div>
+        ) : null}
+
         {/* ローディング中: スケルトンカードを表示 */}
         {loading && <DreamListSkeleton count={6} />}
         {/* エラーメッセージがある場合は表示 */}
@@ -477,7 +525,7 @@ export default function HomePage() {
       </section>
 
       {/* サイドバー: 統計・ストリーク・月ごとリンク */}
-      <aside className="w-full lg:w-1/3 flex flex-col items-center px-3 md:px-6 mt-4 lg:mt-0">
+      <aside className="hidden w-full lg:flex lg:w-1/3 flex-col items-center px-3 md:px-6 mt-4 lg:mt-0">
         {/* 今日の夢クエスト */}
         {!loading && !errorMessage && <DreamAdventurePanel dreams={dreams} />}
 

--- a/frontend/app/insights/page.tsx
+++ b/frontend/app/insights/page.tsx
@@ -96,16 +96,24 @@ export default function InsightsPage() {
   }
 
   return (
-    <div className="mx-auto max-w-6xl px-1 py-6 md:py-8">
-      <header className="mb-6">
-        <p className="text-[12.5px] font-medium text-muted-foreground">
-          {ym.replace("-", "年")}月のふりかえり
-        </p>
-        <h1 className="text-2xl font-bold text-foreground">きもちインサイト</h1>
+    <div className="mx-auto max-w-6xl px-1 py-4 md:py-8">
+      <header className="mb-5 flex items-end justify-between gap-4 md:mb-6">
+        <div>
+          <p className="hidden text-[12.5px] font-medium text-muted-foreground md:block">
+            {ym.replace("-", "年")}月のふりかえり
+          </p>
+          <h1 className="text-2xl font-bold text-foreground">きもちインサイト</h1>
+        </div>
+        <span
+          aria-label={`${Number(ym.split("-")[1])}月の記録`}
+          className="inline-flex min-h-11 items-center rounded-full border border-border bg-card px-4 text-sm font-semibold text-muted-foreground shadow-sm md:hidden"
+        >
+          ‹ {Number(ym.split("-")[1])}月 ›
+        </span>
       </header>
 
       {/* KPI */}
-      <div className="mb-4 grid grid-cols-2 gap-3.5 lg:grid-cols-4">
+      <div className="mb-4 hidden grid-cols-2 gap-3.5 md:grid lg:grid-cols-4">
         <KpiCard label="今月の記録" value={String(total)} unit="こ" tone="text-foreground" />
         <KpiCard label="連続記録" value={String(streak)} unit="日" tone="text-orange-600 dark:text-orange-400" />
         <KpiCard label="前向きな夢" value={String(positiveRate)} unit="%" tone="text-emerald-600 dark:text-emerald-400" />
@@ -116,45 +124,28 @@ export default function InsightsPage() {
       <div className="grid gap-4 lg:grid-cols-[1.5fr_1fr]">
         <MoodCalendar dreams={dreams} month={ym} />
 
-        <section className="relative overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-indigo-950 to-slate-900 p-5">
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-0 opacity-75"
-            style={{
-              backgroundImage:
-                "radial-gradient(2px 2px at 20% 24%, #fde68a, transparent), radial-gradient(1.6px 1.6px at 78% 30%, #fff, transparent), radial-gradient(1.6px 1.6px at 50% 60%, #c7d2fe, transparent)",
-            }}
-          />
-          <div className="relative mb-3 flex items-center gap-3">
-            <div className="motion-safe:animate-morpheus-float">
-              <MorpheusAvatar variant="reward" size={46} className="ring-2 ring-white/20" />
-            </div>
-            <div>
-              <h3 className="font-bold text-white">モルペウスの 月まとめ</h3>
-              <span className="mt-0.5 inline-block rounded-full bg-violet-400/20 px-2 py-0.5 text-[10px] font-semibold text-violet-200">
-                {user?.premium ? "プレミアム" : "プレビュー"}
-              </span>
-            </div>
-          </div>
-          <p className="relative text-[13px] leading-loose text-slate-200">
-            {total > 0 ? (
-              <>
-                今月は <b className="text-sky-300">前向きな夢が{positiveRate}%</b>。 とくに「{topEmotion}」の気持ちが多く、心のうごきが見えてきたよ。
-              </>
-            ) : (
-              <>今月はまだ記録がないみたい。ひとつ書くと、ここに今月のまとめが出るよ。</>
-            )}
-          </p>
-        </section>
+        <InsightSummary
+          total={total}
+          positiveRate={positiveRate}
+          topEmotion={topEmotion}
+          premium={user?.premium === true}
+          className="hidden lg:block"
+        />
       </div>
 
       {/* TOP5 + トレンド */}
       <div className="mt-4 grid gap-4 lg:grid-cols-2">
         <section className="rounded-2xl border border-border bg-card p-5 shadow-sm">
-          <h3 className="mb-3.5 font-bold text-card-foreground">きもち TOP5</h3>
+          <h3 className="mb-3.5 font-bold text-card-foreground">
+            <span className="md:hidden">今月のきもち TOP3</span>
+            <span className="hidden md:inline">きもち TOP5</span>
+          </h3>
           <div className="flex flex-col gap-3">
-            {emotionCounts.slice(0, 5).map(([label, n]) => (
-              <div key={label} className="flex items-center gap-2.5">
+            {emotionCounts.slice(0, 5).map(([label, n], index) => (
+              <div
+                key={label}
+                className={`items-center gap-2.5 ${index >= 3 ? "hidden md:flex" : "flex"}`}
+              >
                 <span className="w-24 shrink-0 truncate text-xs font-semibold text-muted-foreground">
                   {label}
                 </span>
@@ -177,9 +168,85 @@ export default function InsightsPage() {
           </div>
         </section>
 
+        <InsightSummary
+          total={total}
+          positiveRate={positiveRate}
+          topEmotion={topEmotion}
+          premium={user?.premium === true}
+          className="lg:hidden"
+          mobile
+        />
+
         <MonthlyTrend dreams={dreams} />
       </div>
     </div>
+  );
+}
+
+function InsightSummary({
+  total,
+  positiveRate,
+  topEmotion,
+  premium,
+  className,
+  mobile = false,
+}: {
+  total: number;
+  positiveRate: number;
+  topEmotion: string;
+  premium: boolean;
+  className?: string;
+  mobile?: boolean;
+}) {
+  return (
+    <section
+      className={`relative overflow-hidden rounded-2xl border p-5 ${
+        mobile
+          ? "border-sky-100 bg-gradient-to-br from-sky-50 to-white text-slate-700 shadow-sm dark:border-sky-900/50 dark:from-slate-900 dark:to-slate-950 dark:text-slate-200"
+          : "border-white/10 bg-gradient-to-br from-indigo-950 to-slate-900 text-slate-200"
+      } ${className ?? ""}`}
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-75"
+        style={{
+          backgroundImage:
+            "radial-gradient(2px 2px at 20% 24%, #fde68a, transparent), radial-gradient(1.6px 1.6px at 78% 30%, #fff, transparent), radial-gradient(1.6px 1.6px at 50% 60%, #c7d2fe, transparent)",
+        }}
+      />
+      <div className="relative mb-3 flex items-center gap-3">
+        <div className="motion-safe:animate-morpheus-float">
+          <MorpheusAvatar
+            variant="reward"
+            size={mobile ? 58 : 46}
+            className="ring-2 ring-white/30"
+          />
+        </div>
+        <div>
+          <h3 className={`font-bold ${mobile ? "text-slate-800 dark:text-white" : "text-white"}`}>
+            モルペウスの 月まとめ
+          </h3>
+          <span
+            className={`mt-0.5 inline-block rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+              mobile
+                ? "bg-sky-100 text-sky-700 dark:bg-sky-400/20 dark:text-sky-200"
+                : "bg-violet-400/20 text-violet-200"
+            }`}
+          >
+            {premium ? "プレミアム" : "プレビュー"}
+          </span>
+        </div>
+      </div>
+      <p className="relative text-[13px] leading-loose">
+        {total > 0 ? (
+          <>
+            今月は <b className="text-sky-500">前向きな夢が{positiveRate}%</b>。とくに「{topEmotion}」の気持ちが多く、心のうごきが見えてきたよ。
+          </>
+        ) : (
+          <>今月はまだ記録がないみたい。ひとつ書くと、ここに今月のまとめが出るよ。</>
+        )}
+      </p>
+    </section>
   );
 }
 
@@ -225,7 +292,7 @@ function MonthlyTrend({ dreams }: { dreams: Dream[] }) {
   const rising = bars.length >= 2 && bars[bars.length - 1].n >= bars[0].n;
 
   return (
-    <section className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+    <section className="hidden rounded-2xl border border-border bg-card p-5 shadow-sm md:block">
       <div className="mb-3.5 flex items-center justify-between">
         <h3 className="font-bold text-card-foreground">記録の流れ（半年）</h3>
         {rising && <span className="text-[11px] font-semibold text-emerald-600">▲ 増加中</span>}

--- a/frontend/hooks/useVoiceRecorder.ts
+++ b/frontend/hooks/useVoiceRecorder.ts
@@ -51,6 +51,7 @@ const useVoiceRecorder = ({ onBlobReady }: UseVoiceRecorderOptions) => {
   const chunksRef = useRef<BlobPart[]>([]);
   const startedAtRef = useRef<number | null>(null);
   const mimeTypeRef = useRef<string>("");
+  const discardRecordingRef = useRef(false);
 
   // ストリームと MediaRecorder の後片付け
   const cleanupStream = useCallback(() => {
@@ -61,6 +62,7 @@ const useVoiceRecorder = ({ onBlobReady }: UseVoiceRecorderOptions) => {
     mediaRecorderRef.current = null;
     chunksRef.current = [];
     startedAtRef.current = null;
+    discardRecordingRef.current = false;
   }, []);
 
   // 先に権限を取得し、許可後に可能なら「モニター系の無音マイク」を避けて選択する
@@ -148,6 +150,7 @@ const useVoiceRecorder = ({ onBlobReady }: UseVoiceRecorderOptions) => {
       const recorder = createAudioRecorder(stream, mimeTypeRef.current);
       mediaRecorderRef.current = recorder;
       chunksRef.current = [];
+      discardRecordingRef.current = false;
 
       recorder.ondataavailable = (e: BlobEvent) => {
         if (e.data && e.data.size > 0) {
@@ -156,6 +159,12 @@ const useVoiceRecorder = ({ onBlobReady }: UseVoiceRecorderOptions) => {
       };
 
       recorder.onstop = () => {
+        if (discardRecordingRef.current) {
+          cleanupStream();
+          setIsRecording(false);
+          return;
+        }
+
         const duration =
           startedAtRef.current != null
             ? performance.now() - startedAtRef.current
@@ -215,13 +224,31 @@ const useVoiceRecorder = ({ onBlobReady }: UseVoiceRecorderOptions) => {
     }
   }, []);
 
+  const cancelRecording = useCallback(() => {
+    const recorder = mediaRecorderRef.current;
+    if (recorder && recorder.state === "recording") {
+      discardRecordingRef.current = true;
+      recorder.stop();
+      return;
+    }
+
+    cleanupStream();
+    setIsRecording(false);
+  }, [cleanupStream]);
+
   useEffect(() => {
     return () => {
       cleanupStream();
     };
   }, [cleanupStream]);
 
-  return { isRecording, error, startRecording, stopRecording };
+  return {
+    isRecording,
+    error,
+    startRecording,
+    stopRecording,
+    cancelRecording,
+  };
 };
 
 export default useVoiceRecorder;


### PR DESCRIPTION
## 概要
モバイルで頻繁に使うホーム、音声記録、夢詳細、きもちインサイトの体験をまとめて改善します。

## 変更内容
- ホームに日付・連続記録・最近の夢導線を追加
- ボトムナビ中央から音声記録を直接開始できる全画面UIを追加
- 録音キャンセル時は音声を解析せず安全に破棄
- 夢詳細にモバイル向けイメージヒーローを追加
- きもちインサイトの情報順序と密度をモバイル向けに調整
- 関連コンポーネント／フックの回帰テストを追加

## 影響範囲
11ファイルのみ。設定画面、夢作成デスクトップレイアウト、認証、API、決済には変更ありません。

## 検証
- 対象4スイート — 20件通過
- `npx jest --runInBand` — 54スイート、407件通過
- `npm run build` — 成功
- `git diff --check origin/main...HEAD` — 問題なし