### PR TITLE
fix: 夢本文が本番ログに残らないよう是正する

### DIFF
--- a/backend/app/controllers/dreams_controller.rb
+++ b/backend/app/controllers/dreams_controller.rb
@@ -92,9 +92,10 @@ class DreamsController < ApplicationController
 
   # POST /dreams
   def create
+    # 夢のタイトル・本文は機微な自由記述のため、paramsの全文をログへ出さない
+    # （filter_parameter_logging.rb で :title / :content をマスク対象にしている）。
     Rails.logger.info "DreamsController#create called"
-    Rails.logger.info "Params: #{params.inspect}"
-    
+
     # 音声ファイルがあるかどうかで処理を分岐
     if params[:dream][:audio].present?
       @dream = current_user.dreams.build(

--- a/backend/config/initializers/filter_parameter_logging.rb
+++ b/backend/config/initializers/filter_parameter_logging.rb
@@ -6,8 +6,12 @@
 # セキュリティ強化：認証情報・機密データのログフィルタリング
 Rails.application.config.filter_parameters += [
   :passw, :password, :password_confirmation,
-  :secret, :token, :access_token, :refresh_token, 
+  :secret, :token, :access_token, :refresh_token,
   :authorization, :bearer, :api_key,
   :_key, :crypt, :salt, :certificate, :otp, :ssn,
-  :email, :phone, :jwt, :session_id
+  :email, :phone, :jwt, :session_id,
+  # 夢日記の本文はユーザーの機微な自由記述のため、Railsの自動リクエストログ
+  # （Parameters: {...}）に出さない。DreamsController#create の手動ログは
+  # 別途削除済みだが、こちらは他コントローラ・将来の変更に対する保険。
+  :title, :content
 ]

--- a/backend/spec/config/dream_body_logging_spec.rb
+++ b/backend/spec/config/dream_body_logging_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+# 夢のタイトル・本文がユーザーの機微な自由記述であるにもかかわらず、
+# 本番ログに平文で残っていた問題への回帰テスト。
+#
+# 原因は2つあった：
+# (1) DreamsController#create が `Rails.logger.info "Params: #{params.inspect}"`
+#     を無条件に実行し、paramsの全内容（夢の本文含む）をそのままログへ出していた。
+# (2) filter_parameters に :title / :content が含まれておらず、Railsが自動で出す
+#     「Parameters: {...}」ログ（ActionController::LogSubscriberによるもの）でも
+#     マスクされない状態だった。
+#
+# (1)は該当の手動ログ呼び出しを削除して対応し、(2)はfilter_parametersへ追加して対応した。
+RSpec.describe '夢本文が本番ログに残らないための保護' do
+  # 本物の夢の内容とは混同しない合成マーカー。
+  SYNTHETIC_TITLE   = 'SYNTHETIC_DREAM_TITLE_DO_NOT_LEAK'.freeze
+  SYNTHETIC_CONTENT = 'SYNTHETIC_DREAM_CONTENT_DO_NOT_LEAK'.freeze
+
+  describe '設定値そのもの（filter_parameters）' do
+    it 'filter_parameters に :title と :content が含まれている' do
+      expect(Rails.application.config.filter_parameters).to include(:title, :content)
+    end
+
+    it 'ActiveSupport::ParameterFilter で実際にマスクされる' do
+      filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+      filtered = filter.filter(title: SYNTHETIC_TITLE, content: SYNTHETIC_CONTENT)
+
+      expect(filtered[:title]).to eq('[FILTERED]')
+      expect(filtered[:content]).to eq('[FILTERED]')
+    end
+
+    # 「この設定が無いと本当に漏れる」ことを示す対照実験。
+    # これが失敗するようになったら、フィルタ以外の仕組みで保護されていることになるので、
+    # テストの前提を見直す合図になる。
+    it '対照実験: :title / :content を外すとマスクされない（検知力の確認）' do
+      filter = ActiveSupport::ParameterFilter.new(
+        Rails.application.config.filter_parameters - [:title, :content]
+      )
+      filtered = filter.filter(title: SYNTHETIC_TITLE, content: SYNTHETIC_CONTENT)
+
+      expect(filtered[:title]).to eq(SYNTHETIC_TITLE)
+      expect(filtered[:content]).to eq(SYNTHETIC_CONTENT)
+    end
+  end
+
+  describe 'POST /dreams の実際のログ出力（動作ベース）', type: :request do
+    let!(:user) { create(:user, :with_self_profile) }
+    let(:log_output) { StringIO.new }
+
+    around do |example|
+      original_logger = Rails.logger
+
+      captured_logger = ActiveSupport::Logger.new(log_output)
+      captured_logger.level = Logger::DEBUG
+      Rails.logger = captured_logger
+      # ActionController::Base はRailtieの起動時にRails.loggerを一度キャプチャして
+      # 保持しているため、コントローラ側のロガーも明示的に差し替える。
+      ActionController::Base.logger = captured_logger
+
+      example.run
+    ensure
+      Rails.logger = original_logger
+      ActionController::Base.logger = original_logger
+    end
+
+    it '夢の本文（合成マーカー）がログに出ない' do
+      authenticated_post(
+        '/dreams',
+        user,
+        params: { dream: { title: SYNTHETIC_TITLE, content: SYNTHETIC_CONTENT } }
+      )
+
+      expect(response).to have_http_status(:created)
+      expect(log_output.string).not_to include(SYNTHETIC_TITLE)
+      expect(log_output.string).not_to include(SYNTHETIC_CONTENT)
+    end
+
+    it 'リクエスト自体のログは残る（調査に必要な情報まで消していないことの確認）' do
+      authenticated_post(
+        '/dreams',
+        user,
+        params: { dream: { title: SYNTHETIC_TITLE, content: SYNTHETIC_CONTENT } }
+      )
+
+      expect(log_output.string).to include('DreamsController#create called')
+      expect(log_output.string).to match(/Started POST "\/dreams"/)
+    end
+  end
+end


### PR DESCRIPTION
## 背景
8月スプリント計画（Codex監査）で発見。`DreamsController#create`が
`Rails.logger.info "Params: #{params.inspect}"`を無条件（本番含む）で実行しており、
ユーザーの夢のタイトル・本文がそのまま本番ログに残っていた。
`filter_parameters`にも`:title`/`:content`が含まれておらず、Railsが自動生成する
「Parameters: {...}」ログでも保護されていなかった。

## 変更内容
- `backend/app/controllers/dreams_controller.rb`: 該当の手動ログ呼び出し（`Params: #{params.inspect}`）を削除
- `backend/config/initializers/filter_parameter_logging.rb`: `:title`・`:content`を`filter_parameters`に追加（保険）
- `backend/spec/config/dream_body_logging_spec.rb`: 新規回帰テスト
  - `filter_parameters`の設定値そのものの確認＋対照実験（外すとマスクされないことも確認）
  - 実際に`POST /dreams`を叩き、Railsロガーを捕まえて合成マーカーがログに出ないことを確認
  - 調査に必要な情報（コントローラ名・リクエストログ）までは消えていないことも確認

## 動作確認
```
bundle exec rspec spec/config/dream_body_logging_spec.rb spec/requests/dreams_spec.rb
95 examples, 0 failures
```

## スコープ外
- CSRF対策は別PRで対応（このPRには含まない）
- パスワードリセット/メール確認トークンのURL露出対策は別途検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)