### PR TITLE
fix: メール本文のログ出力を止め、送信失敗を検知できるようにする

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -85,8 +85,18 @@ Rails.application.configure do
     authentication: :plain,
     tls: true
   }
-  # 送信失敗でリクエストを落とさない（配信基盤未設定の間も安全に動かすため）
-  config.action_mailer.raise_delivery_errors = false
+  # 送信失敗を検知できるようにする。
+  #
+  # false のままだと、Rails は送信に失敗しても例外を出さず、ログには
+  # 「Delivered mail ...」とだけ残る。そのため「送ったつもりで1通も届いていない」
+  # 状態に誰も気づけない（2026-07-27 のパスワードリセット調査でこれが起きた）。
+  #
+  # true にしてもユーザーのリクエストは落ちない。メール送信は
+  #   - password_resets_controller#create
+  #   - application_controller#send_verification_email
+  # の2箇所だけで、どちらも deliver_later（非同期ジョブ）だから。
+  # 失敗はジョブのエラーとしてログと Sentry に残り、HTTPレスポンスには影響しない。
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/backend/config/initializers/mail_delivery_safety.rb
+++ b/backend/config/initializers/mail_delivery_safety.rb
@@ -1,0 +1,32 @@
+# メール配信まわりの安全策。
+# 詳細な理由は lib/mailer_log_level.rb / lib/mail_delivery_config.rb のコメント参照。
+#
+# 1. メール本文をログに出さない（トークン漏洩の防止）
+# 2. 設定不足を起動時に警告する（無音の配信失敗に気づけるようにする）
+#
+# すべての初期化が終わってから実行する。production では
+# structured_logging.rb が Rails.logger を JSON ロガーに差し替えるため、
+# その後でないと formatter を引き継げない。
+Rails.application.config.after_initialize do
+  next unless Rails.env.production?
+
+  # --- 1. ActionMailer のログを INFO 止まりにする -----------------------
+  # Rails 全体が debug でも、メール本文（＝リセットURL）は出力しない。
+  base_logger = Rails.logger
+  mailer_logger = ActiveSupport::Logger.new($stdout)
+  mailer_logger.formatter = base_logger.formatter
+  mailer_logger.level = MailerLogLevel.safe_level(base_logger.level)
+  ActionMailer::Base.logger = mailer_logger
+
+  # --- 2. 設定が足りなければ起動時に警告する ---------------------------
+  # 値は出さず、不足しているキー名だけを記録する。
+  warning = MailDeliveryConfig.warning_message
+  if warning
+    Rails.logger.warn(
+      event_type: 'config',
+      component: 'mail_delivery',
+      message: warning,
+      missing_keys: MailDeliveryConfig.missing_env_keys
+    )
+  end
+end

--- a/backend/lib/mail_delivery_config.rb
+++ b/backend/lib/mail_delivery_config.rb
@@ -1,0 +1,35 @@
+# メール配信（SMTP）の設定が揃っているかを判定する。
+#
+# 【なぜ必要か】
+# production では次の設定になっている:
+#   - delivery_method = :smtp（接続先は SMTP_USERNAME / SMTP_PASSWORD）
+#   - from は ENV.fetch("MAIL_FROM", "support@yumelog.com")
+# これらが未設定でも Rails は例外を出さず、ログには
+# 「Delivered mail ...」とだけ残るため、送信されていないことに気づけない。
+# 実際、2026-07-27 のパスワードリセット調査では、MAIL_FROM が未設定で
+# 既定値にフォールバックしたまま、メールが1通も届いていなかった。
+#
+# そこで起動時にこの判定を使い、不足している設定名をログに出す。
+module MailDeliveryConfig
+  # これらが1つでも欠けると、実質メールは送信できない
+  REQUIRED_ENV_KEYS = %w[SMTP_USERNAME SMTP_PASSWORD MAIL_FROM].freeze
+
+  # 未設定（空文字・空白のみを含む）のキーを返す
+  def self.missing_env_keys(env = ENV)
+    REQUIRED_ENV_KEYS.reject { |key| env[key].to_s.strip != '' }
+  end
+
+  def self.configured?(env = ENV)
+    missing_env_keys(env).empty?
+  end
+
+  # 起動ログ用のメッセージ。設定が揃っていれば nil を返す。
+  # 値そのものは絶対に含めない（APIキーが漏れるため）。
+  def self.warning_message(env = ENV)
+    missing = missing_env_keys(env)
+    return nil if missing.empty?
+
+    "メール送信の設定が不足しています（#{missing.join(', ')}）。" \
+      'この状態ではパスワードリセット・確認メールは配信されません。'
+  end
+end

--- a/backend/lib/mailer_log_level.rb
+++ b/backend/lib/mailer_log_level.rb
@@ -1,0 +1,27 @@
+# ActionMailer のログ出力レベルを決める。
+#
+# 【なぜ必要か】
+# ActionMailer の LogSubscriber は、メール送信時に2種類のログを出す:
+#   info  → "Delivered mail <message-id> (4.2ms)"
+#   debug → メール本文まるごと（RFC822形式のヘッダ＋本文）
+#
+# 本文にはパスワードリセットや メールアドレス確認の URL がそのまま入るため、
+# RAILS_LOG_LEVEL=debug で運用すると、ログを見られる人が
+# 誰のアカウントでもパスワードを再設定できてしまう。
+# トークンをDBに digest 保存している対策（#414 / #415 / #421）が、
+# ログ経由で無効化されることになる。
+#
+# 実際 2026-07-27 の本番ログには、パスワードリセットのリンクが
+# base64 のメール本文としてそのまま出力されていた。
+#
+# そこで ActionMailer 専用のロガーを用意し、アプリ全体が debug でも
+# INFO より詳細にはしない。「Delivered mail ...」は残るので、
+# 送信を試みた記録自体は追える。
+module MailerLogLevel
+  # アプリのログレベルを受け取り、メール用に安全なレベルを返す。
+  # - debug(0) が渡されても INFO(1) まで引き上げる（本文を出さない）
+  # - warn(2) 以上で運用しているときは、それより饒舌にはしない
+  def self.safe_level(app_level)
+    [app_level.to_i, Logger::INFO].max
+  end
+end

--- a/backend/spec/lib/mail_delivery_config_spec.rb
+++ b/backend/spec/lib/mail_delivery_config_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+# 「メールが送られていないのに気づけない」状態を防ぐための設定チェック。
+# 背景は lib/mail_delivery_config.rb のコメント参照。
+RSpec.describe MailDeliveryConfig do
+  # 本物の ENV を汚さないよう、判定対象は引数で渡す
+  let(:complete_env) do
+    {
+      'SMTP_USERNAME' => 'resend',
+      'SMTP_PASSWORD' => 'dummy-api-key',
+      'MAIL_FROM' => 'no-reply@example.com'
+    }
+  end
+
+  describe '.missing_env_keys' do
+    it 'すべて揃っていれば空を返す' do
+      expect(described_class.missing_env_keys(complete_env)).to be_empty
+    end
+
+    it '欠けているキーだけを返す' do
+      env = complete_env.merge('MAIL_FROM' => nil)
+
+      expect(described_class.missing_env_keys(env)).to eq(['MAIL_FROM'])
+    end
+
+    it '空文字は未設定として扱う' do
+      env = complete_env.merge('SMTP_PASSWORD' => '')
+
+      expect(described_class.missing_env_keys(env)).to eq(['SMTP_PASSWORD'])
+    end
+
+    it '空白だけの値も未設定として扱う' do
+      env = complete_env.merge('SMTP_USERNAME' => '   ')
+
+      expect(described_class.missing_env_keys(env)).to eq(['SMTP_USERNAME'])
+    end
+
+    it '何も設定されていなければ3つとも返す' do
+      expect(described_class.missing_env_keys({}))
+        .to match_array(%w[SMTP_USERNAME SMTP_PASSWORD MAIL_FROM])
+    end
+  end
+
+  describe '.configured?' do
+    it 'すべて揃っていれば true' do
+      expect(described_class.configured?(complete_env)).to be true
+    end
+
+    it '1つでも欠ければ false' do
+      expect(described_class.configured?(complete_env.merge('MAIL_FROM' => nil))).to be false
+    end
+  end
+
+  describe '.warning_message' do
+    it '設定が揃っていれば nil（警告しない）' do
+      expect(described_class.warning_message(complete_env)).to be_nil
+    end
+
+    it '不足しているキー名を含む警告を返す' do
+      env = complete_env.merge('MAIL_FROM' => nil, 'SMTP_PASSWORD' => nil)
+      message = described_class.warning_message(env)
+
+      expect(message).to include('SMTP_PASSWORD')
+      expect(message).to include('MAIL_FROM')
+      expect(message).to include('配信されません')
+    end
+
+    it '設定値そのものは含めない（APIキーを漏らさない）' do
+      env = complete_env.merge('MAIL_FROM' => nil)
+      message = described_class.warning_message(env)
+
+      expect(message).not_to include('dummy-api-key')
+      expect(message).not_to include('resend')
+    end
+  end
+end

--- a/backend/spec/lib/mailer_log_level_spec.rb
+++ b/backend/spec/lib/mailer_log_level_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+# メール本文（＝パスワードリセットURL）をログに出さないための安全弁。
+# 背景は lib/mailer_log_level.rb のコメント参照。
+RSpec.describe MailerLogLevel do
+  describe '.safe_level' do
+    it 'debug でも INFO まで引き上げる（本文を出させない）' do
+      expect(described_class.safe_level(Logger::DEBUG)).to eq(Logger::INFO)
+    end
+
+    it 'info はそのまま' do
+      expect(described_class.safe_level(Logger::INFO)).to eq(Logger::INFO)
+    end
+
+    it 'warn / error はそのまま（余計に饒舌にしない）' do
+      expect(described_class.safe_level(Logger::WARN)).to eq(Logger::WARN)
+      expect(described_class.safe_level(Logger::ERROR)).to eq(Logger::ERROR)
+    end
+
+    it '返す値が必ず INFO 以上（＝debug を許さない）' do
+      [Logger::DEBUG, Logger::INFO, Logger::WARN, Logger::ERROR, Logger::FATAL].each do |level|
+        expect(described_class.safe_level(level)).to be >= Logger::INFO
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
2026-07-27 のパスワードリセット調査で判明した**2つの問題**に対応します。バックエンドの設定とヘルパーのみで、アプリのロジックは変更していません。

## 1. 🔒 パスワードリセットURLが本番ログに出ていた（セキュリティ）

本番ログにメール本文が**丸ごと**出力されていました:
```
"level":"DEBUG" ... "From: support@yumelog.com\r\nTo: ...（本文全体・base64）"
```
デコードするとリセットURLがそのまま含まれます。

**原因**: ActionMailer の LogSubscriber は `deliver` イベントで
- `info` → `Delivered mail <id> (4.2ms)`
- **`debug` → メール本文まるごと（RFC822）**

を出します。本番は `RAILS_LOG_LEVEL=debug` で動いていたため後者が有効でした。

**影響**: ログ閲覧権限があれば任意アカウントのパスワードを再設定できる状態。トークンをDBに digest 保存する対策（PR #414 / #415 / #421）が、ログ経由で無効化されていました。SQLパラメータは `[FILTERED]` されますが、**メール本文にフィルタは効きません**。

**対応**: ActionMailer 専用ロガーを用意し、アプリ全体が `debug` でも **INFO より詳細にしない**（`MailerLogLevel.safe_level`）。`Delivered mail ...` は残るので送信記録は追えます。

> 環境変数 `RAILS_LOG_LEVEL` を `info` に戻す運用対応と**併用**してください。本PRはそれを忘れても本文が出ないようにする多層防御です。

## 2. 👁 送信に失敗しても「Delivered」と記録され気づけなかった（可観測性）

`raise_delivery_errors = false` のため、SMTP未設定でも例外が出ず `Delivered mail (4.2ms)` と記録されていました。**実際には1通も届いていない**のにログ上は成功に見える状態です（4.2msは外部SMTPへの接続としては速すぎ、認証情報が無く即失敗したことを示します）。

**対応:**
- **`raise_delivery_errors = true`** に変更。
  安全性の根拠: メール送信は `password_resets#create` と `application_controller#send_verification_email` の**2箇所だけで、どちらも `deliver_later`（非同期ジョブ）**です（grep で確認済み・`deliver_now`/`deliver!` は存在しない）。失敗はジョブのエラーとしてログと Sentry に残り、**HTTPレスポンスには影響しません**。
- **起動時に設定不足を警告**（`MailDeliveryConfig`）。`SMTP_USERNAME` / `SMTP_PASSWORD` / `MAIL_FROM` が欠けていれば、ユーザーが操作する前にログで気づけます。**値は出さずキー名だけ**を記録します。

## 変更ファイル
| ファイル | 内容 |
|---|---|
| `config/initializers/mail_delivery_safety.rb` | 新規。ロガー差し替え＋起動時警告 |
| `lib/mailer_log_level.rb` | 新規。安全なログレベル計算 |
| `lib/mail_delivery_config.rb` | 新規。設定不足の判定 |
| `config/environments/production.rb` | `raise_delivery_errors` を true に（理由をコメント記載） |
| `spec/lib/*_spec.rb` | 新規テスト14件 |

## Test plan
- [x] 新規テスト: **14 examples, 0 failures**（未設定判定・空白の扱い・**警告に値を含めないこと**・debugを許さないこと）
- [x] RSpec 全体: **375 examples, 0 failures**
- [x] 本番DB・Render・Vercel・Stripe の設定変更なし。migration・backfill なし

## 想定される副作用（正直に）
`raise_delivery_errors = true` により、**Resend未設定の間は送信のたびにエラーログとSentryイベントが出ます**。これは「今まで見えていなかった失敗が見えるようになる」ことであり意図通りですが、Resend設定が完了するまでは通知が増えます。気になる場合は設定完了まで本PRのマージを保留してください。