### PR TITLE
test: Trial P3の正しい導線を守る回帰テストを追加

### DIFF
--- a/backend/spec/requests/trial_conversion_flow_spec.rb
+++ b/backend/spec/requests/trial_conversion_flow_spec.rb
@@ -1,0 +1,145 @@
+require 'rails_helper'
+
+# 7月「守りのMust」ランブック ① Trial P3 の回帰テスト。
+# 参照: docs/2026-07-guard-must-runbook.md
+#
+# 【守りたい不変条件】
+# trialユーザーが通常の夢作成API（= /home の「夢を記録する」導線）でDB保存した夢は、
+# convert_trial による本登録昇格のあとも、同じ夢として残り続ける。
+#
+# 【なぜ残るのか】
+# convert_trial は新しい User を作らない。既存の User レコードの
+# email / username / password を書き換えて trial_user を false にするだけ。
+# dreams.user_id は最初から最後まで同じ User を指しているので、
+# 「持ち主のプロフィールが書き換わった」だけで夢の所属は変わらない。
+#
+# 【このテストが検証対象にしないもの】
+# /trial 画面の「記録だけする」と AI プレビューは React の画面内 state だけで、
+# DBには保存されない。あれを引き継ぎ確認に使うと必ず失敗するが、それは
+# P3 の不具合ではなく検証手順の誤り。よってここでは扱わない。
+#
+# 【既存テストとの違い】
+# auth_spec.rb にも「昇格しても夢が引き継がれる」テストがあるが、あちらは
+# factory で直接作った夢（create(:dream, user: trial_user)）を使う。
+# このテストは trial_login → POST /dreams → GET /dreams という実APIの
+# 通し導線で確認し、「画面から実際に操作したときに壊れていないか」を守る。
+#
+# 【Cookieの扱い】
+# request spec の統合セッションはブラウザと同じようにCookieを保持し、
+# 次のリクエストへ自動で送ってくれる。ここではその仕組みをそのまま使い、
+# 実際の画面遷移に近い形で検証する（手動でCookieヘッダを組み立てない）。
+RSpec.describe 'Trial P3: trialユーザーの夢が本登録後も残る導線', type: :request do
+  let(:host) { { 'HOST' => 'backend' } }
+
+  let(:trial_params) do
+    {
+      trial_user: {
+        email: 'p3_trial@example.com',
+        username: 'p3_trial',
+        password: 'trial_password_123',
+        password_confirmation: 'trial_password_123'
+      }
+    }
+  end
+
+  let(:convert_params) do
+    {
+      user: {
+        email: 'p3_real@example.com',
+        username: 'p3_real',
+        password: 'real_password_123',
+        password_confirmation: 'real_password_123'
+      }
+    }
+  end
+
+  let(:dream_params) do
+    { dream: { title: 'テストP3', content: 'そらを とんで いる ゆめを みたよ。' } }
+  end
+
+  # /trial 画面で「AIにきいてみる」を押したときに実際に走るAPI
+  def trial_login!
+    post '/auth/trial_login', params: trial_params, as: :json, headers: host
+    expect(response).to have_http_status(:created)
+  end
+
+  # /home の「夢を記録する」から夢を保存するのと同じAPI
+  def create_dream!
+    post '/dreams', params: dream_params, as: :json, headers: host
+    expect(response).to have_http_status(:created)
+    json_response['id']
+  end
+
+  def dream_ids_in_list
+    get '/dreams', headers: host
+    expect(response).to have_http_status(:ok)
+    json_response.map { |d| d['id'] }
+  end
+
+  it 'trial_login → /dreamsでDB保存 → convert_trial のあとも同じ夢が残る' do
+    # --- ① trialユーザーとしてログインする -------------------------------
+    trial_login!
+    expect(json_response['user']['trial_user']).to be true
+
+    user = User.find_by(email: 'p3_trial@example.com')
+    expect(user).to be_present
+    user_id_before = user.id
+
+    # --- ③ 通常の夢作成APIでDBに保存する ---------------------------------
+    dream_id = nil
+    expect { dream_id = create_dream! }.to change(Dream, :count).by(1)
+
+    # 画面内stateではなく、本当にDBに入っていることを確認する
+    saved_dream = Dream.find(dream_id)
+    expect(saved_dream.user_id).to eq(user_id_before)
+    # trial_login が self プロフィールを作るので、夢はそこに紐づく
+    expect(saved_dream.dream_profile_id).to be_present
+
+    # --- ④ 本登録の前に、一覧APIで見えている ------------------------------
+    expect(dream_ids_in_list).to include(dream_id)
+
+    # --- ⑤ 同じUserのまま本登録へ昇格する --------------------------------
+    patch '/auth/convert_trial', params: convert_params, as: :json, headers: host
+    expect(response).to have_http_status(:ok)
+
+    # 昇格APIが trial_user: false を返す。
+    # /home はこの値だけを見て TrialBanner の表示を決めているので、
+    # これが false になること＝画面からバナーが消えること。
+    # （画面側の出し分けは frontend/__tests__/app/home/page.test.tsx が担当）
+    expect(json_response['user']['trial_user']).to be false
+    expect(json_response['user']['id']).to eq(user_id_before)
+
+    # --- ⑥ 本登録後も同じ夢が残っている ----------------------------------
+    expect(dream_ids_in_list).to include(dream_id)
+
+    # 新しいUserが作られていないこと（＝夢が迷子にならない理由そのもの）
+    user.reload
+    expect(user.id).to eq(user_id_before)
+    expect(user.trial_user?).to be false
+    expect(user.email).to eq('p3_real@example.com')
+    expect(saved_dream.reload.user_id).to eq(user_id_before)
+
+    # 昇格でUserが増えていないことも明示しておく
+    expect(User.where(email: %w[p3_trial@example.com p3_real@example.com]).count).to eq(1)
+  end
+
+  it '昇格に失敗したときは trial のままで、保存済みの夢も消えない' do
+    # メールが他ユーザーと重複していて昇格が422になるケース。
+    # 「失敗しても巻き戻って夢が残る」ことも P3 の安全性の一部なので一緒に守る。
+    create(:user, email: 'taken@example.com', username: 'taken_user')
+
+    trial_login!
+    user = User.find_by(email: 'p3_trial@example.com')
+    dream_id = create_dream!
+
+    patch '/auth/convert_trial',
+          params: convert_params.deep_merge(user: { email: 'taken@example.com' }),
+          as: :json,
+          headers: host
+    expect(response).to have_http_status(:unprocessable_content)
+
+    # trial のまま維持され、保存済みの夢もそのまま残っている
+    expect(user.reload.trial_user?).to be true
+    expect(dream_ids_in_list).to include(dream_id)
+  end
+end

--- a/frontend/__tests__/app/home/page.test.tsx
+++ b/frontend/__tests__/app/home/page.test.tsx
@@ -216,3 +216,44 @@ describe("HomePage: WeeklyDreamNewsWidgetへのデータ受け渡し", () => {
     expect(listButton).toHaveAttribute("aria-pressed", "true");
   });
 });
+
+// 7月「守りのMust」ランブック ① Trial P3 の回帰テスト（画面側）。
+// 参照: docs/2026-07-guard-must-runbook.md
+//
+// ホームは user.trial_user だけを見て TrialBanner の出し分けをしている。
+// 昇格API（convert_trial）が trial_user: false を返すと、その値が
+// AuthContext 経由でここに流れ、バナーが消える。
+// バックエンド側の「昇格後に trial_user: false を返す」保証は
+// backend/spec/requests/trial_conversion_flow_spec.rb が担当する。
+describe("HomePage: TrialBannerの出し分け（Trial P3）", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockGet.mockResolvedValue([]);
+  });
+
+  it("trialユーザーにはTrialBannerを表示する", async () => {
+    mockUseAuth.mockReturnValue({
+      authStatus: "authenticated",
+      user: { id: "1", username: "おためしユーザー", trial_user: true },
+    });
+
+    render(<HomePage />);
+
+    expect(await screen.findByText("TrialBanner")).toBeInTheDocument();
+  });
+
+  it("本登録へ昇格して trial_user が false になるとTrialBannerが消える", async () => {
+    mockUseAuth.mockReturnValue({
+      authStatus: "authenticated",
+      user: { id: "1", username: "ほんとうろくユーザー", trial_user: false },
+    });
+
+    render(<HomePage />);
+
+    // 画面が描画され切ってからバナーの不在を確認する
+    // （まだ読み込み中の状態を「消えている」と誤判定しないため）
+    // MorpheusHero はバナーと同じ領域にあり、ここが出ていれば描画は済んでいる
+    expect(await screen.findByText("MorpheusHero")).toBeInTheDocument();
+    expect(screen.queryByText("TrialBanner")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
ランブック① Trial P3（trialユーザーがDB保存した夢が本登録後も残る）を、**実APIの通し導線**で守る回帰テストを追加します。テストのみの追加で、アプリのコードは1行も変更していません。

この導線は過去に2回、**検証手順の側で誤解**が起きています（`/trial`画面の「記録だけする」で確認しようとして失敗した）。その誤解が二度と起きないよう、正しい導線をテストとして固定します。

## 追加したテスト

### 1. `backend/spec/requests/trial_conversion_flow_spec.rb`（新規・2 examples）
実HTTPで一本の導線を通します。
`trial_login` → `POST /dreams`（DB保存）→ `GET /dreams`（昇格前に存在）→ `convert_trial` → `GET /dreams`（**昇格後も同じ夢が残る**）

- 同じ `user.id` のままであること、Userが増えていないことも検証
- 昇格が422で失敗したときに trial のまま巻き戻り、**保存済みの夢も消えない**ことを検証
- Cookieはrequest specの統合セッション（＝ブラウザと同じ挙動）に任せ、手動で組み立てない

### 2. `frontend/__tests__/app/home/page.test.tsx`（追記・2 examples）
ホームは `user.trial_user` だけで TrialBanner を出し分けているため、
- trial中 → バナー表示
- 昇格後（`trial_user: false`）→ **バナーが消える**

## 既存テストとの重複回避（調査済み）
| 導線 | 既存 | 今回 |
|---|---|---|
| trial_login単体 | `trial_users_spec.rb` ✅ | 再実装しない |
| 夢作成の上限判定 | `dreams_spec.rb` ✅ | 再実装しない |
| 昇格で夢が残る | `auth_spec.rb`（**factory直挿し**の夢） | **実APIの通し導線**を追加 |
| TrialBannerの描画 | `TrialBanner.test.tsx` ✅ | 再実装しない |
| バナーが消える条件 | なし | **追加** |

## 検証対象にしないもの（コメントに明記）
`/trial`画面の「記録だけする」とAIプレビューはReactの画面内stateのみでDBに保存されません。引き継ぎ確認に使うと必ず失敗しますが、それはP3の不具合ではなく**検証手順の誤り**なので対象外としています。

## 感度確認（このテストは本当にバグを検出するか）
「`convert_trial`ではなく通常登録へフォールバックする」= PR #392 が直したバグを使い捨てスペックで再現したところ、昇格後の夢一覧が `[]` になり、本テストのassertionが**確実に失敗する**ことを確認しました（使い捨て分はコミットしていません）。

## Test plan
- [x] RSpec（Docker内・既存全部＋新規）: **300 examples, 0 failures**
- [x] Jest（全体）: **63 suites / 448 tests 全通過**
- [x] Playwright（smoke + trial-flow, workers=1）: **9 passed**
- [x] 本番環境・本番DB・Stripeには一切触れていない
- [x] migration・backfillは実行していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)