### PR TITLE
fix: 状態変更系APIにOrigin検証によるCSRF対策を追加する

### DIFF
--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -3,11 +3,46 @@ class ApplicationController < ActionController::API
   # ActionController::API を継承する場合、CSRF保護はデフォルトで無効になります。
   # これにより、APIへのJSONリクエストがCSRFチェックでブロックされる問題が根本的に解決します。
   # 必要なモジュールは、上記のように個別に include します。
-
+  #
+  # その代わりとして、状態変更系リクエストのOrigin（送信元）を検証するCSRF対策を行う。
+  # 認証チェックより先に効かせるため、before_actionの宣言順を authorize_request より前にする。
+  # Stripe Webhook（サーバー間通信でOriginヘッダーを持たない）は
+  # WebhooksController 側で skip_before_action している。
+  before_action :verify_request_origin!
   before_action :authorize_request
   attr_reader :current_user
 
   private
+
+  # GET/HEAD以外（状態変更系）のリクエストについて、Origin（無ければReferer）が
+  # 許可オリジン一覧（AllowedOrigins、cors.rbと共有）に含まれているかを確認する。
+  # Rails APIモードはCSRF保護がデフォルト無効なため、これがCSRF対策の実体となる。
+  def verify_request_origin!
+    return if request.get? || request.head? || request.options?
+
+    source = request.headers['Origin'].presence || origin_from_referer
+
+    return if source.present? && AllowedOrigins.list.include?(source)
+
+    Rails.logger.warn(
+      "[CSRF] 許可されていないOriginからの#{request.method}リクエストを拒否 " \
+      "path=#{request.path} origin=#{source.inspect}"
+    )
+    render json: { error: '不正なリクエスト元からの操作は許可されていません。' }, status: :forbidden
+  end
+
+  def origin_from_referer
+    referer = request.headers['Referer']
+    return nil if referer.blank?
+
+    uri = URI.parse(referer)
+    return nil unless uri.scheme && uri.host
+
+    port_suffix = uri.port && uri.port != uri.default_port ? ":#{uri.port}" : ''
+    "#{uri.scheme}://#{uri.host}#{port_suffix}"
+  rescue URI::InvalidURIError
+    nil
+  end
 
   # リクエストを認証する
   def authorize_request

--- a/backend/app/controllers/webhooks_controller.rb
+++ b/backend/app/controllers/webhooks_controller.rb
@@ -6,6 +6,9 @@ class WebhooksController < ApplicationController
   # verify_authenticity_token のスキップは不要。
   # JWT認証のみスキップする（WebhookはStripeサーバーが叩くため）
   skip_before_action :authorize_request, only: [:stripe]
+  # StripeはOriginヘッダーを送らないサーバー間通信のため、Origin検証も対象外にする。
+  # 正当性は署名検証（Stripe-Signatureヘッダー、下記）で担保している。
+  skip_before_action :verify_request_origin!, only: [:stripe]
 
   # POST /webhooks/stripe
   def stripe

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -1,12 +1,10 @@
 # cors.rb は、バックエンドさんのお家の「セキュリティ設定ファイル」です
 
-# 環境変数から許可するオリジン（お友達の住所）のリストを作る
-allow_origins = ENV.fetch("ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:8000").split(",").map(&:strip).reject(&:empty?)
-
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     # 「お知らせ掲示板」に書いてあるお友達の住所を、門番に渡す
-    origins(*allow_origins)
+    # （ApplicationController#verify_request_origin! と同じ一覧を共有している）
+    origins(*AllowedOrigins.list)
 
     # どのリソース（URL）に対して、どのHTTPメソッドを許可するかなどを設定します
     resource '*',

--- a/backend/lib/allowed_origins.rb
+++ b/backend/lib/allowed_origins.rb
@@ -1,0 +1,10 @@
+# CORS(cors.rb)とCSRF由来のOrigin検証(ApplicationController#verify_request_origin!)の
+# 両方が、同じ「許可オリジン一覧」を参照する必要があるため、一箇所にまとめている。
+module AllowedOrigins
+  def self.list
+    ENV.fetch("ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:8000")
+       .split(",")
+       .map(&:strip)
+       .reject(&:empty?)
+  end
+end

--- a/backend/spec/requests/csrf_origin_protection_spec.rb
+++ b/backend/spec/requests/csrf_origin_protection_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+# Rails APIモード（ActionController::API）はCSRF保護がデフォルトで無効なため、
+# 状態変更系リクエストのOrigin（無ければReferer）検証で代替している
+# （ApplicationController#verify_request_origin!）。
+#
+# 8月スプリント計画のCodex監査で発見：CORSはcredentials: trueかつ許可オリジン限定だが、
+# 「レスポンスをJSから読めない」ことしか保証せず、「副作用が起きること」自体は防げない。
+# 本番はSameSite=NoneのCookie認証のため、悪意あるサイトからの単純なフォーム送信が
+# 理論上のCSRFになりうる、という指摘への対応。
+RSpec.describe 'CSRFのOrigin検証（状態変更系リクエスト）', type: :request do
+  let!(:user) { create(:user, :with_self_profile) }
+  let(:allowed_origin) { 'http://localhost:3000' }
+  let(:forged_origin)  { 'https://evil.example.com' }
+
+  describe '偽装Originからの状態変更リクエストを拒否する' do
+    it 'POSTを403で拒否する（例: /dreams）' do
+      expect {
+        authenticated_post_with_origin('/dreams', user, forged_origin,
+                                        params: { dream: { title: 't', content: 'c' } })
+      }.not_to change(Dream, :count)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(json_response['error']).to be_present
+    end
+
+    it 'PATCHを403で拒否する（例: /auth/me）' do
+      authenticated_patch_with_origin('/auth/me', user, forged_origin,
+                                       params: { user: { username: 'renamed' } })
+
+      expect(response).to have_http_status(:forbidden)
+      expect(user.reload.username).not_to eq('renamed')
+    end
+
+    it 'DELETEを403で拒否する（例: /dreams/:id）' do
+      dream = create(:dream, user: user)
+
+      expect {
+        delete "/dreams/#{dream.id}",
+               headers: { 'HOST' => 'backend', 'Origin' => forged_origin, 'Cookie' => "access_token=#{login_token_for(user)}" }
+      }.not_to change(Dream, :count)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'Originが無くても、許可されていないRefererなら拒否する' do
+      # spec/support/default_origin_header.rb が既定Originを補うため、
+      # 「Originが無い」状況を再現するために明示的にnilで上書きする。
+      post '/dreams',
+           params: { dream: { title: 't', content: 'c' } },
+           as: :json,
+           headers: {
+             'HOST' => 'backend',
+             'Origin' => nil,
+             'Referer' => 'https://evil.example.com/attack.html',
+             'Cookie' => "access_token=#{login_token_for(user)}"
+           }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'OriginもRefererも無い状態変更リクエストは拒否する' do
+      post '/dreams',
+           params: { dream: { title: 't', content: 'c' } },
+           as: :json,
+           headers: { 'HOST' => 'backend', 'Origin' => nil, 'Cookie' => "access_token=#{login_token_for(user)}" }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it '認証が必要なアクションに限らず、未認証の公開POST（/auth/login）も拒否する' do
+      post '/auth/login',
+           params: { email: user.email, password: 'password123' },
+           as: :json,
+           headers: { 'HOST' => 'backend', 'Origin' => forged_origin }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe '許可されたOriginからは通常どおり動作する（回帰確認）' do
+    it 'GETはOriginチェックの対象外（そもそも状態を変えない）' do
+      get '/dreams', headers: { 'HOST' => 'backend', 'Cookie' => "access_token=#{login_token_for(user)}" }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it '許可Originからのpostは通常どおり成功する' do
+      expect {
+        authenticated_post_with_origin('/dreams', user, allowed_origin,
+                                        params: { dream: { title: 't', content: 'c' } })
+      }.to change(Dream, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+    end
+  end
+
+  describe 'Stripe Webhookは対象外（サーバー間通信でOriginを送らないため）' do
+    it 'Originヘッダーが無くても、Origin検証では拒否されない（署名検証で別途弾かれる）' do
+      post '/webhooks/stripe', params: '{}', headers: { 'HOST' => 'backend', 'Content-Type' => 'application/json' }
+
+      # STRIPE_WEBHOOK_SECRET未設定 or 署名不一致で失敗するが、
+      # 少なくとも「Origin検証由来の403」ではないことを確認する
+      expect(response).not_to have_http_status(:forbidden)
+    end
+  end
+
+  private
+
+  def login_token_for(user)
+    post '/auth/login',
+         params: { email: user.email, password: 'password123' },
+         as: :json,
+         headers: { 'HOST' => 'backend', 'Origin' => allowed_origin }
+    response.cookies['access_token']
+  end
+
+  def authenticated_post_with_origin(path, user, origin, params:)
+    post path, params: params, as: :json,
+               headers: { 'HOST' => 'backend', 'Origin' => origin, 'Cookie' => "access_token=#{login_token_for(user)}" }
+  end
+
+  def authenticated_patch_with_origin(path, user, origin, params:)
+    patch path, params: params, as: :json,
+                headers: { 'HOST' => 'backend', 'Origin' => origin, 'Cookie' => "access_token=#{login_token_for(user)}" }
+  end
+end

--- a/backend/spec/support/auth_helpers.rb
+++ b/backend/spec/support/auth_helpers.rb
@@ -1,8 +1,11 @@
 module AuthHelpers
+  # Origin検証（ApplicationController#verify_request_origin!）は
+  # spec/support/default_origin_header.rb が既定Originを補ってくれるため、ここでは何もしない。
+
   # ユーザーをログインさせてCookieトークンを取得する
   def login_user(user)
     post '/auth/login', params: { email: user.email, password: 'password123' }, as: :json, headers: { 'HOST' => 'backend' }
-    
+
     expect(response).to have_http_status(:ok)
     response.cookies['access_token']
   end

--- a/backend/spec/support/default_origin_header.rb
+++ b/backend/spec/support/default_origin_header.rb
@@ -1,0 +1,18 @@
+# ApplicationController#verify_request_origin!（CSRF対策のOrigin検証）を、
+# 個々のrequest specがいちいち意識しなくて済むよう、既定でOriginヘッダーを送る。
+# 偽装Originを検証したいテスト（csrf_origin_protection_spec.rb等）は、
+# headers: { 'Origin' => '...' } を明示的に渡せば上書きできる。
+module DefaultOriginHeader
+  DEFAULT_ORIGIN = 'http://localhost:3000'.freeze
+
+  %i[get post put patch delete].each do |verb|
+    define_method(verb) do |path, **options|
+      options[:headers] = { 'Origin' => DEFAULT_ORIGIN }.merge(options[:headers] || {})
+      super(path, **options)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include DefaultOriginHeader, type: :request
+end

--- a/frontend/__tests__/app/api/checkout/request-origin.test.ts
+++ b/frontend/__tests__/app/api/checkout/request-origin.test.ts
@@ -1,0 +1,52 @@
+import { forwardedOriginHeaders } from "@/app/api/checkout/request-origin";
+
+describe("forwardedOriginHeaders", () => {
+  const makeRequest = (headers: Record<string, string | null>) =>
+    ({
+      headers: { get: (key: string) => headers[key.toLowerCase()] ?? null },
+    }) as unknown as Request;
+
+  it("Originがあればそのまま転送する", () => {
+    const req = makeRequest({ origin: "https://dreamjournal-app.vercel.app" });
+
+    expect(forwardedOriginHeaders(req)).toEqual({
+      Origin: "https://dreamjournal-app.vercel.app",
+    });
+  });
+
+  it("Refererがあればそのまま転送する", () => {
+    const req = makeRequest({
+      referer: "https://dreamjournal-app.vercel.app/subscription",
+    });
+
+    expect(forwardedOriginHeaders(req)).toEqual({
+      Referer: "https://dreamjournal-app.vercel.app/subscription",
+    });
+  });
+
+  it("両方あれば両方転送する", () => {
+    const req = makeRequest({
+      origin: "https://dreamjournal-app.vercel.app",
+      referer: "https://dreamjournal-app.vercel.app/subscription",
+    });
+
+    expect(forwardedOriginHeaders(req)).toEqual({
+      Origin: "https://dreamjournal-app.vercel.app",
+      Referer: "https://dreamjournal-app.vercel.app/subscription",
+    });
+  });
+
+  it("偽装されたOrigin/Refererでもそのまま転送する（検証はRails側の責務）", () => {
+    const req = makeRequest({ origin: "https://evil.example.com" });
+
+    expect(forwardedOriginHeaders(req)).toEqual({
+      Origin: "https://evil.example.com",
+    });
+  });
+
+  it("どちらも無ければ空オブジェクトを返す", () => {
+    const req = makeRequest({});
+
+    expect(forwardedOriginHeaders(req)).toEqual({});
+  });
+});

--- a/frontend/__tests__/app/api/checkout/route.test.ts
+++ b/frontend/__tests__/app/api/checkout/route.test.ts
@@ -1,0 +1,82 @@
+import { POST } from "@/app/api/checkout/route";
+
+// 退行防止テスト: Next.jsルートハンドラ→Railsへのサーバー間fetchで
+// ブラウザのOrigin/Refererが失われ、RailsのCSRF対策（Origin検証）に
+// 弾かれて本番のcheckoutが壊れていた問題（Codexレビューで指摘）への回帰テスト。
+const originalEnv = process.env;
+const originalResponse = global.Response;
+const fetchMock = jest.fn<typeof fetch>();
+
+describe("POST /api/checkout", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv, INTERNAL_API_URL: "https://api.example.com" };
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    global.Response = {
+      json: (body: unknown, init?: ResponseInit) =>
+        ({
+          status: init?.status ?? 200,
+          json: async () => body,
+        }) as Response,
+    } as typeof Response;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+    global.Response = originalResponse;
+  });
+
+  const makeRequest = (headers: Record<string, string | null>) =>
+    ({
+      headers: { get: (key: string) => headers[key.toLowerCase()] ?? null },
+      text: async () => "{}",
+      json: async () => ({}),
+    }) as unknown as Request;
+
+  it("ブラウザのOriginをRailsへのリクエストに転送する", async () => {
+    fetchMock.mockResolvedValue({
+      status: 200,
+      json: async () => ({ url: "https://checkout.stripe.com/xxx" }),
+    } as unknown as Response);
+
+    await POST(
+      makeRequest({
+        cookie: "access_token=token-value",
+        origin: "https://dreamjournal-app.vercel.app",
+      })
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/checkout",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Origin: "https://dreamjournal-app.vercel.app",
+        }),
+      })
+    );
+  });
+
+  it("Originが無くRefererのみの場合はRefererを転送する", async () => {
+    fetchMock.mockResolvedValue({
+      status: 200,
+      json: async () => ({}),
+    } as unknown as Response);
+
+    await POST(
+      makeRequest({
+        cookie: "access_token=token-value",
+        referer: "https://dreamjournal-app.vercel.app/subscription",
+      })
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/checkout",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Referer: "https://dreamjournal-app.vercel.app/subscription",
+        }),
+      })
+    );
+  });
+});

--- a/frontend/app/api/analyze_audio_dream/route.ts
+++ b/frontend/app/api/analyze_audio_dream/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { resolveBackendUrl } from "../checkout/backend-url";
+import { forwardedOriginHeaders } from "../checkout/request-origin";
 
 const BACKEND_URL = resolveBackendUrl();
 
@@ -60,6 +61,8 @@ export async function POST(req: NextRequest) {
         // 認証情報をCookie経由でバックエンドに渡す
         headers: {
           cookie: req.headers.get("cookie") ?? "",
+          // RailsのCSRF対策（Origin検証）を通すため、ブラウザが送ってきたOrigin/Refererを転送する
+          ...forwardedOriginHeaders(req),
         },
         signal: controller.signal,
       });

--- a/frontend/app/api/auth/refresh/route.ts
+++ b/frontend/app/api/auth/refresh/route.ts
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import { resolveBackendUrl } from "@/app/api/checkout/backend-url";
+import { forwardedOriginHeaders } from "@/app/api/checkout/request-origin";
 
 export const runtime = "nodejs";
 
@@ -24,6 +25,8 @@ export async function GET(req: NextRequest) {
       method: "POST",
       headers: {
         Cookie: `refresh_token=${refreshToken}`,
+        // RailsのCSRF対策（Origin検証）を通すため、ブラウザが送ってきたOrigin/Refererを転送する
+        ...forwardedOriginHeaders(req),
       },
       cache: "no-store",
     });

--- a/frontend/app/api/billing-portal/route.ts
+++ b/frontend/app/api/billing-portal/route.ts
@@ -1,4 +1,5 @@
 import { resolveBackendUrl } from "../checkout/backend-url";
+import { forwardedOriginHeaders } from "../checkout/request-origin";
 
 export const runtime = "nodejs";
 
@@ -19,6 +20,8 @@ export async function POST(req: Request) {
       headers: {
         "Content-Type": "application/json",
         Cookie: req.headers.get("cookie") ?? "",
+        // RailsのCSRF対策（Origin検証）を通すため、ブラウザが送ってきたOrigin/Refererを転送する
+        ...forwardedOriginHeaders(req),
       },
       signal: controller.signal,
     });

--- a/frontend/app/api/checkout/request-origin.ts
+++ b/frontend/app/api/checkout/request-origin.ts
@@ -1,0 +1,18 @@
+// ブラウザ → Next.jsルートハンドラ（1段目）→ Rails（2段目のサーバー間fetch）という
+// 二段プロキシでは、2段目はNode.jsのfetchであり、ブラウザのように自動でOriginヘッダーを
+// 付けない。RailsのCSRF対策（ApplicationController#verify_request_origin!、Origin検証）は
+// この2段目にもOrigin/Refererを要求するため、1段目でブラウザが実際に送ってきた
+// Origin/Refererをそのまま2段目へ転送する必要がある。
+//
+// 偽装されたOrigin/Refererであってもそのまま転送する（=Rails側で正しく拒否させる）。
+// ここで検証や書き換えは行わない — 検証はRails側の責務のまま。
+export function forwardedOriginHeaders(req: Request): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const origin = req.headers.get("origin");
+  const referer = req.headers.get("referer");
+
+  if (origin) headers["Origin"] = origin;
+  if (referer) headers["Referer"] = referer;
+
+  return headers;
+}

--- a/frontend/app/api/checkout/route.ts
+++ b/frontend/app/api/checkout/route.ts
@@ -1,4 +1,5 @@
 import { resolveBackendUrl } from "./backend-url";
+import { forwardedOriginHeaders } from "./request-origin";
 
 // Sentry OpenTelemetry との互換性のため、Node.js Runtime を使用
 export const runtime = "nodejs";
@@ -26,6 +27,8 @@ export async function POST(req: Request) {
         "Content-Type": "application/json",
         // JWT認証のためCookieをバックエンドへ転送する（checkout はログイン必須）
         Cookie: req.headers.get("cookie") ?? "",
+        // RailsのCSRF対策（Origin検証）を通すため、ブラウザが送ってきたOrigin/Refererを転送する
+        ...forwardedOriginHeaders(req),
       },
       body: requestBody || undefined,
       signal: controller.signal,

--- a/frontend/app/api/dreams/month/[yearMonth]/ai-summary/route.ts
+++ b/frontend/app/api/dreams/month/[yearMonth]/ai-summary/route.ts
@@ -1,4 +1,5 @@
 import { resolveBackendUrl } from "@/app/api/checkout/backend-url";
+import { forwardedOriginHeaders } from "@/app/api/checkout/request-origin";
 
 export const runtime = "nodejs";
 
@@ -25,6 +26,8 @@ export async function POST(
         headers: {
           "Content-Type": "application/json",
           Cookie: req.headers.get("cookie") ?? "",
+          // RailsのCSRF対策（Origin検証）を通すため、ブラウザが送ってきたOrigin/Refererを転送する
+          ...forwardedOriginHeaders(req),
         },
         signal: controller.signal,
       }


### PR DESCRIPTION
## 背景
8月スプリント計画（Codex監査）で発見。Rails APIモードはCSRF保護がデフォルト無効。
CORSはcredentials: true + 許可オリジン限定だが、これは「レスポンスをJSから読めない」
ことしか保証せず、本番`SameSite=None`のCookie認証と組み合わさると、悪意あるサイトからの
単純なフォーム送信で副作用（夢の削除・プロフィール変更等）が発生しうる。

## 変更内容
- `ApplicationController#verify_request_origin!`を追加。GET/HEAD/OPTIONS以外のリクエストで、
  Origin（無ければReferer）が許可オリジン一覧に含まれるか検証し、含まれなければ403
- 許可オリジン一覧を`AllowedOrigins`（`backend/lib/allowed_origins.rb`）へ切り出し、
  `cors.rb`と共有（重複していたENV解析ロジックを一本化）
- Stripe Webhook（`/webhooks/stripe`）はサーバー間通信でOriginヘッダーを送らないため、
  既存の`skip_before_action :authorize_request`と同じ要領で本チェックも除外。
  正当性は既存の署名検証（`Stripe-Signature`）に委ねる
- `spec/requests/csrf_origin_protection_spec.rb`を新規追加：偽装Origin・Referer不一致・
  Origin/Referer両方無しのケースをPOST/PATCH/DELETEで拒否すること、許可Originからは
  通常どおり成功すること、Webhookは対象外であることを確認
- 既存の全request specがOrigin検証を通るよう`spec/support/default_origin_header.rb`で
  既定Originを補う仕組みを追加（偽装Originを検証したいテストは明示的に上書き可能）

## 動作確認
```
bundle exec rspec
405 examples, 0 failures
```
既存のログイン・夢CRUD・トライアル・Stripe関連のrequest specも含め全てgreenです。

## スコープ外
- 夢本文ログの是正は別PR（#471）で対応
- パスワードリセット/メール確認トークンのURL露出対策は別途検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)