### PR TITLE
fix: パスワードリセット画面(/password-reset/:token)の404を解消

### DIFF
--- a/frontend/__tests__/app/password-reset/[token]/page.test.tsx
+++ b/frontend/__tests__/app/password-reset/[token]/page.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useParams } from "next/navigation";
+
+import PasswordResetPage from "@/app/(auth)/password-reset/[token]/page";
+import { confirmPasswordReset, ApiError } from "@/lib/apiClient";
+
+jest.mock("next/navigation", () => ({
+  useParams: jest.fn(),
+}));
+
+jest.mock("@/lib/apiClient", () => {
+  class MockApiError extends Error {
+    status = 0;
+  }
+  return {
+    __esModule: true,
+    confirmPasswordReset: jest.fn(),
+    ApiError: MockApiError,
+  };
+});
+
+const mockedUseParams = useParams as jest.MockedFunction<typeof useParams>;
+const mockedConfirmPasswordReset =
+  confirmPasswordReset as jest.MockedFunction<typeof confirmPasswordReset>;
+
+const fillPasswords = (password: string, confirmation: string) => {
+  fireEvent.change(
+    document.getElementById("reset-password") as HTMLInputElement,
+    { target: { value: password } }
+  );
+  fireEvent.change(
+    document.getElementById(
+      "reset-password-confirmation"
+    ) as HTMLInputElement,
+    { target: { value: confirmation } }
+  );
+};
+
+const submit = () =>
+  fireEvent.click(
+    screen.getByRole("button", { name: "パスワードを変更する" })
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedUseParams.mockReturnValue({
+    token: "abc123token",
+  } as ReturnType<typeof useParams>);
+});
+
+describe("PasswordResetPage", () => {
+  it("URLのtokenと入力値でPATCH /password_resets/:tokenを呼ぶ", async () => {
+    mockedConfirmPasswordReset.mockResolvedValue({ message: "ok" });
+    render(<PasswordResetPage />);
+
+    fillPasswords("newpass123", "newpass123");
+    submit();
+
+    await waitFor(() => {
+      expect(mockedConfirmPasswordReset).toHaveBeenCalledWith(
+        "abc123token",
+        { password: "newpass123", password_confirmation: "newpass123" }
+      );
+    });
+  });
+
+  it("成功時は成功メッセージとログイン画面へのリンクを表示する", async () => {
+    mockedConfirmPasswordReset.mockResolvedValue({ message: "ok" });
+    render(<PasswordResetPage />);
+
+    fillPasswords("newpass123", "newpass123");
+    submit();
+
+    expect(
+      await screen.findByText(/パスワードを変更しました/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "ログイン画面へ" })
+    ).toHaveAttribute("href", "/login");
+  });
+
+  it("パスワードが一致しない場合はAPIを呼ばずエラーを表示する", async () => {
+    render(<PasswordResetPage />);
+
+    fillPasswords("newpass123", "different123");
+    submit();
+
+    expect(
+      await screen.findByText(
+        "パスワードが ちがっているみたい。もういちど みてみよう。"
+      )
+    ).toBeInTheDocument();
+    expect(mockedConfirmPasswordReset).not.toHaveBeenCalled();
+  });
+
+  it("パスワードが8文字未満の場合はAPIを呼ばずエラーを表示する", async () => {
+    render(<PasswordResetPage />);
+
+    fillPasswords("short1", "short1");
+    submit();
+
+    expect(
+      await screen.findByText("パスワードは 8もじ いじょうで いれてね。")
+    ).toBeInTheDocument();
+    expect(mockedConfirmPasswordReset).not.toHaveBeenCalled();
+  });
+
+  it("バックエンドが無効・期限切れトークンのエラーを返したらそのメッセージを表示する", async () => {
+    mockedConfirmPasswordReset.mockRejectedValue(
+      new ApiError("無効または期限切れのトークンです。")
+    );
+    render(<PasswordResetPage />);
+
+    fillPasswords("newpass123", "newpass123");
+    submit();
+
+    expect(
+      await screen.findByText("無効または期限切れのトークンです。")
+    ).toBeInTheDocument();
+  });
+
+  it("URLにtokenが無い場合は送信ボタンがdisabledでエラー案内を表示する", () => {
+    mockedUseParams.mockReturnValue({} as ReturnType<typeof useParams>);
+    render(<PasswordResetPage />);
+
+    expect(
+      screen.getByRole("button", { name: "パスワードを変更する" })
+    ).toBeDisabled();
+    expect(
+      screen.getByText(
+        "リンクが正しくないみたい。もう一度メールのリンクを確認してね。"
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/app/(auth)/password-reset/[token]/page.tsx
+++ b/frontend/app/(auth)/password-reset/[token]/page.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { confirmPasswordReset, ApiError } from "@/lib/apiClient";
+
+const defaultResetError =
+  "うまく へんこうできなかったよ。もういちど ためしてね。";
+const invalidTokenError =
+  "リンクが正しくないみたい。もう一度メールのリンクを確認してね。";
+
+export default function PasswordResetPage() {
+  const params = useParams();
+  const rawToken = params?.token;
+  const token = typeof rawToken === "string" ? rawToken : "";
+
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [error, setError] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError("");
+    setSuccessMessage("");
+
+    if (isLoading) return;
+
+    if (!token) {
+      setError(invalidTokenError);
+      return;
+    }
+    if (!password || !passwordConfirmation) {
+      setError("まだ はいっていない ところが あるよ。");
+      return;
+    }
+    if (password.length < 8) {
+      setError("パスワードは 8もじ いじょうで いれてね。");
+      return;
+    }
+    if (!/[a-zA-Z]/.test(password) || !/[0-9]/.test(password)) {
+      setError("パスワードに えいじ と すうじ を いれてね。");
+      return;
+    }
+    if (password !== passwordConfirmation) {
+      setError("パスワードが ちがっているみたい。もういちど みてみよう。");
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      await confirmPasswordReset(token, {
+        password,
+        password_confirmation: passwordConfirmation,
+      });
+      setSuccessMessage(
+        "パスワードを変更しました。新しいパスワードでログインしてください。"
+      );
+      setPassword("");
+      setPasswordConfirmation("");
+    } catch (err) {
+      if (err instanceof ApiError && err.message) {
+        setError(err.message);
+      } else {
+        setError(defaultResetError);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-background text-foreground px-4 sm:px-6 lg:px-8">
+      <form
+        onSubmit={handleSubmit}
+        noValidate
+        className="bg-card p-6 sm:p-8 md:p-10 rounded-lg shadow-lg w-full max-w-md border border-border"
+      >
+        <h2 className="text-2xl md:text-3xl font-semibold mb-4 md:mb-6 text-center text-card-foreground">
+          新しいパスワードを設定
+        </h2>
+
+        {successMessage ? (
+          <>
+            <p className="text-green-600 text-center" aria-live="polite">
+              {successMessage}
+            </p>
+            <div className="mt-6 text-center text-sm">
+              <Link
+                href="/login"
+                className="font-medium text-primary hover:underline"
+              >
+                ログイン画面へ
+              </Link>
+            </div>
+          </>
+        ) : (
+          <>
+            {!token && (
+              <p
+                className="text-destructive text-center mb-4"
+                aria-live="assertive"
+              >
+                {invalidTokenError}
+              </p>
+            )}
+            <div className="space-y-4">
+              <div>
+                <label
+                  htmlFor="reset-password"
+                  className="mb-2 block text-sm font-medium text-card-foreground"
+                >
+                  新しいパスワード
+                </label>
+                <div className="relative">
+                  <input
+                    id="reset-password"
+                    type={showPassword ? "text" : "password"}
+                    name="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="8もじ いじょう"
+                    aria-describedby="password-hint"
+                    autoComplete="new-password"
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    spellCheck={false}
+                    required
+                    aria-required="true"
+                    aria-invalid={error ? "true" : "false"}
+                    className="w-full px-4 py-2 pr-12 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-ring"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword((v) => !v)}
+                    aria-label={
+                      showPassword ? "パスワードを隠す" : "パスワードを表示"
+                    }
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+                  >
+                    {showPassword ? "🙈" : "👁"}
+                  </button>
+                </div>
+                {password.length > 0 ? (
+                  <ul
+                    id="password-hint"
+                    className="mt-2 ml-1 space-y-1 text-xs"
+                    aria-label="パスワードの条件"
+                  >
+                    {[
+                      { ok: password.length >= 8, label: "8もじ いじょう" },
+                      {
+                        ok: /[a-zA-Z]/.test(password),
+                        label: "えいじ（a〜z）を ふくむ",
+                      },
+                      {
+                        ok: /[0-9]/.test(password),
+                        label: "すうじ（0〜9）を ふくむ",
+                      },
+                    ].map(({ ok, label }) => (
+                      <li
+                        key={label}
+                        className={`flex items-center gap-1.5 transition-colors ${
+                          ok ? "text-green-500" : "text-muted-foreground"
+                        }`}
+                      >
+                        <span aria-hidden="true" className="font-bold">
+                          {ok ? "✓" : "○"}
+                        </span>
+                        {label}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p
+                    id="password-hint"
+                    className="text-xs text-muted-foreground mt-1 ml-1"
+                  >
+                    8文字以上・英字と数字をそれぞれ含む
+                  </p>
+                )}
+              </div>
+              <div>
+                <label
+                  htmlFor="reset-password-confirmation"
+                  className="mb-2 block text-sm font-medium text-card-foreground"
+                >
+                  新しいパスワード（確認）
+                </label>
+                <div className="relative">
+                  <input
+                    id="reset-password-confirmation"
+                    type={showConfirmPassword ? "text" : "password"}
+                    name="password_confirmation"
+                    value={passwordConfirmation}
+                    onChange={(e) => setPasswordConfirmation(e.target.value)}
+                    placeholder="もういちど いれてね"
+                    autoComplete="new-password"
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    spellCheck={false}
+                    required
+                    aria-label="パスワード確認"
+                    aria-required="true"
+                    aria-invalid={error ? "true" : "false"}
+                    className="w-full px-4 py-2 pr-12 border border-input bg-background text-foreground rounded-lg focus:outline-none focus:ring-2 focus:ring-ring"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowConfirmPassword((v) => !v)}
+                    aria-label={
+                      showConfirmPassword
+                        ? "パスワード確認を隠す"
+                        : "パスワード確認を表示"
+                    }
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+                  >
+                    {showConfirmPassword ? "🙈" : "👁"}
+                  </button>
+                </div>
+              </div>
+              <button
+                type="submit"
+                disabled={isLoading || !token}
+                className="w-full py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring active:bg-primary/80 transition-colors duration-200 ease-in-out disabled:opacity-50"
+              >
+                {isLoading ? "へんこう中..." : "パスワードを変更する"}
+              </button>
+            </div>
+            {error && (
+              <p
+                className="text-destructive mt-4 text-center"
+                aria-live="assertive"
+              >
+                {error}
+              </p>
+            )}
+            <div className="mt-6 text-center text-sm">
+              <Link
+                href="/login"
+                className="font-medium text-primary hover:underline"
+              >
+                ログイン画面へ戻る
+              </Link>
+            </div>
+          </>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/frontend/lib/apiClient.ts
+++ b/frontend/lib/apiClient.ts
@@ -364,6 +364,22 @@ export async function clientLogout(): Promise<null> {
   });
 }
 
+// パスワードリセットメール内のリンク（/password-reset/:token）から呼ばれる。
+// トークンは使い切り・60分制限で、無効/期限切れ/使用済みのいずれも
+// バックエンドが同じ { error: '無効または期限切れのトークンです。' } を返す。
+export async function confirmPasswordReset(
+  token: string,
+  credentials: { password: string; password_confirmation: string }
+): Promise<{ message: string }> {
+  return apiFetch<{ message: string }>(
+    `/password_resets/${encodeURIComponent(token)}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(credentials),
+    }
+  );
+}
+
 export async function getEmotions(): Promise<Emotion[]> {
   return apiFetch("/emotions");
 }


### PR DESCRIPTION
## 背景
本番でパスワードリセットメールのリンクをクリックすると404になる不具合を調査したところ、原因はSMTPやRailsではなく、リンク先 `/password-reset/:token` に対応するフロント画面がそもそも存在しないことだった。

バックエンドの `PATCH /password_resets/:token`（backend/app/controllers/password_resets_controller.rb）は既に実装済みで、対応するフロント画面のみが欠けていた。

## 変更内容
- `frontend/app/(auth)/password-reset/[token]/page.tsx` を新規作成
  - URLからtokenを取得（`useParams`、`forest/[profileId]/page.tsx` と同じ既存パターン）
  - 新パスワード・確認用パスワードの入力、クライアント側一致確認
  - `PATCH /password_resets/:token` 呼び出し、成功時はログイン画面へ案内
  - 無効/期限切れ/使用済みトークンはバックエンドの共通エラーメッセージをそのまま表示
  - token・パスワードはログ出力しない
- `frontend/lib/apiClient.ts` に `confirmPasswordReset(token, credentials)` を追加
- `frontend/__tests__/app/password-reset/[token]/page.test.tsx` を新規追加（6ケース）

## 動作確認
- Jest: 新規6件 + 既存の関連テスト（forgot-password/register/login）すべて成功
- ローカルDocker + 実トークンでブラウザ確認済み: 画面表示 → PATCH成功 → ログイン画面 → 新パスワードでログイン → ホーム到達 まで一連の動線を確認

## 未確認事項（このPRの範囲外）
- 本番Vercelへの反映後の実メールからの動線確認
- Render側のSMTP設定（`SMTP_PORT`）は別途調査済み・このPRでは変更していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)