### PR TITLE
Stripeのtest/live設定混在を実行前に拒否する

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -51,6 +51,9 @@ JWT_EXPIRATION_MINUTES=15
 # ========================================
 # 💳 Stripe決済設定
 # ========================================
+# Stripe実行モード（ローカル・テスト: test、本番: live）
+STRIPE_MODE=test
+
 # Stripe公開可能キー（フロントエンド用、pk_test_ or pk_live_）
 STRIPE_PUBLISHABLE_KEY=your_stripe_publishable_key_here
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -55,10 +55,10 @@ JWT_EXPIRATION_MINUTES=15
 STRIPE_MODE=test
 
 # Stripe公開可能キー（フロントエンド用、pk_test_ or pk_live_）
-STRIPE_PUBLISHABLE_KEY=your_stripe_publishable_key_here
+STRIPE_PUBLISHABLE_KEY=
 
 # Stripeシークレットキー（バックエンド用、sk_test_ or sk_live_）
-STRIPE_SECRET_KEY=your_stripe_secret_key_here
+STRIPE_SECRET_KEY=
 
 # Stripe Webhook署名シークレット
 # ローカル: stripe listen --print-secret で取得（ローカル検証用）

--- a/backend/app/controllers/checkout_controller.rb
+++ b/backend/app/controllers/checkout_controller.rb
@@ -27,13 +27,15 @@ class CheckoutController < ApplicationController
         return render json: { error: 'すでにプレミアム会員です。' }, status: :unprocessable_content
       end
 
+      premium_price_id = verified_premium_price_id! if plan == 'premium'
       customer_id = ensure_stripe_customer_id!
 
       session = Stripe::Checkout::Session.create(
         build_checkout_session_params(
           plan: plan,
           frontend_url: frontend_url,
-          customer_id: customer_id
+          customer_id: customer_id,
+          premium_price_id: premium_price_id
         )
       )
 
@@ -52,6 +54,11 @@ class CheckoutController < ApplicationController
       PaymentsObservability.log(event: 'checkout.error.premium_price_missing', level: :error, user_id: current_user.id)
       Rails.logger.error "Checkout configuration error: #{e.message}"
       render json: { error: 'プレミアム決済の設定が未完了です。' }, status: :internal_server_error
+    rescue StripeEnvironmentGuard::ConfigurationError => e
+      PaymentsObservability.increment('checkout.error.stripe_mode_mismatch', user_id: current_user.id)
+      PaymentsObservability.log(event: 'checkout.error.stripe_mode_mismatch', level: :error, user_id: current_user.id)
+      Rails.logger.error "Checkout configuration error: #{e.message}"
+      render json: { error: 'プレミアム決済の設定が一致していません。' }, status: :internal_server_error
     rescue Stripe::StripeError => e
       PaymentsObservability.increment('checkout.error.stripe', user_id: current_user.id)
       PaymentsObservability.log(event: 'checkout.error.stripe', level: :error, user_id: current_user.id, message: e.message)
@@ -104,7 +111,7 @@ class CheckoutController < ApplicationController
     params[:plan].to_s == 'premium' ? 'premium' : 'donation'
   end
 
-  def build_checkout_session_params(plan:, frontend_url:, customer_id:)
+  def build_checkout_session_params(plan:, frontend_url:, customer_id:, premium_price_id: nil)
     base_params = {
       customer: customer_id,
       client_reference_id: current_user.id.to_s,
@@ -115,7 +122,11 @@ class CheckoutController < ApplicationController
       payment_method_types: ['card']
     }
 
-    plan == 'premium' ? base_params.merge(premium_session_params(frontend_url)) : base_params.merge(donation_session_params(frontend_url))
+    if plan == 'premium'
+      base_params.merge(premium_session_params(frontend_url, premium_price_id))
+    else
+      base_params.merge(donation_session_params(frontend_url))
+    end
   end
 
   def donation_session_params(frontend_url)
@@ -137,10 +148,19 @@ class CheckoutController < ApplicationController
     }
   end
 
-  def premium_session_params(frontend_url)
+  def verified_premium_price_id!
     price_id = ENV['STRIPE_PREMIUM_PRICE_ID']
     raise MissingPremiumPriceIdError, 'STRIPE_PREMIUM_PRICE_ID is not set' if price_id.blank?
 
+    price = Stripe::Price.retrieve(price_id)
+    StripeEnvironmentGuard.validate_price!(
+      price: price,
+      mode: Rails.configuration.stripe[:mode]
+    )
+    price_id
+  end
+
+  def premium_session_params(frontend_url, price_id)
     {
       line_items: [{
         price: price_id,

--- a/backend/app/controllers/webhooks_controller.rb
+++ b/backend/app/controllers/webhooks_controller.rb
@@ -28,6 +28,10 @@ class WebhooksController < ApplicationController
       event = Stripe::Webhook.construct_event(
         payload, sig_header, ENV['STRIPE_WEBHOOK_SECRET']
       )
+      StripeEnvironmentGuard.validate_event!(
+        event: event,
+        mode: Rails.configuration.stripe[:mode]
+      )
     rescue JSON::ParserError => e
       # リクエストボディが不正なJSON
       PaymentsObservability.increment('webhook.error.invalid_json')
@@ -40,6 +44,11 @@ class WebhooksController < ApplicationController
       PaymentsObservability.log(event: 'webhook.error.invalid_signature', level: :warn, message: e.message)
       Rails.logger.warn("[Webhook] Signature verification failed: #{e.message}")
       return head :bad_request
+    rescue StripeEnvironmentGuard::ConfigurationError => e
+      PaymentsObservability.increment('webhook.error.stripe_mode_mismatch')
+      PaymentsObservability.log(event: 'webhook.error.stripe_mode_mismatch', level: :error, stripe_event_id: event&.id)
+      Rails.logger.error("[Webhook] Stripe mode mismatch event_id=#{event&.id}: #{e.message}")
+      return head :internal_server_error
     end
 
     PaymentsObservability.increment('webhook.event.received', event_type: event.type)

--- a/backend/config/initializers/stripe.rb
+++ b/backend/config/initializers/stripe.rb
@@ -1,6 +1,20 @@
+require Rails.root.join('lib/stripe_environment_guard')
+
+stripe_mode = StripeEnvironmentGuard.resolve_mode(
+  configured_mode: ENV['STRIPE_MODE'],
+  rails_env: Rails.env
+)
+
+StripeEnvironmentGuard.validate_key_modes!(
+  mode: stripe_mode,
+  secret_key: ENV['STRIPE_SECRET_KEY'],
+  publishable_key: ENV['STRIPE_PUBLISHABLE_KEY']
+)
+
 Rails.configuration.stripe = {
   publishable_key: ENV['STRIPE_PUBLISHABLE_KEY'],
-  secret_key:      ENV['STRIPE_SECRET_KEY']
+  secret_key:      ENV['STRIPE_SECRET_KEY'],
+  mode:            stripe_mode
 }
 
 Stripe.api_key = Rails.configuration.stripe[:secret_key]

--- a/backend/lib/stripe_environment_guard.rb
+++ b/backend/lib/stripe_environment_guard.rb
@@ -1,0 +1,70 @@
+module StripeEnvironmentGuard
+  class ConfigurationError < StandardError; end
+
+  MODES = %w[test live].freeze
+  SECRET_KEY_PREFIXES = {
+    'test' => %w[sk_test_ rk_test_],
+    'live' => %w[sk_live_ rk_live_]
+  }.freeze
+  PUBLISHABLE_KEY_PREFIXES = {
+    'test' => 'pk_test_',
+    'live' => 'pk_live_'
+  }.freeze
+
+  module_function
+
+  def resolve_mode(configured_mode:, rails_env:)
+    mode = configured_mode.to_s.strip
+    mode = rails_env.to_s == 'production' ? 'live' : 'test' if mode.empty?
+    raise ConfigurationError, 'STRIPE_MODE must be test or live' unless MODES.include?(mode)
+
+    mode
+  end
+
+  def validate_key_modes!(mode:, secret_key:, publishable_key:)
+    validate_secret_key!(mode, secret_key) if present?(secret_key)
+    validate_publishable_key!(mode, publishable_key) if present?(publishable_key)
+  end
+
+  def validate_price!(price:, mode:)
+    validate_livemode!(resource: price, mode: mode, resource_name: 'Stripe Price')
+  end
+
+  def validate_event!(event:, mode:)
+    validate_livemode!(resource: event, mode: mode, resource_name: 'Stripe Event')
+  end
+
+  def validate_secret_key!(mode, secret_key)
+    prefixes = SECRET_KEY_PREFIXES.fetch(mode)
+    return if prefixes.any? { |prefix| secret_key.start_with?(prefix) }
+
+    raise ConfigurationError, 'STRIPE_SECRET_KEY does not match STRIPE_MODE'
+  end
+  private_class_method :validate_secret_key!
+
+  def validate_publishable_key!(mode, publishable_key)
+    return if publishable_key.start_with?(PUBLISHABLE_KEY_PREFIXES.fetch(mode))
+
+    raise ConfigurationError, 'STRIPE_PUBLISHABLE_KEY does not match STRIPE_MODE'
+  end
+  private_class_method :validate_publishable_key!
+
+  def validate_livemode!(resource:, mode:, resource_name:)
+    return if mode.nil?
+
+    unless resource.respond_to?(:livemode)
+      raise ConfigurationError, "#{resource_name} does not expose livemode"
+    end
+
+    expected_livemode = mode == 'live'
+    return if resource.livemode == expected_livemode
+
+    raise ConfigurationError, "#{resource_name} livemode does not match STRIPE_MODE"
+  end
+  private_class_method :validate_livemode!
+
+  def present?(value)
+    !value.to_s.strip.empty?
+  end
+  private_class_method :present?
+end

--- a/backend/spec/lib/stripe_environment_guard_spec.rb
+++ b/backend/spec/lib/stripe_environment_guard_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe StripeEnvironmentGuard do
+  describe '.resolve_mode' do
+    it 'productionでは未設定時にliveを返す' do
+      expect(described_class.resolve_mode(configured_mode: nil, rails_env: 'production')).to eq('live')
+    end
+
+    it 'production以外では未設定時にtestを返す' do
+      expect(described_class.resolve_mode(configured_mode: nil, rails_env: 'test')).to eq('test')
+    end
+
+    it '明示されたtestを返す' do
+      expect(described_class.resolve_mode(configured_mode: 'test', rails_env: 'production')).to eq('test')
+    end
+
+    it '不正なmodeを拒否する' do
+      expect do
+        described_class.resolve_mode(configured_mode: 'staging', rails_env: 'production')
+      end.to raise_error(described_class::ConfigurationError, /STRIPE_MODE/)
+    end
+  end
+
+  describe '.validate_key_modes!' do
+    it '同じtest modeのキーを受理する' do
+      expect do
+        described_class.validate_key_modes!(
+          mode: 'test',
+          secret_key: 'sk_test_example',
+          publishable_key: 'pk_test_example'
+        )
+      end.not_to raise_error
+    end
+
+    it 'Secret Keyのmode不一致を拒否する' do
+      expect do
+        described_class.validate_key_modes!(
+          mode: 'live',
+          secret_key: 'sk_test_example',
+          publishable_key: nil
+        )
+      end.to raise_error(described_class::ConfigurationError, /STRIPE_SECRET_KEY/)
+    end
+
+    it 'Publishable Keyのmode不一致を拒否する' do
+      expect do
+        described_class.validate_key_modes!(
+          mode: 'test',
+          secret_key: nil,
+          publishable_key: 'pk_live_example'
+        )
+      end.to raise_error(described_class::ConfigurationError, /STRIPE_PUBLISHABLE_KEY/)
+    end
+
+    it '未設定のキーは起動時検証をスキップする' do
+      expect do
+        described_class.validate_key_modes!(
+          mode: 'test',
+          secret_key: nil,
+          publishable_key: ''
+        )
+      end.not_to raise_error
+    end
+  end
+
+  describe '.validate_price!' do
+    it 'modeと一致するPriceを受理する' do
+      price = double('StripePrice', livemode: false)
+
+      expect do
+        described_class.validate_price!(price: price, mode: 'test')
+      end.not_to raise_error
+    end
+
+    it 'modeと異なるPriceを拒否する' do
+      price = double('StripePrice', livemode: true)
+
+      expect do
+        described_class.validate_price!(price: price, mode: 'test')
+      end.to raise_error(described_class::ConfigurationError, /Stripe Price/)
+    end
+  end
+
+  describe '.validate_event!' do
+    it 'modeと一致するWebhook Eventを受理する' do
+      event = double('StripeEvent', livemode: true)
+
+      expect do
+        described_class.validate_event!(event: event, mode: 'live')
+      end.not_to raise_error
+    end
+
+    it 'modeと異なるWebhook Eventを拒否する' do
+      event = double('StripeEvent', livemode: false)
+
+      expect do
+        described_class.validate_event!(event: event, mode: 'live')
+      end.to raise_error(described_class::ConfigurationError, /Stripe Event/)
+    end
+  end
+end

--- a/backend/spec/requests/checkout_spec.rb
+++ b/backend/spec/requests/checkout_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe 'Checkout API', type: :request do
   let(:premium_price_id) { 'price_premium_test' }
   let(:checkout_url) { 'https://checkout.stripe.com/c/pay/cs_test_123' }
 
+  around do |example|
+    original_mode = Rails.configuration.stripe[:mode]
+    Rails.configuration.stripe[:mode] = 'test'
+    example.run
+  ensure
+    Rails.configuration.stripe[:mode] = original_mode
+  end
+
   before do
     stub_const(
       'ENV',
@@ -13,6 +21,8 @@ RSpec.describe 'Checkout API', type: :request do
         'STRIPE_PREMIUM_PRICE_ID' => premium_price_id
       )
     )
+    allow(Stripe::Price).to receive(:retrieve)
+      .and_return(double('StripePrice', livemode: false))
   end
 
   describe 'POST /checkout' do
@@ -137,13 +147,29 @@ RSpec.describe 'Checkout API', type: :request do
         )
         user = create(:user, stripe_customer_id: 'cus_existing_123')
 
-        expect(Stripe::Customer).to receive(:retrieve).with('cus_existing_123').and_return(double('StripeCustomer'))
+        expect(Stripe::Customer).not_to receive(:retrieve)
         expect(Stripe::Checkout::Session).not_to receive(:create)
 
         authenticated_post('/checkout', user, params: { plan: 'premium' })
 
         expect(response).to have_http_status(:internal_server_error)
         expect(JSON.parse(response.body)['error']).to include('プレミアム決済')
+      end
+
+      it 'Priceがlive modeならCustomerやCheckout Sessionを作成しない' do
+        user = create(:user, stripe_customer_id: nil)
+        allow(Stripe::Price).to receive(:retrieve)
+          .with(premium_price_id)
+          .and_return(double('StripePrice', livemode: true))
+
+        expect(Stripe::Customer).not_to receive(:create)
+        expect(Stripe::Checkout::Session).not_to receive(:create)
+
+        authenticated_post('/checkout', user, params: { plan: 'premium' })
+
+        expect(response).to have_http_status(:internal_server_error)
+        expect(JSON.parse(response.body)['error']).to include('設定が一致していません')
+        expect(user.reload.stripe_customer_id).to be_nil
       end
     end
 
@@ -191,7 +217,7 @@ RSpec.describe 'Checkout API', type: :request do
         ))
         user = create(:user, stripe_customer_id: 'cus_existing_123')
 
-        expect(Stripe::Customer).to receive(:retrieve).with('cus_existing_123').and_return(double('StripeCustomer'))
+        expect(Stripe::Customer).not_to receive(:retrieve)
         expect(Stripe::Checkout::Session).not_to receive(:create)
 
         authenticated_post('/checkout', user, params: { plan: 'premium' })

--- a/backend/spec/requests/webhooks_spec.rb
+++ b/backend/spec/requests/webhooks_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe 'Webhooks API', type: :request do
   let(:sig_header) { 't=12345,v1=fakesignature' }
   let(:customer_email) { 'webhook-user@example.com' }
 
+  around do |example|
+    original_mode = Rails.configuration.stripe[:mode]
+    Rails.configuration.stripe[:mode] = nil
+    example.run
+  ensure
+    Rails.configuration.stripe[:mode] = original_mode
+  end
+
   # 有効なStripeイベントのdouble（成功系テスト用）
   # Stripe::StripeObjectはmethod_missingでattributeにアクセスするため
   # instance_doubleではなくdoubleを使用
@@ -107,6 +115,60 @@ RSpec.describe 'Webhooks API', type: :request do
             }
 
           expect(response).to have_http_status(:bad_request)
+        end
+      end
+
+      context 'Stripe mode検証' do
+        let(:mode_event_data) do
+          double('StripeEventData', object: session_double)
+        end
+
+        before do
+          Rails.configuration.stripe[:mode] = 'test'
+        end
+
+        it 'test modeのEventを受理する' do
+          event = double(
+            'StripeEvent',
+            id: 'evt_mode_test',
+            type: 'payment_intent.created',
+            livemode: false,
+            data: mode_event_data
+          )
+          allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+
+          post '/webhooks/stripe',
+            params: payload,
+            headers: {
+              'Content-Type' => 'application/json',
+              'Stripe-Signature' => sig_header,
+              'HOST' => 'backend'
+            }
+
+          expect(response).to have_http_status(:ok)
+          expect(ProcessedWebhookEvent.where(stripe_event_id: 'evt_mode_test').count).to eq(1)
+        end
+
+        it 'live modeのEventを処理前に拒否する' do
+          event = double(
+            'StripeEvent',
+            id: 'evt_mode_live',
+            type: 'payment_intent.created',
+            livemode: true,
+            data: mode_event_data
+          )
+          allow(Stripe::Webhook).to receive(:construct_event).and_return(event)
+
+          post '/webhooks/stripe',
+            params: payload,
+            headers: {
+              'Content-Type' => 'application/json',
+              'Stripe-Signature' => sig_header,
+              'HOST' => 'backend'
+            }
+
+          expect(response).to have_http_status(:internal_server_error)
+          expect(ProcessedWebhookEvent.where(stripe_event_id: 'evt_mode_live')).to be_empty
         end
       end
 
@@ -947,10 +1009,15 @@ RSpec.describe 'Webhooks API', type: :request do
       end
 
       context '実際に署名したraw bodyの場合' do
+        before do
+          Rails.configuration.stripe[:mode] = 'test'
+        end
+
         let(:signed_payload) do
           {
             id: 'evt_real_signature',
             object: 'event',
+            livemode: false,
             type: 'payment_intent.created',
             data: {
               object: {

--- a/docs/payment-production-readiness-checklist.md
+++ b/docs/payment-production-readiness-checklist.md
@@ -75,7 +75,8 @@
 `STRIPE_PREMIUM_PRICE_ID` を本番Renderに設定する前に、以下を確認する。
 
 - [ ] 本番Stripeダッシュボードで590円の月額価格（Price）が作成済みである
-- [ ] 作成した本番Price IDが `price_` で始まる本番用IDである（テスト用 `price_test_` ではない）
+- [ ] `STRIPE_MODE=live` が設定されている
+- [ ] Price IDはtest/liveともに`price_`で始まるため文字列では判定せず、Checkout前の`livemode`検証が成功することを確認
 - [ ] 本番Stripeの `STRIPE_SECRET_KEY` が `sk_live_` で始まることを確認（値は確認するが絶対にログや画面に出力しない）
 - [ ] 本番Stripeの `STRIPE_WEBHOOK_SECRET` が本番エンドポイント用のものであることを確認
 - [ ] RenderのWebhookエンドポイントURL（`https://dreamjournal-app.onrender.com/webhooks/stripe`）がStripeダッシュボードに登録されている

--- a/docs/release-checklist-payments.md
+++ b/docs/release-checklist-payments.md
@@ -5,9 +5,10 @@
 ## Environment
 
 1. `STRIPE_SECRET_KEY` が本番キーになっている。
-2. `STRIPE_WEBHOOK_SECRET` が本番 endpoint と一致している。
-3. `FRONTEND_URL` が絶対 URL で設定されている。
-4. `INTERNAL_API_URL` / `NEXT_PUBLIC_API_URL` が正しい。
+2. `STRIPE_MODE=live` でSecret/Publishable Keyのmode検証が成功する。
+3. `STRIPE_WEBHOOK_SECRET` が本番 endpoint と一致し、受信Eventの`livemode`検証が成功する。
+4. `FRONTEND_URL` が絶対 URL で設定されている。
+5. `INTERNAL_API_URL` / `NEXT_PUBLIC_API_URL` が正しい。
 
 ## Application
 
@@ -15,7 +16,7 @@
 2. Checkout Session に `client_reference_id` と `metadata.user_id` が含まれる。
 3. `stripe_customer_id` の作成・保存・再利用が動作する。
 4. Webhook で `checkout.session.completed` 受信時に `payments` が保存される。
-5. user 未解決時に `payments` を作成せず `200` で返す。
+5. user 未解決時に `payments` と処理済み行を作成せず、再送可能な `5xx` で返す。
 6. 重複 `stripe_event_id` を二重処理しない。
 
 ## Test

--- a/docs/runbook-payments.md
+++ b/docs/runbook-payments.md
@@ -39,7 +39,8 @@
 - 原因候補:
 1. `FRONTEND_URL` 未設定。
 2. `STRIPE_SECRET_KEY` 無効。
-3. Stripe API 側障害。
+3. `STRIPE_MODE` とSecret KeyまたはPriceの`livemode`が不一致。
+4. Stripe API 側障害。
 - 対応:
 1. 環境変数を確認。
 2. `checkout.error.*` KPI を確認。
@@ -73,6 +74,7 @@
 7. `webhook.payment.unmatched_user`
 8. `webhook.event.duplicate`
 9. `webhook.error.processing`
+10. `webhook.error.stripe_mode_mismatch`
 
 ## Webhook 再送と処理確定
 


### PR DESCRIPTION
## 概要

Webhook安全化PR #456の次段として、Stripeのtest/live設定が混在した場合にCheckoutやWebhook業務更新を開始しないガードを追加します。

## Root cause

従来はSecret Key、Price ID、Webhook secretを環境ごとに設定できましたが、それらが同じStripe modeに属することをコードで検証していませんでした。特にPrice IDとWebhook secretは文字列prefixだけではtest/liveを判別できません。

## 変更内容

- `STRIPE_MODE=test|live`を追加
  - 未設定時はproduction=`live`、その他=`test`
- Secret/Restricted/Publishable Keyのprefixと`STRIPE_MODE`を起動時に照合
- premium Checkout前にPriceを取得し、Stripeが返す`livemode`を照合
- Price不一致時はCustomer・Checkout Sessionを作成せず500
- raw body署名検証後にWebhook Eventの`livemode`を照合
- Event不一致時は処理済みマーカーや業務更新を作らず500
- `checkout.error.stripe_mode_mismatch`と`webhook.error.stripe_mode_mismatch`を追加
- test/liveともPrice IDは`price_`で始まるため文字列判定できないことを運用資料へ反映
- PR #456後の再送仕様に合わせ、古い「user未解決時200」のチェックリストを5xxへ修正

## テスト

- Stripe/premium関連RSpec: `84 examples, 0 failures`
- Ruby構文確認: pass
- `git diff --check`: pass
- 秘密値パターン混入確認: pass

確認ケース:

- productionの既定modeはlive
- test/live Keyの一致・不一致
- Price `livemode`一致・不一致
- Webhook Event `livemode`一致・不一致
- Price不一致時にCustomer/Checkout Sessionを作らない
- 実際に署名したraw bodyとtest mode Eventの組み合わせ
- PR #456の重複排除・再送・premium更新テスト

## 安全範囲

- Stripe Checkout・決済は未実行
- Stripe APIはRSpecでstubし、外部Stripeへ未接続
- Render・Vercel・Stripe設定は未変更
- 本番DB未接続
- migration追加・適用なし
- `dream_profile_id`関連テスト・処理は未実行

## 残るリスク

- premium Checkout前にPrice取得APIが1回増えるため、Stripe障害時はCheckoutを安全側に停止する
- Webhook secret自体はprefixでmode判定できないため、署名成功後のEvent `livemode`で最終判定する
- Render本番では既定値でもliveになるが、運用上は`STRIPE_MODE=live`の明示設定を推奨する