### PR TITLE
fix: 本番のActive Job引数ログから認証トークンを除外する

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -71,6 +71,11 @@ Rails.application.configure do
   # config.active_job.queue_adapter = :resque
   # config.active_job.queue_name_prefix = "app_production"
 
+  # deliver_later はメール本文だけでなく、パスワード再設定・メール認証用の
+  # トークンもジョブ引数として直列化する。引数を INFO ログへ出すと、
+  # ActionMailer の本文ログを抑止してもトークンが漏れるため、本番では出力しない。
+  config.active_job.log_arguments = false
+
   config.action_mailer.perform_caching = false
 
   # メール配信（SMTP・Resend等を想定）。

--- a/backend/config/initializers/sentry.rb
+++ b/backend/config/initializers/sentry.rb
@@ -21,8 +21,17 @@ Sentry.init do |config|
   config.enabled_environments = %w[production development]
 
   # 送信前にイベントを加工・フィルタリングする場合
-  config.before_send = lambda do |event, hint|
-    # パスワードなどセンシティブな情報をフィルタリング
-    event
+  # 送信前にイベントからセンシティブな情報を落とす。
+  #
+  # sentry-rails の ActiveJob 連携は、ジョブ例外時に extra へ
+  # ジョブ引数（arguments）を丸ごと入れて送る。
+  # ActionMailer::MailDeliveryJob の引数にはパスワード再設定・
+  # メールアドレス確認の生トークンが含まれるため、ここでマスクする。
+  # production.rb の active_job.log_arguments = false は Rails のログにしか
+  # 効かず、この経路は塞げない。詳細は lib/sentry_job_arguments_filter.rb 参照。
+  #
+  # 定数は呼び出し時に解決されるので、初期化順序の影響を受けない。
+  config.before_send = lambda do |event, _hint|
+    SentryJobArgumentsFilter.call(event)
   end
 end

--- a/backend/lib/sentry_job_arguments_filter.rb
+++ b/backend/lib/sentry_job_arguments_filter.rb
@@ -1,0 +1,78 @@
+# Sentry へ送るイベントから Active Job の引数を落とす。
+#
+# 【なぜ必要か】
+# sentry-rails の ActiveJob 連携は、ジョブが例外を投げたとき
+#   extra: { active_job:, arguments:, scheduled_at:, job_id:, provider_job_id:, locale: }
+# を付けて capture_exception する
+# （sentry-rails 6.6.2 / lib/sentry/rails/active_job.rb の sentry_context）。
+#
+# ActionMailer::MailDeliveryJob の arguments には、パスワード再設定・
+# メールアドレス確認の「生トークン」がそのまま入る。
+#   ["UserMailer", "password_reset", "deliver_now", { args: [GlobalID, "<生トークン>"] }]
+#
+# production.rb の `config.active_job.log_arguments = false` は Rails の
+# LogSubscriber にしか効かないため、Sentry へ送られる経路は塞げない。
+# さらに raise_delivery_errors = true（メール送信失敗を検知するための設定）に
+# より、送信失敗のたびにこの経路が発火する。そこでここで落とす。
+#
+# 【設計方針】
+# - Active Job 由来と判断できる extra のときだけ触る（無関係な extra は壊さない）
+# - arguments は削除ではなくマスクする。「引数があった」事実は残るので、
+#   調査時に「引数なしのジョブ」と区別できる
+# - ジョブクラス名・job_id・provider_job_id・queue・例外・スタックトレースは残す
+# - 文字列キー / シンボルキー / ネストのどれでも落とせるようにする
+# - extra が nil や想定外の型でも例外を出さない（フィルタ都合で送信を壊さない）
+# - イベント全体をログへ出力しない（それ自体が漏洩になるため）
+module SentryJobArgumentsFilter
+  REDACTED = '[FILTERED]'
+
+  # 落とす対象のキー名（文字列比較するのでシンボル/文字列どちらでも一致する）
+  ARGUMENT_KEY_NAMES = %w[arguments].freeze
+
+  # 「この extra は Active Job 由来」と判断するための目印。
+  # これが無い extra には触らない（無関係な情報を消さないため）。
+  ACTIVE_JOB_MARKER_KEYS = %w[active_job job_id provider_job_id].freeze
+
+  # 異常に深い/循環した構造で無限に潜らないための上限
+  MAX_DEPTH = 5
+
+  # before_send から呼ばれる。必ず event を返す（nil を返すと送信自体が消える）。
+  def self.call(event)
+    extra = event.respond_to?(:extra) ? event.extra : nil
+    return event unless extra.is_a?(Hash)
+    return event unless active_job_extra?(extra)
+
+    event.extra = redact(extra, 0)
+    event
+  rescue StandardError
+    # フィルタ自身の失敗で Sentry 送信を壊さない。
+    # ここで event の中身をログに出すと本末転倒なので、何も出力しない。
+    event
+  end
+
+  # extra が Active Job 由来かどうか（トップレベルの目印だけで判断する）
+  def self.active_job_extra?(hash)
+    hash.any? { |key, _value| ACTIVE_JOB_MARKER_KEYS.include?(key.to_s) }
+  end
+
+  # arguments キーの値をマスクした新しい構造を返す（元の Hash は壊さない）
+  def self.redact(value, depth)
+    return value if depth > MAX_DEPTH
+
+    case value
+    when Hash
+      value.each_with_object({}) do |(key, nested), result|
+        result[key] =
+          if ARGUMENT_KEY_NAMES.include?(key.to_s)
+            REDACTED
+          else
+            redact(nested, depth + 1)
+          end
+      end
+    when Array
+      value.map { |element| redact(element, depth + 1) }
+    else
+      value
+    end
+  end
+end

--- a/backend/lib/sentry_job_arguments_filter.rb
+++ b/backend/lib/sentry_job_arguments_filter.rb
@@ -21,7 +21,9 @@
 #   調査時に「引数なしのジョブ」と区別できる
 # - ジョブクラス名・job_id・provider_job_id・queue・例外・スタックトレースは残す
 # - 文字列キー / シンボルキー / ネストのどれでも落とせるようにする
-# - extra が nil や想定外の型でも例外を出さない（フィルタ都合で送信を壊さない）
+# - extra が nil や想定外の型でも例外を出さない（想定内なのでイベントは通す）
+# - 想定外の例外でマスクに失敗したときは、マスク前のイベントを返さず nil を返して
+#   送信ごと捨てる（安全側に倒す。理由は self.call のコメント参照）
 # - イベント全体をログへ出力しない（それ自体が漏洩になるため）
 module SentryJobArgumentsFilter
   REDACTED = '[FILTERED]'
@@ -36,7 +38,17 @@ module SentryJobArgumentsFilter
   # 異常に深い/循環した構造で無限に潜らないための上限
   MAX_DEPTH = 5
 
-  # before_send から呼ばれる。必ず event を返す（nil を返すと送信自体が消える）。
+  # before_send から呼ばれる。
+  # 正常時は event を返す。マスクに失敗したときだけ nil を返す。
+  #
+  # nil を返すと sentry-ruby はそのイベントを送らずに捨てる
+  # （sentry-ruby 6.6.2 / client.rb#send_event: before_send の戻り値が
+  #   ErrorEvent でなければ record_lost_event して return）。
+  #
+  # 失敗時に event をそのまま返すと、マスク前＝生トークン入りのイベントを
+  # 送ってしまう。このフィルタの目的はトークンの流出防止なので、
+  # 「通知を1件失う」より「トークンを送らない」を優先する。
+  # 通知が消えても Rails 側のログには例外が残る。
   def self.call(event)
     extra = event.respond_to?(:extra) ? event.extra : nil
     return event unless extra.is_a?(Hash)
@@ -45,9 +57,8 @@ module SentryJobArgumentsFilter
     event.extra = redact(extra, 0)
     event
   rescue StandardError
-    # フィルタ自身の失敗で Sentry 送信を壊さない。
     # ここで event の中身をログに出すと本末転倒なので、何も出力しない。
-    event
+    nil
   end
 
   # extra が Active Job 由来かどうか（トップレベルの目印だけで判断する）

--- a/backend/spec/config/production_active_job_logging_spec.rb
+++ b/backend/spec/config/production_active_job_logging_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'production Active Job logging configuration' do
+  it 'does not log serialized job arguments' do
+    production_config = Rails.root.join('config/environments/production.rb').read
+
+    expect(production_config).to include('config.active_job.log_arguments = false')
+  end
+end

--- a/backend/spec/config/production_active_job_logging_spec.rb
+++ b/backend/spec/config/production_active_job_logging_spec.rb
@@ -1,9 +1,101 @@
 require 'rails_helper'
 
-RSpec.describe 'production Active Job logging configuration' do
-  it 'does not log serialized job arguments' do
-    production_config = Rails.root.join('config/environments/production.rb').read
+# Active Job の enqueue / perform ログに、パスワード再設定・メールアドレス確認の
+# トークンが残らないことを守る回帰テスト。
+#
+# ActionMailer::MailDeliveryJob の引数には生トークンが入るため、
+# production.rb で `config.active_job.log_arguments = false` を設定している。
+# ここでは「設定ファイルに文字列がある」ことだけでなく、
+# 実際に ActiveJob のログ購読機構を通して引数が出ないことを確認する。
+RSpec.describe 'Active Job のログにジョブ引数を残さない' do
+  # 本物のトークンは使わない。混入検知用の合成マーカー。
+  SYNTHETIC_JOB_MARKER = 'SYNTHETIC_PASSWORD_RESET_TOKEN_DO_NOT_LEAK'.freeze
 
-    expect(production_config).to include('config.active_job.log_arguments = false')
+  describe '設定値そのもの' do
+    it 'ActiveJob が log_arguments 設定に対応している（Rails側の改名を検知する）' do
+      expect(ActiveJob::Base).to respond_to(:log_arguments=)
+      expect(ActiveJob::Base).to respond_to(:log_arguments?)
+    end
+
+    # production.rb は Rails.application.configure ブロックなので、テスト中に
+    # 評価するとアプリ全体の設定を書き換えてしまう。そのため実行はせず、
+    # 「コメントを除いた最後の代入が false か」を見る。
+    # これで次の退行を検知できる:
+    #   - 行ごとコメントアウトされた
+    #   - 後から true で上書きされた
+    #   - 行が消された
+    it 'production.rb の最終的な設定が false になっている' do
+      source = Rails.root.join('config/environments/production.rb').read
+
+      # 行コメントを除去してから代入行だけを集める
+      assignments = source
+                    .lines
+                    .map { |line| line.sub(/#.*\z/, '') }
+                    .grep(/config\.active_job\.log_arguments\s*=/)
+
+      expect(assignments).not_to(be_empty,
+                                'production.rb に config.active_job.log_arguments の設定がありません')
+      expect(assignments.last).to match(/=\s*false/)
+    end
+  end
+
+  describe '実際のログ出力（動作ベース）' do
+    let(:user) { create(:user) }
+    let(:log_output) { StringIO.new }
+
+    # ログ購読先を差し替えて出力を捕まえる。
+    # log_arguments はグローバル設定なので、必ず元へ戻す。
+    around do |example|
+      original_logger = ActiveJob::Base.logger
+      original_log_arguments = ActiveJob::Base.log_arguments
+
+      captured_logger = ActiveSupport::Logger.new(log_output)
+      captured_logger.level = Logger::DEBUG
+      ActiveJob::Base.logger = captured_logger
+
+      example.run
+    ensure
+      ActiveJob::Base.logger = original_logger
+      ActiveJob::Base.log_arguments = original_log_arguments
+    end
+
+    context 'log_arguments = false（production と同じ設定）' do
+      before { ActiveJob::Base.log_arguments = false }
+
+      it 'enqueue ログにトークンが出ない' do
+        UserMailer.password_reset(user, SYNTHETIC_JOB_MARKER).deliver_later
+
+        expect(log_output.string).to include('Enqueued ActionMailer::MailDeliveryJob')
+        expect(log_output.string).not_to include(SYNTHETIC_JOB_MARKER)
+      end
+
+      it 'perform（実行開始）ログにもトークンが出ない' do
+        # test 環境の queue_adapter は :inline なので、enqueue で実行まで走る
+        UserMailer.password_reset(user, SYNTHETIC_JOB_MARKER).deliver_later
+
+        expect(log_output.string).to include('Performing ActionMailer::MailDeliveryJob')
+        expect(log_output.string).not_to include(SYNTHETIC_JOB_MARKER)
+      end
+
+      it 'ジョブ名と Job ID は残る（調査に必要）' do
+        UserMailer.password_reset(user, SYNTHETIC_JOB_MARKER).deliver_later
+
+        expect(log_output.string).to include('ActionMailer::MailDeliveryJob')
+        expect(log_output.string).to match(/Job ID: [0-9a-f-]+/)
+      end
+    end
+
+    # 「この設定が無いと本当に漏れる」ことを示す対照実験。
+    # これが失敗するようになったら、log_arguments 以外の仕組みで
+    # 引数が隠れていることになるので、テストの前提を見直す合図になる。
+    context 'log_arguments = true（設定を外した場合）' do
+      before { ActiveJob::Base.log_arguments = true }
+
+      it 'トークンがログに出てしまう（＝この設定が効いている証拠）' do
+        UserMailer.password_reset(user, SYNTHETIC_JOB_MARKER).deliver_later
+
+        expect(log_output.string).to include(SYNTHETIC_JOB_MARKER)
+      end
+    end
   end
 end

--- a/backend/spec/initializers/sentry_before_send_spec.rb
+++ b/backend/spec/initializers/sentry_before_send_spec.rb
@@ -1,0 +1,150 @@
+require 'rails_helper'
+
+# Sentry へ送るイベントに、パスワード再設定・メールアドレス確認の
+# トークンが混ざらないことを守る回帰テスト。
+#
+# ここでは「テスト専用の別実装」ではなく、
+#   - 実際の Sentry::ErrorEvent
+#   - config/initializers/sentry.rb で実際に登録された before_send
+#   - 実際のシリアライズ（to_json_compatible）
+# を使う。フィルタを外したり before_send の登録を消したりすれば落ちる。
+RSpec.describe 'Sentry before_send によるジョブ引数のマスク' do
+  # 本物のトークンは使わない。混入検知用の合成マーカー。
+  SYNTHETIC_MARKER = 'SYNTHETIC_PASSWORD_RESET_TOKEN_DO_NOT_LEAK'.freeze
+
+  # test は enabled_environments に含まれないため、そのままだと
+  # event_from_exception が nil を返す。イベントを作れるよう一時的に許可し、
+  # 必ず元へ戻す（他のテストへ影響させない）。
+  around do |example|
+    original_environments = Sentry.configuration.enabled_environments
+    Sentry.configuration.enabled_environments = original_environments + ['test']
+    example.run
+  ensure
+    Sentry.configuration.enabled_environments = original_environments
+  end
+
+  # 実際に登録されている before_send（初期化子で設定されたもの）
+  let(:before_send) { Sentry.configuration.before_send }
+
+  let(:delivery_error) do
+    begin
+      raise Net::SMTPAuthenticationError, '535 authentication failed'
+    rescue StandardError => e
+      e
+    end
+  end
+
+  # sentry-rails 6.6.2 の sentry_context(job) と同じ形。
+  # ActionMailer::MailDeliveryJob の arguments には生トークンが入る。
+  let(:active_job_extra) do
+    {
+      active_job: 'ActionMailer::MailDeliveryJob',
+      arguments: [
+        'UserMailer',
+        'password_reset',
+        'deliver_now',
+        { args: ['gid://app/User/1', SYNTHETIC_MARKER] }
+      ],
+      scheduled_at: nil,
+      job_id: 'job-id-for-spec',
+      provider_job_id: nil,
+      locale: 'en'
+    }
+  end
+
+  def build_event(extra:)
+    event = Sentry.get_current_client.event_from_exception(delivery_error)
+    event.extra = extra
+    event.tags = { job_id: 'job-id-for-spec' }
+    event
+  end
+
+  it 'before_send が登録されている（未設定なら素通りしてしまう）' do
+    expect(before_send).to respond_to(:call)
+  end
+
+  context 'メールジョブの例外イベント' do
+    let(:filtered) { before_send.call(build_event(extra: active_job_extra), {}) }
+    let(:serialized) { filtered.to_json_compatible.to_s }
+
+    it 'シリアライズ結果に合成マーカーが残らない' do
+      expect(serialized).not_to include(SYNTHETIC_MARKER)
+    end
+
+    it 'arguments がマスクされている' do
+      expect(filtered.extra[:arguments]).to eq(SentryJobArgumentsFilter::REDACTED)
+    end
+
+    it 'ジョブクラス名は残る（調査に必要）' do
+      expect(filtered.extra[:active_job]).to eq('ActionMailer::MailDeliveryJob')
+      expect(serialized).to include('ActionMailer::MailDeliveryJob')
+    end
+
+    it 'Job ID は残る' do
+      expect(filtered.extra[:job_id]).to eq('job-id-for-spec')
+      expect(serialized).to include('job-id-for-spec')
+    end
+
+    it '例外情報（クラス・メッセージ）は残る' do
+      expect(serialized).to include('SMTPAuthenticationError')
+      expect(serialized).to include('535 authentication failed')
+    end
+
+    it 'ジョブ引数以外の項目は消さない' do
+      expect(filtered.extra).to include(:scheduled_at, :provider_job_id, :locale)
+    end
+
+    it 'イベント自体は必ず返る（nilを返すと送信が消える）' do
+      expect(filtered).to be_a(Sentry::ErrorEvent)
+    end
+  end
+
+  context 'キーの表記ゆれ・ネスト' do
+    it '文字列キーの arguments もマスクする' do
+      extra = { 'active_job' => 'ActionMailer::MailDeliveryJob',
+                'arguments' => [SYNTHETIC_MARKER],
+                'job_id' => 'job-id-for-spec' }
+
+      filtered = before_send.call(build_event(extra: extra), {})
+
+      expect(filtered.to_json_compatible.to_s).not_to include(SYNTHETIC_MARKER)
+    end
+
+    it 'ネストした arguments もマスクする' do
+      extra = { active_job: 'ActionMailer::MailDeliveryJob',
+                job_id: 'job-id-for-spec',
+                wrapped: { arguments: [{ args: [SYNTHETIC_MARKER] }] } }
+
+      filtered = before_send.call(build_event(extra: extra), {})
+
+      expect(filtered.to_json_compatible.to_s).not_to include(SYNTHETIC_MARKER)
+    end
+  end
+
+  context 'Active Job 以外のイベント' do
+    it '無関係な extra は変更しない' do
+      extra = { request_id: 'req-1', arguments: 'この arguments は残す' }
+
+      filtered = before_send.call(build_event(extra: extra), {})
+
+      # active_job / job_id の目印が無いので触らない
+      expect(filtered.extra[:arguments]).to eq('この arguments は残す')
+    end
+  end
+
+  context '想定外の入力でも壊れない' do
+    it 'extra が nil でも例外を出さずイベントを返す' do
+      event = build_event(extra: nil)
+
+      expect { before_send.call(event, {}) }.not_to raise_error
+      expect(before_send.call(event, {})).to be_a(Sentry::ErrorEvent)
+    end
+
+    it 'extra が Hash でなくても例外を出さない' do
+      event = build_event(extra: nil)
+      allow(event).to receive(:extra).and_return('unexpected string')
+
+      expect { before_send.call(event, {}) }.not_to raise_error
+    end
+  end
+end

--- a/backend/spec/initializers/sentry_before_send_spec.rb
+++ b/backend/spec/initializers/sentry_before_send_spec.rb
@@ -12,17 +12,6 @@ RSpec.describe 'Sentry before_send によるジョブ引数のマスク' do
   # 本物のトークンは使わない。混入検知用の合成マーカー。
   SYNTHETIC_MARKER = 'SYNTHETIC_PASSWORD_RESET_TOKEN_DO_NOT_LEAK'.freeze
 
-  # test は enabled_environments に含まれないため、そのままだと
-  # event_from_exception が nil を返す。イベントを作れるよう一時的に許可し、
-  # 必ず元へ戻す（他のテストへ影響させない）。
-  around do |example|
-    original_environments = Sentry.configuration.enabled_environments
-    Sentry.configuration.enabled_environments = original_environments + ['test']
-    example.run
-  ensure
-    Sentry.configuration.enabled_environments = original_environments
-  end
-
   # 実際に登録されている before_send（初期化子で設定されたもの）
   let(:before_send) { Sentry.configuration.before_send }
 
@@ -52,8 +41,14 @@ RSpec.describe 'Sentry before_send によるジョブ引数のマスク' do
     }
   end
 
+  # イベントは Sentry::ErrorEvent を直接組み立てる。
+  # client.event_from_exception は SENTRY_DSN が無い環境（CIなど）だと
+  # sending_allowed? が false になり nil を返すため、ここでは使わない。
+  # 実際のイベントクラスと add_exception_interface を使うので、
+  # 例外情報もシリアライズ結果も本番と同じ形になる。
   def build_event(extra:)
-    event = Sentry.get_current_client.event_from_exception(delivery_error)
+    event = Sentry::ErrorEvent.new(configuration: Sentry.configuration)
+    event.add_exception_interface(delivery_error, mechanism: Sentry::Mechanism.new)
     event.extra = extra
     event.tags = { job_id: 'job-id-for-spec' }
     event
@@ -94,7 +89,9 @@ RSpec.describe 'Sentry before_send によるジョブ引数のマスク' do
       expect(filtered.extra).to include(:scheduled_at, :provider_job_id, :locale)
     end
 
-    it 'イベント自体は必ず返る（nilを返すと送信が消える）' do
+    it '正常時は ErrorEvent を返す（通知は届く）' do
+      # sentry-ruby は before_send が ErrorEvent 以外を返すとイベントを捨てる
+      # （sentry-ruby 6.6.2 client.rb:243-251）。正常時は捨てさせない。
       expect(filtered).to be_a(Sentry::ErrorEvent)
     end
   end
@@ -143,6 +140,27 @@ RSpec.describe 'Sentry before_send によるジョブ引数のマスク' do
     it 'extra が Hash でなくても例外を出さない' do
       event = build_event(extra: nil)
       allow(event).to receive(:extra).and_return('unexpected string')
+
+      expect { before_send.call(event, {}) }.not_to raise_error
+    end
+
+    # 安全側の設計（fail-closed）の確認。
+    # マスク処理が想定外の例外で失敗したときに、マスク前のイベントを返すと
+    # 生トークンをそのまま送ってしまう。そこで nil を返して送信ごと捨てる。
+    # sentry-ruby は ErrorEvent 以外が返るとイベントを破棄する
+    # （sentry-ruby 6.6.2 client.rb:243-251）。
+    it 'マスクに失敗したときはイベントを送らせない（nilを返す）' do
+      event = build_event(extra: active_job_extra)
+      allow(event).to receive(:extra=).and_raise(RuntimeError, 'マスク中の想定外エラー')
+
+      result = before_send.call(event, {})
+
+      expect(result).to be_nil
+    end
+
+    it 'マスクに失敗しても例外を外へ出さない（Sentry送信処理を壊さない）' do
+      event = build_event(extra: active_job_extra)
+      allow(event).to receive(:extra=).and_raise(RuntimeError, 'マスク中の想定外エラー')
 
       expect { before_send.call(event, {}) }.not_to raise_error
     end


### PR DESCRIPTION
## 背景

PR #465 で ActionMailer の本文ログを INFO 止まりにしましたが、`deliver_later` の `ActionMailer::MailDeliveryJob` にはパスワードリセット・メール認証用トークンが引数としてシリアライズされます。

Active Job は既定でそれらの引数を INFO ログに出すため、本文を抑止してもトークンが本番ログに残る可能性がありました。加えて、sentry-rails の ActiveJob 連携はジョブ例外時にジョブ引数を `extra` として Sentry へ送るため、`raise_delivery_errors = true`（#465）によりメール送信失敗のたびにこの経路が発火し、トークンが Sentry にも送信され得る状態でした。

## 対応

- production で `config.active_job.log_arguments = false` を設定し、serialized job arguments を本番ログに出さない
- `Sentry.configuration.before_send` に `SentryJobArgumentsFilter` を追加し、Active Job 由来の `extra.arguments` を `[FILTERED]` へ置換してから送信する
  - ジョブクラス名・Job ID・provider_job_id・例外情報・スタックトレースは保持し、調査に必要な情報は残す
  - フィルタ処理自体が想定外の例外で失敗した場合は、マスク前（生トークン入り）のイベントを送らないよう **fail-closed** とし、`before_send` は `nil` を返してイベント送信ごと破棄する
- 将来この設定・フィルタが消えないための回帰テストを追加

## 影響範囲

- **Sentry通知の挙動は変更します**：Active Job 例外イベントの `arguments` は `[FILTERED]` に置換されます。フィルタ処理自体が失敗した場合（想定外のケース）はイベントが送信されません（fail-closed）。ジョブクラス名・Job ID・例外内容は通常どおり届きます
- メール送信・ジョブ実行・HTTPレスポンスの挙動は変更しません
- 失われるのは本番ログ・Sentry通知上のジョブ引数だけです（トークン保護を優先）
- Render / Resend / Stripe / DB の外部設定変更なし

## 確認

- RSpec: 全 396 examples, 0 failures（`SENTRY_DSN` 未設定の CI相当環境、および設定済み環境の両方で確認）
- 対照実験として `SentryJobArgumentsFilter` を無効化した状態でも実行し、フィルタ関連テストが実際に失敗する（＝検知できる）ことを確認済み
- CIで Backend / Frontend / E2E も確認予定
