### PR TITLE
feat: login/registerをデスクトップ2段組レイアウトに変更

### DIFF
--- a/frontend/__tests__/app/login/page.test.tsx
+++ b/frontend/__tests__/app/login/page.test.tsx
@@ -49,6 +49,21 @@ describe("Login page cold-start retry UX", () => {
     jest.clearAllMocks();
   });
 
+  it("デスクトップ用のAuthVisualPanel(login)をあわせて描画する", () => {
+    render(<Login />);
+    // MorpheusGuideLogin（lg未満用）と冒頭の文言が似ているため、
+    // AuthVisualPanel側にしか出現しない一節で存在確認する
+    expect(
+      screen.getByText(/今日はどんな夢を見たのか、聞かせてくれるかな/)
+    ).toBeInTheDocument();
+  });
+
+  it("MorpheusGuideLoginは375px相当の狭い画面で隠すクラスを持つ（hidden sm:block lg:hidden）", () => {
+    render(<Login />);
+    const guide = screen.getByTestId("morpheus-guide");
+    expect(guide.parentElement).toHaveClass("hidden", "sm:block", "lg:hidden");
+  });
+
   it("shows the warming-up notice and button label while clientLogin retries", async () => {
     // clientLogin がコールドスタートのリトライに入った状態を再現する。
     // onColdStartRetry を呼んだあと未解決のままにして、表示を観測できるようにする。

--- a/frontend/__tests__/app/register/page.test.tsx
+++ b/frontend/__tests__/app/register/page.test.tsx
@@ -75,6 +75,14 @@ beforeEach(() => {
 });
 
 describe("RegisterPage トライアル昇格の分岐", () => {
+  it("デスクトップ用のAuthVisualPanel(register)をあわせて描画する", () => {
+    mockedUseAuth.mockReturnValue(makeAuth({}));
+    render(<RegisterPage />);
+    // MorpheusSmallの既存メッセージと冒頭が似ているため、
+    // AuthVisualPanel側にしか出現しない一節で存在確認する
+    expect(screen.getByText(/ぼくはモルペウス/)).toBeInTheDocument();
+  });
+
   it("認証確認中は submit ボタンが disabled になる", () => {
     mockedUseAuth.mockReturnValue(
       makeAuth({

--- a/frontend/__tests__/components/AuthVisualPanel.test.tsx
+++ b/frontend/__tests__/components/AuthVisualPanel.test.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import AuthVisualPanel from "@/app/components/AuthVisualPanel";
+
+jest.mock("@/app/components/MorpheusImage", () => ({
+  __esModule: true,
+  default: ({ variant }: { variant: string }) => (
+    <div data-testid="morpheus-image" data-variant={variant} />
+  ),
+}));
+
+describe("AuthVisualPanel", () => {
+  it("login variant では専用メッセージを表示する", () => {
+    render(<AuthVisualPanel variant="login" />);
+    expect(
+      screen.getByText(/また来てくれたんだね/)
+    ).toBeInTheDocument();
+  });
+
+  it("register variant では専用メッセージを表示する", () => {
+    render(<AuthVisualPanel variant="register" />);
+    expect(screen.getByText(/はじめまして/)).toBeInTheDocument();
+  });
+
+  it("lg未満では非表示になるクラスを持つ（hidden lg:flex）", () => {
+    const { container } = render(<AuthVisualPanel variant="login" />);
+    const root = container.firstChild as HTMLElement;
+    expect(root.className).toEqual(expect.stringContaining("hidden"));
+    expect(root.className).toEqual(expect.stringContaining("lg:flex"));
+  });
+
+  it("純粋装飾のため aria-hidden を持つ", () => {
+    const { container } = render(<AuthVisualPanel variant="login" />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("未検証の利用者数統計やGoogleログインボタンを含まない", () => {
+    render(<AuthVisualPanel variant="login" />);
+    expect(screen.queryByText(/50,000/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Google/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/app/components/AuthVisualPanel.tsx
+++ b/frontend/app/components/AuthVisualPanel.tsx
@@ -1,0 +1,42 @@
+import MorpheusImage from "@/app/components/MorpheusImage";
+
+type AuthVisualPanelProps = {
+  variant: "login" | "register";
+};
+
+const COPY: Record<AuthVisualPanelProps["variant"], string> = {
+  login: "また来てくれたんだね。今日はどんな夢を見たのか、聞かせてくれるかな？",
+  register: "はじめまして。ぼくはモルペウス。きみの夢を一緒に記録していくよ。",
+};
+
+/**
+ * ログイン/登録ページの右側（lg+のみ）に表示する夜空＋モルペウスの装飾パネル。
+ * 認証ロジックには一切関与しない純粋な見た目のコンポーネント。
+ */
+export default function AuthVisualPanel({ variant }: AuthVisualPanelProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className="relative hidden flex-1 flex-col items-center justify-center overflow-hidden bg-gradient-to-br from-indigo-950 via-slate-900 to-sky-950 px-10 lg:flex"
+    >
+      <div
+        className="pointer-events-none absolute inset-0 opacity-75"
+        style={{
+          backgroundImage:
+            "radial-gradient(2px 2px at 16% 20%, #fde68a, transparent), radial-gradient(1.6px 1.6px at 80% 26%, #fff, transparent), radial-gradient(1.6px 1.6px at 60% 14%, #c7d2fe, transparent), radial-gradient(2px 2px at 30% 68%, #fff, transparent)",
+        }}
+      />
+      <div className="relative mb-6 h-52 w-52 animate-morpheus-float">
+        <div className="absolute inset-1 rounded-full bg-amber-300/25 blur-3xl animate-moon-pulse" />
+        <MorpheusImage
+          variant="login"
+          size={208}
+          className="relative drop-shadow-[0_20px_40px_rgba(99,102,241,0.5)]"
+        />
+      </div>
+      <p className="relative max-w-xs rounded-2xl bg-white/92 px-5 py-4 text-center text-sm font-semibold leading-relaxed text-slate-800">
+        {COPY[variant]}
+      </p>
+    </div>
+  );
+}

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
 import MorpheusHero from "@/app/components/MorpheusHero";
 import { MorpheusGuideLogin } from "@/app/components/MorpheusGuide";
+import AuthVisualPanel from "@/app/components/AuthVisualPanel";
 
 const hiddenEmailStyle = {
   WebkitTextSecurity: "disc",
@@ -84,7 +85,8 @@ export default function Login() {
   };
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-background text-foreground px-4 sm:px-6 lg:px-8 py-8">
+    <div className="flex min-h-screen bg-background text-foreground">
+      <div className="flex flex-1 flex-col items-center justify-center px-4 py-8 sm:px-6 lg:px-8">
       <div className="w-full max-w-md">
         <MorpheusHero
           title="おかえり！"
@@ -206,7 +208,11 @@ export default function Login() {
         )}
       </form>
       </div>
-      <MorpheusGuideLogin />
+      <div className="hidden sm:block lg:hidden">
+        <MorpheusGuideLogin />
+      </div>
+      </div>
+      <AuthVisualPanel variant="login" />
     </div>
   );
 }

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { clientRegister, convertTrial } from "@/lib/apiClient";
 import { useAuth } from "@/context/AuthContext";
 import MorpheusSmall from "@/app/components/MorpheusSmall";
+import AuthVisualPanel from "@/app/components/AuthVisualPanel";
 
 const hiddenEmailStyle = {
   WebkitTextSecurity: "disc",
@@ -126,7 +127,8 @@ export default function Register() {
   };
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-background text-foreground px-4 sm:px-6 lg:px-8">
+    <div className="flex min-h-screen bg-background text-foreground">
+      <div className="flex flex-1 flex-col items-center justify-center px-4 py-8 sm:px-6 lg:px-8">
       <div className="w-full max-w-md">
         <MorpheusSmall
           message="はじめまして！いっしょにゆめを記録しよう"
@@ -371,6 +373,8 @@ export default function Register() {
         </div>
       </form>
       </div>
+      </div>
+      <AuthVisualPanel variant="register" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `AuthVisualPanel`（lg+のみ表示の夜空＋モルペウス装飾パネル）を新設し、`/login`・`/register`の外側だけを「フォーム＋装飾パネル」の2段組に再構成
- `MorpheusGuideLogin`（ログインページ固定表示の吹き出し）は375pxなど狭いモバイルでは非表示にし、フォームへの重なりを解消。sm(≥640px)〜lg未満のタブレット幅では従来どおり表示、lg+（AuthVisualPanelが出る幅）では引き続き非表示
- **認証ロジック変更なし**：`handleSubmit`・API呼び出し・エラー処理・リダイレクト・コールドスタート再試行・メールマスキング・パスワード強度／確認欄／規約同意・trial変換分岐は一切変更していません
- **未実装機能の追加なし**：Googleログインボタンやダミー統計等、外部デザインハンドオフ案にあった未実装/プレースホルダー要素は採用していません
- **375pxの重なり解消**：`MorpheusGuideLogin`のラッパーを`lg:hidden` → `hidden sm:block lg:hidden`に変更し、狭いモバイルで入力欄・送信ボタン・リンクに重ならないことを確認

## Test plan
- [x] 対象テスト: `__tests__/app/login/page.test.tsx` `__tests__/app/register/page.test.tsx` `__tests__/components/AuthVisualPanel.test.tsx` 全pass
- [x] Jest全体: 55 suites / 415 tests all pass
- [x] E2E（`--workers=1`）: `registration-flow.spec.ts` `password-reset-flow.spec.ts` 21/21 pass
- [x] `tsc --noEmit`: 新規エラーなし（既存の`__tests__/**`広域エラーはmainと同一で無関係と確認済み）
- [x] `next build`: 成功
- [x] `git diff --check`: クリーン
- [x] ブラウザ確認: 375px（非表示・重なりなし）／768px（sm、従来どおり表示）／1440px（lg+、AuthVisualPanel表示・MorpheusGuideLogin非表示）／ダークモード／コールドスタート再試行表示 いずれも問題なし
