### PR TITLE
fix: 統合済みの「マイ夢」をナビから外す

### DIFF
--- a/frontend/__tests__/components/CommandPalette.test.tsx
+++ b/frontend/__tests__/components/CommandPalette.test.tsx
@@ -70,6 +70,22 @@ describe("CommandPalette", () => {
     await flushFetch();
   });
 
+  // /my-dreams は /home へ統合済み（ルートはブックマーク対策のリダイレクトのみ）。
+  // コマンドに残すと「実行しても /home のまま」で機能が無いように見えるため出さない。
+  it("統合済みの「マイ夢へ」(/my-dreams) をコマンドに出さない", async () => {
+    setup();
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+
+    expect(screen.queryByText("マイ夢へ")).toBeNull();
+
+    // 検索しても出てこない
+    const input = screen.getByPlaceholderText("夢を検索 / コマンド…");
+    fireEvent.change(input, { target: { value: "マイ夢" } });
+    expect(screen.queryByText("マイ夢へ")).toBeNull();
+
+    await flushFetch();
+  });
+
   it("Enter で選択中コマンドを実行する（先頭=新しい夢を記録→/dream/new）", async () => {
     setup();
     fireEvent.keyDown(window, { key: "k", metaKey: true });

--- a/frontend/__tests__/components/Sidebar.test.tsx
+++ b/frontend/__tests__/components/Sidebar.test.tsx
@@ -50,10 +50,18 @@ describe("Sidebar", () => {
     render(<Sidebar />);
     expect(screen.getByRole("link", { name: "ホーム" })).toHaveAttribute("href", "/home");
     expect(screen.getByRole("link", { name: "夢の森" })).toHaveAttribute("href", "/forest");
-    expect(screen.getByRole("link", { name: "マイ夢" })).toHaveAttribute("href", "/my-dreams");
+    expect(screen.getByRole("link", { name: "きもち" })).toHaveAttribute("href", "/insights");
     expect(screen.getByRole("link", { name: "設定" })).toHaveAttribute("href", "/settings");
     expect(screen.getByRole("button", { name: /さがす/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /ログアウト/ })).toBeInTheDocument();
+  });
+
+  // /my-dreams は /home へ統合済み（ルートはブックマーク対策のリダイレクトのみ）。
+  // ナビに残すと「押しても /home のまま」で機能が無いように見えるため出さない。
+  it("統合済みの「マイ夢」(/my-dreams) をナビに出さない", () => {
+    const { container } = render(<Sidebar />);
+    expect(screen.queryByRole("link", { name: "マイ夢" })).not.toBeInTheDocument();
+    expect(container.querySelector('a[href="/my-dreams"]')).toBeNull();
   });
 
   it("現在地のナビをアクティブ表示する", () => {

--- a/frontend/app/components/CommandPalette.tsx
+++ b/frontend/app/components/CommandPalette.tsx
@@ -22,7 +22,7 @@ import {
   type ReactNode,
 } from "react";
 import { useRouter } from "next/navigation";
-import { BarChart3, House, Moon, Plus, Search, Settings, Sparkles, Trees } from "lucide-react";
+import { BarChart3, House, Plus, Search, Settings, Sparkles, Trees } from "lucide-react";
 
 import { useAuth } from "@/context/AuthContext";
 import apiClient from "@/lib/apiClient";
@@ -107,7 +107,7 @@ export function CommandPaletteProvider({ children }: { children: ReactNode }) {
       { id: "home", label: "ホームへ", icon: <House size={16} />, group: "action", run: () => router.push("/home") },
       { id: "insights", label: "きもちインサイトを見る", icon: <BarChart3 size={16} />, group: "action", run: () => router.push("/insights") },
       { id: "forest", label: "もりへ", icon: <Trees size={16} />, group: "action", run: () => router.push("/forest") },
-      { id: "my-dreams", label: "マイ夢へ", icon: <Moon size={16} />, group: "action", run: () => router.push("/my-dreams") },
+      // 「マイ夢へ」(/my-dreams) は /home へ統合済みのため出さない（Sidebar と同じ理由）
       { id: "settings", label: "設定へ", icon: <Settings size={16} />, group: "action", run: () => router.push("/settings") },
     ];
     const dreamCmds: Command[] = recentDreams.map((d) => ({

--- a/frontend/app/components/Sidebar.tsx
+++ b/frontend/app/components/Sidebar.tsx
@@ -11,7 +11,7 @@
 import { useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { BarChart3, Home, LogOut, Moon, Search, Settings, Trees } from "lucide-react";
+import { BarChart3, Home, LogOut, Search, Settings, Trees } from "lucide-react";
 
 import { useAuth } from "@/context/AuthContext";
 import { toast } from "@/lib/toast";
@@ -20,11 +20,13 @@ import ThemeToggle from "./ThemeToggle";
 
 type NavItem = { href: string; label: string; icon: typeof Home };
 
+// 「マイ夢」(/my-dreams) は 2025-02-21 に /home へ統合済み。
+// ルート自体は古いブックマーク対策のリダイレクトとして残しているが、
+// ナビに置くと「押しても /home のまま＝何も起きない」ように見えるため載せない。
 const NAV: NavItem[] = [
   { href: "/home", label: "ホーム", icon: Home },
   { href: "/insights", label: "きもち", icon: BarChart3 },
   { href: "/forest", label: "夢の森", icon: Trees },
-  { href: "/my-dreams", label: "マイ夢", icon: Moon },
   { href: "/settings", label: "設定", icon: Settings },
 ];
 


### PR DESCRIPTION
## Summary
デスクトップのサイドバーと `⌘K` コマンドパレットに **「マイ夢」が残っていましたが、押しても `/home` のまま**で、機能が無いように見える状態でした。

調べたところ、リンク先の `/my-dreams` は **2025-02-21 のコミット「my-dreamページを削除し、homeに統一」でページ本体が廃止済み**で、現在は `/home` へリダイレクトするだけです。つまりナビ項目の方が消し忘れでした。

> PR #455 のレビュー時に「READMEとは分離し、別のフロントエンド課題として扱う」と切り出した項目です。

## 外したもの
- `Sidebar.tsx` の `NAV` から「マイ夢」
- `CommandPalette.tsx` の「マイ夢へ」
- 未使用になった `Moon` アイコンの import（両ファイル）

## 残したもの（意図的）
| | 理由 |
|---|---|
| `/my-dreams` のリダイレクト本体 | 古いブックマーク・外部リンクからの404を防ぐ（2026-03-17 の404修正コミットの意図を維持） |
| `lib/site.ts` の noindex 登録 | リダイレクト先URLを検索結果に出さないため |

## 効果
モバイルの `BottomTabBar` には元から「マイ夢」が無いため、**モバイルとデスクトップの導線がそろいます**。

変更後のサイドバー: ホーム / きもち / 夢の森 / 設定（＋さがす・ログアウト）

## Test plan
- [x] Jest（全体）: **63 suites / 450 tests 全通過**
- [x] 回帰防止テストを追加（Sidebar・CommandPalette の両方で「マイ夢が出ないこと」を検証）
- [x] `yarn build` 成功（未使用importの整理を含む）
- [x] ブラウザでコンソールエラーなしを確認
- [x] 既存の Sidebar テストは「きもち(/insights)」の検証に置き換え、カバレッジを落としていない

## 影響なし
本番DB・Render・Vercel・Stripeの設定変更なし。migration・backfillなし。バックエンド非変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)