### PR TITLE
Stripe Webhookの処理確定と到着順逆転を安全化

### DIFF
--- a/backend/app/controllers/webhooks_controller.rb
+++ b/backend/app/controllers/webhooks_controller.rb
@@ -1,5 +1,6 @@
 class WebhooksController < ApplicationController
   class InvalidCheckoutSessionPayloadError < StandardError; end
+  class UnresolvedWebhookDataError < StandardError; end
 
   # Rails API モードでは CSRF保護はデフォルトで無効のため、
   # verify_authenticity_token のスキップは不要。
@@ -41,67 +42,70 @@ class WebhooksController < ApplicationController
     PaymentsObservability.increment('webhook.event.received', event_type: event.type)
     PaymentsObservability.log(event: 'webhook.event.received', event_type: event.type, stripe_event_id: event.id)
 
-    begin
-      marker = ProcessedWebhookEvent.create!(stripe_event_id: event.id, processed_at: Time.current)
-    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+    result = StripeWebhookEventProcessor.call(event.id) do
+      dispatch_webhook_event(event)
+    end
+
+    if result == :duplicate
       PaymentsObservability.increment('webhook.event.duplicate', event_type: event.type)
       PaymentsObservability.log(event: 'webhook.event.duplicate', event_type: event.type, stripe_event_id: event.id)
       Rails.logger.info("[Webhook] 重複イベントをスキップ event_id=#{event.id}")
-      return head :ok
-    end
-
-    begin
-      # イベント種別ごとの処理
-      case event.type
-      when 'checkout.session.completed'
-        session = event.data.object
-        if session.mode == 'subscription'
-          handle_subscription_checkout_completed(session, event.id)
-        else
-          handle_donation_checkout_completed(session, event.id)
-        end
-      when 'invoice.payment_succeeded'
-        handle_invoice_payment_succeeded(event.data.object, event.id)
-      when 'customer.subscription.deleted'
-        handle_subscription_deleted(event.data.object, event.id)
-      else
-        PaymentsObservability.increment('webhook.event.unhandled', event_type: event.type)
-        PaymentsObservability.log(event: 'webhook.event.unhandled', event_type: event.type, stripe_event_id: event.id)
-        Rails.logger.info("[Webhook] 未処理イベント: #{event.type}")
-      end
-    rescue InvalidCheckoutSessionPayloadError => e
-      PaymentsObservability.increment('webhook.error.processing', event_type: event.type)
-      PaymentsObservability.log(
-        event: 'webhook.error.processing',
-        level: :error,
-        event_type: event.type,
-        stripe_event_id: event.id,
-        message: e.message
-      )
-      marker&.destroy!
-      Rails.logger.error("[Webhook] checkout.session.completed payload invalid: #{e.message}")
-      return head :internal_server_error
-    rescue => e
-      PaymentsObservability.increment('webhook.error.processing', event_type: event.type)
-      PaymentsObservability.log(
-        event: 'webhook.error.processing',
-        level: :error,
-        event_type: event.type,
-        stripe_event_id: event.id,
-        message: e.message
-      )
-      marker&.destroy!
-      raise
     end
 
     head :ok
+  rescue InvalidCheckoutSessionPayloadError, UnresolvedWebhookDataError => e
+    log_processing_error(event, e)
+    head :internal_server_error
+  rescue Stripe::StripeError => e
+    log_processing_error(event, e)
+    head :bad_gateway
+  rescue => e
+    log_processing_error(event, e)
+    head :internal_server_error
   end
 
   private
 
+  def dispatch_webhook_event(event)
+    case event.type
+    when 'checkout.session.completed'
+      session = event.data.object
+      if session.mode == 'subscription'
+        handle_subscription_checkout_completed(session, event.id)
+      else
+        handle_donation_checkout_completed(session, event.id)
+      end
+    when 'invoice.payment_succeeded'
+      handle_invoice_payment_succeeded(event.data.object, event.id)
+    when 'customer.subscription.deleted'
+      handle_subscription_deleted(event.data.object, event.id)
+    else
+      PaymentsObservability.increment('webhook.event.unhandled', event_type: event.type)
+      PaymentsObservability.log(event: 'webhook.event.unhandled', event_type: event.type, stripe_event_id: event.id)
+      Rails.logger.info("[Webhook] 未処理イベント: #{event.type}")
+    end
+  end
+
+  def log_processing_error(event, error)
+    event_type = event&.type || 'unknown'
+    event_id = event&.id
+    PaymentsObservability.increment('webhook.error.processing', event_type: event_type)
+    PaymentsObservability.log(
+      event: 'webhook.error.processing',
+      level: :error,
+      event_type: event_type,
+      stripe_event_id: event_id,
+      message: error.message
+    )
+    Rails.logger.error("[Webhook] processing failed event_id=#{event_id} type=#{event_type}: #{error.message}")
+  end
+
   def handle_donation_checkout_completed(session, event_id)
     user = resolve_user_from_session(session)
-    return log_unmatched_user(session, event_id, 'webhook.payment.unmatched_user') unless user
+    unless user
+      log_unmatched_user(session, event_id, 'webhook.payment.unmatched_user')
+      raise UnresolvedWebhookDataError, 'Webhook user could not be resolved'
+    end
 
     payment_attributes = payment_attributes_from_session(session)
     payment = Payment.find_or_initialize_by(stripe_checkout_session_id: session.id)
@@ -122,20 +126,22 @@ class WebhooksController < ApplicationController
 
   def handle_subscription_checkout_completed(session, event_id)
     user = resolve_user_from_session(session)
-    return log_unmatched_user(session, event_id, 'webhook.subscription.unmatched_user') unless user
+    unless user
+      log_unmatched_user(session, event_id, 'webhook.subscription.unmatched_user')
+      raise UnresolvedWebhookDataError, 'Subscription checkout user could not be resolved'
+    end
 
     stripe_subscription_id = extract_object_id(session.subscription)
     stripe_customer_id = extract_object_id(session.customer)
     raise InvalidCheckoutSessionPayloadError, 'Stripe subscription checkout is missing subscription id' if stripe_subscription_id.blank?
     raise InvalidCheckoutSessionPayloadError, 'Stripe subscription checkout is missing customer id' if stripe_customer_id.blank?
 
-    subscription = Subscription.find_or_initialize_by(stripe_subscription_id: stripe_subscription_id)
-    subscription.user = user
-    subscription.stripe_customer_id = stripe_customer_id
-    subscription.status = 'active'
-    subscription.save!
-
-    user.update!(premium: true, stripe_customer_id: stripe_customer_id)
+    latest_subscription = Stripe::Subscription.retrieve(stripe_subscription_id)
+    subscription, user = sync_subscription!(
+      latest_subscription,
+      preferred_user: user,
+      fallback_customer_id: stripe_customer_id
+    )
 
     PaymentsObservability.increment('webhook.subscription.started', user_id: user.id)
     PaymentsObservability.log(
@@ -150,43 +156,30 @@ class WebhooksController < ApplicationController
   def handle_invoice_payment_succeeded(invoice, event_id)
     stripe_subscription_id = extract_object_id(invoice.subscription)
     stripe_customer_id = extract_object_id(invoice.customer)
-    return if stripe_subscription_id.blank?
+    raise InvalidCheckoutSessionPayloadError, 'Stripe invoice is missing subscription id' if stripe_subscription_id.blank?
 
-    subscription = Subscription.find_or_initialize_by(stripe_subscription_id: stripe_subscription_id)
-    subscription.user ||= User.find_by(stripe_customer_id: stripe_customer_id)
-    return unless subscription.user
+    latest_subscription = Stripe::Subscription.retrieve(stripe_subscription_id)
+    subscription, user = sync_subscription!(
+      latest_subscription,
+      fallback_customer_id: stripe_customer_id,
+      fallback_current_period_end: extract_current_period_end(invoice)
+    )
 
-    subscription.stripe_customer_id ||= stripe_customer_id
-    subscription.status = 'active'
-    subscription.current_period_end = extract_current_period_end(invoice)
-    subscription.save!
-
-    subscription.user.update!(premium: true, stripe_customer_id: stripe_customer_id.presence || subscription.user.stripe_customer_id)
-
-    PaymentsObservability.increment('webhook.subscription.invoice_paid', user_id: subscription.user.id)
+    PaymentsObservability.increment('webhook.subscription.invoice_paid', user_id: user.id)
     PaymentsObservability.log(
       event: 'webhook.subscription.invoice_paid',
-      user_id: subscription.user.id,
+      user_id: user.id,
       stripe_event_id: event_id,
       stripe_subscription_id: stripe_subscription_id
     )
-    Rails.logger.info("[Webhook] 月次請求成功 user_id=#{subscription.user.id} sub_id=#{stripe_subscription_id}")
+    Rails.logger.info("[Webhook] 月次請求成功 user_id=#{user.id} sub_id=#{stripe_subscription_id}")
   end
 
   def handle_subscription_deleted(subscription_object, event_id)
     stripe_subscription_id = extract_object_id(subscription_object)
-    return if stripe_subscription_id.blank?
+    raise InvalidCheckoutSessionPayloadError, 'Stripe subscription deletion is missing subscription id' if stripe_subscription_id.blank?
 
-    subscription = Subscription.find_by(stripe_subscription_id: stripe_subscription_id)
-    return unless subscription
-
-    subscription.update!(
-      status: subscription_object.respond_to?(:status) ? subscription_object.status : 'canceled',
-      current_period_end: timestamp_to_time(subscription_object.respond_to?(:current_period_end) ? subscription_object.current_period_end : nil)
-    )
-
-    user = subscription.user
-    user.update!(premium: false) unless user.premium_active_subscription?
+    subscription, user = sync_subscription!(subscription_object)
 
     PaymentsObservability.increment('webhook.subscription.deleted', user_id: user.id)
     PaymentsObservability.log(
@@ -196,6 +189,48 @@ class WebhooksController < ApplicationController
       stripe_subscription_id: stripe_subscription_id
     )
     Rails.logger.info("[Webhook] サブスク解約 user_id=#{user.id} sub_id=#{stripe_subscription_id}")
+  end
+
+  def sync_subscription!(stripe_subscription, preferred_user: nil, fallback_customer_id: nil, fallback_current_period_end: nil)
+    stripe_subscription_id = extract_object_id(stripe_subscription)
+    subscription = Subscription.find_or_initialize_by(stripe_subscription_id: stripe_subscription_id)
+    stripe_customer_id =
+      if stripe_subscription.respond_to?(:customer)
+        extract_object_id(stripe_subscription.customer).presence
+      end
+    stripe_customer_id ||= fallback_customer_id
+    stripe_customer_id ||= subscription.stripe_customer_id
+
+    status = stripe_subscription.respond_to?(:status) ? stripe_subscription.status.to_s : nil
+    current_period_end =
+      if stripe_subscription.respond_to?(:current_period_end)
+        timestamp_to_time(stripe_subscription.current_period_end)
+      end
+    current_period_end ||= fallback_current_period_end
+
+    raise InvalidCheckoutSessionPayloadError, 'Stripe subscription is missing id' if stripe_subscription_id.blank?
+    raise InvalidCheckoutSessionPayloadError, 'Stripe subscription is missing customer id' if stripe_customer_id.blank?
+    unless Subscription::STATUSES.include?(status)
+      raise InvalidCheckoutSessionPayloadError, "Unsupported Stripe subscription status: #{status.presence || 'missing'}"
+    end
+
+    user = preferred_user || subscription.user || User.find_by(stripe_customer_id: stripe_customer_id)
+    raise UnresolvedWebhookDataError, 'Subscription user could not be resolved' unless user
+
+    subscription.assign_attributes(
+      user: user,
+      stripe_customer_id: stripe_customer_id,
+      status: status,
+      current_period_end: current_period_end
+    )
+    subscription.save!
+
+    user.update!(
+      stripe_customer_id: stripe_customer_id,
+      premium: user.premium_active_subscription?
+    )
+
+    [subscription, user]
   end
 
   def resolve_user_from_session(session)

--- a/backend/app/models/subscription.rb
+++ b/backend/app/models/subscription.rb
@@ -1,8 +1,10 @@
 class Subscription < ApplicationRecord
   belongs_to :user
 
-  STATUSES = %w[active canceled past_due].freeze
-  ACTIVE_STATUSES = %w[active past_due].freeze
+  STATUSES = %w[
+    incomplete incomplete_expired trialing active past_due canceled unpaid paused
+  ].freeze
+  ACTIVE_STATUSES = %w[trialing active past_due].freeze
 
   validates :stripe_subscription_id, presence: true, uniqueness: true
   validates :stripe_customer_id, presence: true

--- a/backend/app/services/stripe_webhook_event_processor.rb
+++ b/backend/app/services/stripe_webhook_event_processor.rb
@@ -1,0 +1,43 @@
+require 'digest'
+
+class StripeWebhookEventProcessor
+  def self.call(stripe_event_id, &block)
+    new(stripe_event_id).call(&block)
+  end
+
+  def initialize(stripe_event_id)
+    @stripe_event_id = stripe_event_id.to_s
+  end
+
+  def call
+    result = nil
+
+    ApplicationRecord.transaction(requires_new: true) do
+      acquire_event_lock!
+
+      if ProcessedWebhookEvent.exists?(stripe_event_id: @stripe_event_id)
+        result = :duplicate
+      else
+        yield
+        ProcessedWebhookEvent.create!(
+          stripe_event_id: @stripe_event_id,
+          processed_at: Time.current
+        )
+        result = :processed
+      end
+    end
+
+    result
+  end
+
+  private
+
+  def acquire_event_lock!
+    raise ArgumentError, 'stripe_event_id is required' if @stripe_event_id.blank?
+
+    lock_key = Digest::SHA256.digest(@stripe_event_id).unpack1('q>')
+    ApplicationRecord.connection.execute(
+      "SELECT pg_advisory_xact_lock(#{lock_key})"
+    )
+  end
+end

--- a/backend/spec/requests/webhooks_spec.rb
+++ b/backend/spec/requests/webhooks_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'openssl'
 
 RSpec.describe 'Webhooks API', type: :request do
   let(:webhook_secret) { 'whsec_test_secret' }
@@ -59,6 +60,12 @@ RSpec.describe 'Webhooks API', type: :request do
     double('StripeEvent', id: 'evt_test_other', type: 'payment_intent.created', data: event_data_double)
   end
 
+  def stripe_signature(payload, secret)
+    timestamp = Time.current.to_i
+    signature = OpenSSL::HMAC.hexdigest('SHA256', secret, "#{timestamp}.#{payload}")
+    "t=#{timestamp},v1=#{signature}"
+  end
+
   describe 'POST /webhooks/stripe' do
     context 'STRIPE_WEBHOOK_SECRET が未設定の場合' do
       it '500 Internal Server Error を返す' do
@@ -75,6 +82,15 @@ RSpec.describe 'Webhooks API', type: :request do
     context 'STRIPE_WEBHOOK_SECRET が設定されている場合' do
       before do
         stub_const('ENV', ENV.to_hash.merge('STRIPE_WEBHOOK_SECRET' => webhook_secret))
+        allow(Stripe::Subscription).to receive(:retrieve) do |subscription_id|
+          double(
+            'LatestStripeSubscription',
+            id: subscription_id,
+            customer: 'cus_test_123',
+            status: 'active',
+            current_period_end: nil
+          )
+        end
       end
 
       context '署名が不正な場合' do
@@ -113,6 +129,7 @@ RSpec.describe 'Webhooks API', type: :request do
 
       context '有効な署名 + checkout.session.completed の場合' do
         it '200 OK を返す' do
+          create(:user, email: customer_email, stripe_customer_id: 'cus_test_123')
           allow(Stripe::Webhook).to receive(:construct_event)
             .and_return(stripe_event_completed)
 
@@ -203,6 +220,7 @@ RSpec.describe 'Webhooks API', type: :request do
 
       context '同じ event.id を2回受信した場合' do
         it '2回目は処理をスキップしつつ 200 OK を返し、記録は1件のまま' do
+          create(:user, email: customer_email, stripe_customer_id: 'cus_test_123')
           allow(Stripe::Webhook).to receive(:construct_event)
             .and_return(stripe_event_completed)
 
@@ -225,8 +243,10 @@ RSpec.describe 'Webhooks API', type: :request do
               }
             expect(response).to have_http_status(:ok)
           end.to change(ProcessedWebhookEvent, :count).by(1)
+            .and change(Payment, :count).by(1)
 
           expect(ProcessedWebhookEvent.where(stripe_event_id: 'evt_test_duplicate').count).to eq(1)
+          expect(Payment.where(stripe_checkout_session_id: 'cs_test_xxx').count).to eq(1)
         end
       end
 
@@ -459,9 +479,23 @@ RSpec.describe 'Webhooks API', type: :request do
       end
 
       context 'ユーザーが見つからない場合' do
-        it 'Paymentを作成せず 200 OK を返す' do
+        it '処理完了にせず、同じイベントの再送時に復旧する' do
           allow(Stripe::Webhook).to receive(:construct_event)
             .and_return(stripe_event_completed)
+
+          post '/webhooks/stripe',
+            params: payload,
+            headers: {
+              'Content-Type' => 'application/json',
+              'Stripe-Signature' => sig_header,
+              'HOST' => 'backend'
+            }
+
+          expect(response).to have_http_status(:internal_server_error)
+          expect(Payment.where(stripe_checkout_session_id: 'cs_test_xxx')).to be_empty
+          expect(ProcessedWebhookEvent.where(stripe_event_id: 'evt_test_duplicate')).to be_empty
+
+          user = create(:user, email: customer_email, stripe_customer_id: 'cus_test_123')
 
           expect do
             post '/webhooks/stripe',
@@ -471,9 +505,53 @@ RSpec.describe 'Webhooks API', type: :request do
                 'Stripe-Signature' => sig_header,
                 'HOST' => 'backend'
               }
-          end.not_to change(Payment, :count)
+          end.to change(Payment, :count).by(1)
 
           expect(response).to have_http_status(:ok)
+          expect(Payment.find_by!(stripe_checkout_session_id: 'cs_test_xxx').user_id).to eq(user.id)
+          expect(ProcessedWebhookEvent.where(stripe_event_id: 'evt_test_duplicate').count).to eq(1)
+        end
+      end
+
+      context '業務更新中に例外が発生した場合' do
+        let(:subscription_session) do
+          double(
+            'StripeSubscriptionSession',
+            id: 'cs_rollback_test',
+            mode: 'subscription',
+            subscription: 'sub_rollback_test',
+            customer: 'cus_test_123',
+            client_reference_id: nil,
+            customer_details: customer_details_double,
+            customer_email: customer_email
+          )
+        end
+        let(:rollback_event) do
+          double(
+            'StripeEvent',
+            id: 'evt_rollback_test',
+            type: 'checkout.session.completed',
+            data: double('StripeEventData', object: subscription_session)
+          )
+        end
+
+        it '業務更新と処理完了マーカーを両方ロールバックする' do
+          create(:user, email: customer_email, stripe_customer_id: 'cus_test_123', premium: false)
+          allow(Stripe::Webhook).to receive(:construct_event).and_return(rollback_event)
+          allow_any_instance_of(User).to receive(:update!)
+            .and_raise(ActiveRecord::StatementInvalid, 'simulated update failure')
+
+          post '/webhooks/stripe',
+            params: payload,
+            headers: {
+              'Content-Type' => 'application/json',
+              'Stripe-Signature' => sig_header,
+              'HOST' => 'backend'
+            }
+
+          expect(response).to have_http_status(:internal_server_error)
+          expect(Subscription.where(stripe_subscription_id: 'sub_rollback_test')).to be_empty
+          expect(ProcessedWebhookEvent.where(stripe_event_id: 'evt_rollback_test')).to be_empty
         end
       end
 
@@ -611,6 +689,7 @@ RSpec.describe 'Webhooks API', type: :request do
         end
 
         it '200 OK を返す' do
+          create(:user, email: customer_email, stripe_customer_id: 'cus_test_123')
           allow(Stripe::Webhook).to receive(:construct_event)
             .and_return(stripe_event_invoice_paid)
 
@@ -646,7 +725,13 @@ RSpec.describe 'Webhooks API', type: :request do
 
       context 'customer.subscription.deleted の場合' do
         let(:stripe_sub_double) do
-          double('StripeSubscription', id: 'sub_test_123')
+          double(
+            'StripeSubscription',
+            id: 'sub_test_123',
+            customer: 'cus_test_123',
+            status: 'canceled',
+            current_period_end: nil
+          )
         end
 
         let(:deletion_event_data) { double('StripeEventData', object: stripe_sub_double) }
@@ -661,6 +746,14 @@ RSpec.describe 'Webhooks API', type: :request do
         end
 
         it '200 OK を返す' do
+          user = create(:user, email: customer_email, stripe_customer_id: 'cus_test_123', premium: true)
+          create(
+            :subscription,
+            user: user,
+            stripe_subscription_id: 'sub_test_123',
+            stripe_customer_id: 'cus_test_123',
+            status: 'active'
+          )
           allow(Stripe::Webhook).to receive(:construct_event)
             .and_return(stripe_event_sub_deleted)
 
@@ -723,6 +816,176 @@ RSpec.describe 'Webhooks API', type: :request do
           expect(response).to have_http_status(:ok)
           expect(canceled_subscription.reload.status).to eq('canceled')
           expect(user.reload.premium).to be true
+        end
+      end
+
+      context 'customer.subscription.deleted が checkout.session.completed より先に届く場合' do
+        let(:out_of_order_subscription) do
+          double(
+            'StripeSubscription',
+            id: 'sub_out_of_order',
+            customer: 'cus_out_of_order',
+            status: 'canceled',
+            current_period_end: nil
+          )
+        end
+        let(:deleted_first_event) do
+          double(
+            'StripeEvent',
+            id: 'evt_deleted_first',
+            type: 'customer.subscription.deleted',
+            data: double('StripeEventData', object: out_of_order_subscription)
+          )
+        end
+        let(:late_checkout_session) do
+          double(
+            'StripeSubscriptionSession',
+            id: 'cs_out_of_order',
+            mode: 'subscription',
+            subscription: 'sub_out_of_order',
+            customer: 'cus_out_of_order',
+            client_reference_id: nil,
+            customer_details: customer_details_double,
+            customer_email: customer_email
+          )
+        end
+        let(:late_checkout_event) do
+          double(
+            'StripeEvent',
+            id: 'evt_checkout_late',
+            type: 'checkout.session.completed',
+            data: double('StripeEventData', object: late_checkout_session)
+          )
+        end
+
+        it 'Stripeの最新状態を同期し、最終的にpremium=falseを維持する' do
+          user = create(
+            :user,
+            email: customer_email,
+            stripe_customer_id: 'cus_out_of_order',
+            premium: true
+          )
+          allow(Stripe::Webhook).to receive(:construct_event)
+            .and_return(deleted_first_event, late_checkout_event)
+          allow(Stripe::Subscription).to receive(:retrieve)
+            .with('sub_out_of_order')
+            .and_return(out_of_order_subscription)
+
+          2.times do
+            post '/webhooks/stripe',
+              params: payload,
+              headers: {
+                'Content-Type' => 'application/json',
+                'Stripe-Signature' => sig_header,
+                'HOST' => 'backend'
+              }
+            expect(response).to have_http_status(:ok)
+          end
+
+          subscription = Subscription.find_by!(stripe_subscription_id: 'sub_out_of_order')
+          expect(subscription.status).to eq('canceled')
+          expect(user.reload.premium).to be false
+          expect(ProcessedWebhookEvent.where(stripe_event_id: %w[evt_deleted_first evt_checkout_late]).count).to eq(2)
+        end
+      end
+
+      context '削除イベントのUserとSubscriptionが未解決の場合' do
+        let(:unresolved_deleted_subscription) do
+          double(
+            'StripeSubscription',
+            id: 'sub_unresolved_deleted',
+            customer: 'cus_unresolved_deleted',
+            status: 'canceled',
+            current_period_end: nil
+          )
+        end
+        let(:unresolved_deleted_event) do
+          double(
+            'StripeEvent',
+            id: 'evt_unresolved_deleted',
+            type: 'customer.subscription.deleted',
+            data: double('StripeEventData', object: unresolved_deleted_subscription)
+          )
+        end
+
+        it '処理完了にせず、User作成後の再送でcanceled状態を復旧する' do
+          allow(Stripe::Webhook).to receive(:construct_event)
+            .and_return(unresolved_deleted_event)
+
+          post '/webhooks/stripe',
+            params: payload,
+            headers: {
+              'Content-Type' => 'application/json',
+              'Stripe-Signature' => sig_header,
+              'HOST' => 'backend'
+            }
+
+          expect(response).to have_http_status(:internal_server_error)
+          expect(Subscription.where(stripe_subscription_id: 'sub_unresolved_deleted')).to be_empty
+          expect(ProcessedWebhookEvent.where(stripe_event_id: 'evt_unresolved_deleted')).to be_empty
+
+          user = create(
+            :user,
+            stripe_customer_id: 'cus_unresolved_deleted',
+            premium: true
+          )
+
+          post '/webhooks/stripe',
+            params: payload,
+            headers: {
+              'Content-Type' => 'application/json',
+              'Stripe-Signature' => sig_header,
+              'HOST' => 'backend'
+            }
+
+          subscription = Subscription.find_by!(stripe_subscription_id: 'sub_unresolved_deleted')
+          expect(response).to have_http_status(:ok)
+          expect(subscription.status).to eq('canceled')
+          expect(user.reload.premium).to be false
+          expect(ProcessedWebhookEvent.where(stripe_event_id: 'evt_unresolved_deleted').count).to eq(1)
+        end
+      end
+
+      context '実際に署名したraw bodyの場合' do
+        let(:signed_payload) do
+          {
+            id: 'evt_real_signature',
+            object: 'event',
+            type: 'payment_intent.created',
+            data: {
+              object: {
+                id: 'pi_signature_test',
+                object: 'payment_intent'
+              }
+            }
+          }.to_json
+        end
+
+        it '未改変本文を受理し、署名後に改変した本文を拒否する' do
+          signature = stripe_signature(signed_payload, webhook_secret)
+
+          post '/webhooks/stripe',
+            params: signed_payload,
+            headers: {
+              'Content-Type' => 'application/json',
+              'Stripe-Signature' => signature,
+              'HOST' => 'backend'
+            }
+
+          expect(response).to have_http_status(:ok)
+          expect(ProcessedWebhookEvent.where(stripe_event_id: 'evt_real_signature').count).to eq(1)
+
+          tampered_payload = signed_payload.sub('payment_intent.created', 'payment_intent.updated')
+          post '/webhooks/stripe',
+            params: tampered_payload,
+            headers: {
+              'Content-Type' => 'application/json',
+              'Stripe-Signature' => signature,
+              'HOST' => 'backend'
+            }
+
+          expect(response).to have_http_status(:bad_request)
+          expect(ProcessedWebhookEvent.where(stripe_event_id: 'evt_real_signature').count).to eq(1)
         end
       end
     end

--- a/backend/spec/services/stripe_webhook_event_processor_spec.rb
+++ b/backend/spec/services/stripe_webhook_event_processor_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe StripeWebhookEventProcessor, type: :model do
+  self.use_transactional_tests = false
+
+  let(:stripe_event_id) { "evt_concurrent_#{SecureRandom.hex(8)}" }
+
+  after do
+    ProcessedWebhookEvent.where(stripe_event_id: stripe_event_id).delete_all
+  end
+
+  it '同じstripe_event_idを並行処理しても業務処理を1回だけ実行する' do
+    executions = 0
+    executions_mutex = Mutex.new
+    start_gate = Queue.new
+
+    threads = 2.times.map do
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          start_gate.pop
+          described_class.call(stripe_event_id) do
+            executions_mutex.synchronize { executions += 1 }
+            sleep 0.1
+          end
+        end
+      end
+    end
+
+    2.times { start_gate << true }
+    results = threads.map(&:value)
+
+    expect(results).to contain_exactly(:processed, :duplicate)
+    expect(executions).to eq(1)
+    expect(ProcessedWebhookEvent.where(stripe_event_id: stripe_event_id).count).to eq(1)
+  end
+end

--- a/docs/payment-flow.md
+++ b/docs/payment-flow.md
@@ -20,9 +20,9 @@
 ## 2. User Resolution Rule (user不明時の扱い)
 
 - 仕様: `checkout.session.completed` 受信時に user を特定できない場合、`payments` は保存しない。
-- Webhook 応答: 200 OK を返す（Stripe 再送ループを避ける）。
+- Webhook 応答: 500 Internal Server Error を返し、処理済み行を作らずStripeの再送で復旧可能にする。
 - 記録: warning ログを残す。
-- 備考: 将来の調査性向上が必要な場合は別テーブル（例: `unmatched_payments`）を追加する。
+- 備考: user解決後の同一イベント再送で、業務更新と処理済み行を同一トランザクションに確定する。
 
 ## 3. Payment Status Definition
 
@@ -51,6 +51,8 @@
 
 - `processed_webhook_events.stripe_event_id` の一意制約で同一イベント再処理を防ぐ。
 - `payments.stripe_session_id` の一意制約で二重作成を防ぐ。
+- 同じ `stripe_event_id` はDBトランザクション単位のアドバイザリロックで直列化する。
+- 業務更新が成功した最後にだけ `processed_webhook_events` を作成し、例外時は同じトランザクションで全更新をロールバックする。
 
 ## 6. Error Handling
 

--- a/docs/runbook-payments.md
+++ b/docs/runbook-payments.md
@@ -55,6 +55,7 @@
 1. `STRIPE_WEBHOOK_SECRET` が一致しているか確認。
 2. ログで `webhook.payment.unmatched_user` を確認。
 3. `processed_webhook_events` に該当 `stripe_event_id` が存在するか確認。
+4. user または Subscription を解決できない間は 5xx を返し、処理済み行を作らない。対応データを復旧した後、Stripe の再送が 200 になることを確認。
 
 ## KPI / ログの見方
 
@@ -71,6 +72,14 @@
 6. `webhook.payment.saved`
 7. `webhook.payment.unmatched_user`
 8. `webhook.event.duplicate`
+9. `webhook.error.processing`
+
+## Webhook 再送と処理確定
+
+1. 業務更新と `processed_webhook_events` の作成は同一DBトランザクションで確定する。
+2. `processed_webhook_events` に行がなければ、受信済みでも処理完了とは限らない。
+3. 5xx のイベントはStripeからの再送対象。UserやSubscriptionの照合状態を直した後、再送成功とDB状態を確認する。
+4. 同じ `stripe_event_id` の200再送は正常な重複排除であり、業務更新は再実行されない。
 
 ## 手動検証コマンド（開発環境）
 


### PR DESCRIPTION
## 概要

Stripe Webhookの業務更新と処理済みマーカーを同じDBトランザクションで確定し、User・Subscription未解決時や例外時に安全に再送できるようにします。

## Root cause

従来はイベント受信直後に`processed_webhook_events`を作成していたため、業務処理前の停止や未解決データでも処理済みになり得ました。また、`customer.subscription.deleted`が`checkout.session.completed`より先に届くと、削除イベントがDBへ反映されず、後着checkoutによってpremiumがtrueへ戻る可能性がありました。

## 変更内容

- PostgreSQLのtransaction-level advisory lockで同じ`stripe_event_id`を直列化
- 業務更新成功後にのみ処理済みマーカーを作成し、同一トランザクションでcommit
- User・Subscription未解決時は5xxを返し、マーカーを残さず再送可能に変更
- subscription checkoutとinvoice受信時にStripe APIからSubscription最新状態を取得して同期
- deleted先着時もcanceled Subscriptionを作成し、後着checkoutでpremiumを戻さない
- StripeのSubscription状態集合を保存可能にし、premium対象を`trialing`/`active`/`past_due`に限定
- raw body署名検証と既存のDB一意制約を維持
- 再送・処理確定の運用ドキュメントを更新

## テスト

- Stripe関連RSpec: 69 examples, 0 failures
- バックエンド全RSpec: 359 examples, 0 failures
- `git diff --check`: pass
- Ruby syntax check: pass

追加ケース:

- deletedがcheckout.session.completedより先に届く
- User／Subscription未解決後の再送復旧
- 業務更新例外時の全ロールバック
- 同一イベントの並行受信
- 正常な重複再送の二重更新防止
- 実署名raw body成功と本文改変拒否

## 安全範囲

- Stripe Checkout・決済は未実行
- Stripe API呼び出しはRSpecでstubし、外部Stripeへ未接続
- Render・Vercel・Stripe設定は未変更
- 本番DB未接続
- migration追加・本番適用なし

## 残るリスク

- Subscription最新状態取得にStripe API可用性と応答時間が加わる。失敗時は2xxにせず再送対象とする
- 並行制御はPostgreSQL advisory lockに依存する
- Stripe test modeを使った外部E2EはこのPRでは未実施