### PR TITLE
fix: 体験版(/trial)で書いた夢をDBに保存する

### DIFF
--- a/frontend/__tests__/app/trial/page.test.tsx
+++ b/frontend/__tests__/app/trial/page.test.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@/context/AuthContext";
 import apiClient, {
   createDream,
   previewAnalysis,
+  updateDream,
   verifyAuth,
 } from "@/lib/apiClient";
 
@@ -16,13 +17,20 @@ jest.mock("@/context/AuthContext", () => ({
   useAuth: jest.fn(),
 }));
 
-jest.mock("@/lib/apiClient", () => ({
-  __esModule: true,
-  default: { post: jest.fn() },
-  createDream: jest.fn(),
-  previewAnalysis: jest.fn(),
-  verifyAuth: jest.fn(),
-}));
+jest.mock("@/lib/apiClient", () => {
+  class MockApiError extends Error {
+    status = 0;
+  }
+  return {
+    __esModule: true,
+    default: { post: jest.fn() },
+    ApiError: MockApiError,
+    createDream: jest.fn(),
+    previewAnalysis: jest.fn(),
+    updateDream: jest.fn(),
+    verifyAuth: jest.fn(),
+  };
+});
 
 jest.mock("@/app/components/MorpheusSmall", () => ({
   __esModule: true,
@@ -31,6 +39,7 @@ jest.mock("@/app/components/MorpheusSmall", () => ({
 
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const mockedCreateDream = createDream as jest.MockedFunction<typeof createDream>;
+const mockedUpdateDream = updateDream as jest.MockedFunction<typeof updateDream>;
 const mockedPreviewAnalysis = previewAnalysis as jest.MockedFunction<
   typeof previewAnalysis
 >;
@@ -65,6 +74,9 @@ beforeEach(() => {
   mockedCreateDream.mockResolvedValue({ id: 1 } as Awaited<
     ReturnType<typeof createDream>
   >);
+  mockedUpdateDream.mockResolvedValue({ id: 1 } as Awaited<
+    ReturnType<typeof updateDream>
+  >);
   mockedPreviewAnalysis.mockResolvedValue({
     analysis: "やさしい ゆめ だね",
     emotion_tags: ["うれしい"],
@@ -85,7 +97,7 @@ describe("TrialPage: 体験版の夢をDBへ保存する", () => {
     });
   });
 
-  it("「AIにきいてみる」でも分析結果ごとDBへ保存する", async () => {
+  it("「AIにきいてみる」は先に保存してから分析し、結果を紐づける", async () => {
     render(<TrialPage />);
     writeDream("空を飛ぶ夢");
 
@@ -93,13 +105,70 @@ describe("TrialPage: 体験版の夢をDBへ保存する", () => {
 
     await waitFor(() => {
       expect(mockedCreateDream).toHaveBeenCalledWith(
+        expect.objectContaining({ content: "空を飛ぶ夢" })
+      );
+    });
+    await waitFor(() => {
+      expect(mockedUpdateDream).toHaveBeenCalledWith(
+        1,
         expect.objectContaining({
-          content: "空を飛ぶ夢",
-          analysis_json: { analysis: "やさしい ゆめ だね", emotion_tags: ["うれしい"] },
+          analysis_json: {
+            analysis: "やさしい ゆめ だね",
+            emotion_tags: ["うれしい"],
+          },
           analysis_status: "done",
         })
       );
     });
+  });
+
+  // AI分析は体験版で3回しか使えないため、保存できないのに回数だけ
+  // 消費してしまう順序にはしない（Codexレビュー指摘）。
+  it("保存に失敗したらAI分析を実行しない（貴重な回数を無駄にしない）", async () => {
+    mockedCreateDream.mockRejectedValue(new Error("boom"));
+    render(<TrialPage />);
+    writeDream("ほぞんに しっぱいする ゆめ");
+
+    fireEvent.click(screen.getByRole("button", { name: /AIにきいてみる/ }));
+
+    await waitFor(() => expect(mockedCreateDream).toHaveBeenCalled());
+    expect(mockedPreviewAnalysis).not.toHaveBeenCalled();
+  });
+
+  it("分析だけ失敗しても、保存済みの夢は一覧に残る", async () => {
+    mockedPreviewAnalysis.mockRejectedValue(new Error("analysis down"));
+    render(<TrialPage />);
+    writeDream("ぶんせきが こける ゆめ");
+
+    fireEvent.click(screen.getByRole("button", { name: /AIにきいてみる/ }));
+
+    expect(
+      await screen.findByText(
+        "ぶんせきは できなかったけど、ゆめは のこして あるよ。"
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/記録した夢 \(1\/7\)/)).toBeInTheDocument();
+  });
+
+  // ensureTrialSession の失敗を握りつぶすと、未処理のPromise拒否になり
+  // 画面に何も出ないまま終わる（Codexレビュー指摘）。
+  it("トライアルログインに失敗してもエラーを表示する", async () => {
+    mockedUseAuth.mockReturnValue(
+      makeAuth({ authStatus: "unauthenticated", isLoggedIn: false, user: null })
+    );
+    mockedVerifyAuth.mockResolvedValue(null);
+    mockedPost.mockRejectedValue(new Error("network down"));
+
+    render(<TrialPage />);
+    writeDream("ログインに しっぱいする ゆめ");
+
+    fireEvent.click(screen.getByRole("button", { name: /AIにきいてみる/ }));
+
+    expect(
+      await screen.findByText(
+        "いま うまく つながらなかったよ。もういちど ためしてね。"
+      )
+    ).toBeInTheDocument();
   });
 
   it("タイトル未入力なら既定の名前で保存する", async () => {

--- a/frontend/__tests__/app/trial/page.test.tsx
+++ b/frontend/__tests__/app/trial/page.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import TrialPage from "@/app/trial/page";
+import { useAuth } from "@/context/AuthContext";
+import apiClient, {
+  createDream,
+  previewAnalysis,
+  verifyAuth,
+} from "@/lib/apiClient";
+
+// 体験版で書いた夢がDBに保存されず、再読み込みや本登録で消えていた問題
+// （2026-07-22・2026-08-02のTrial P3 QAを2回無効化した実データ損失バグ）の回帰テスト。
+// 「記録した夢」と画面に出る以上、実際にDBへ保存されていなければならない。
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@/lib/apiClient", () => ({
+  __esModule: true,
+  default: { post: jest.fn() },
+  createDream: jest.fn(),
+  previewAnalysis: jest.fn(),
+  verifyAuth: jest.fn(),
+}));
+
+jest.mock("@/app/components/MorpheusSmall", () => ({
+  __esModule: true,
+  default: () => <div data-testid="morpheus-small" />,
+}));
+
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockedCreateDream = createDream as jest.MockedFunction<typeof createDream>;
+const mockedPreviewAnalysis = previewAnalysis as jest.MockedFunction<
+  typeof previewAnalysis
+>;
+const mockedVerifyAuth = verifyAuth as jest.MockedFunction<typeof verifyAuth>;
+const mockedPost = apiClient.post as jest.MockedFunction<typeof apiClient.post>;
+
+type AuthValue = ReturnType<typeof useAuth>;
+
+const makeAuth = (over: Partial<AuthValue> = {}): AuthValue =>
+  ({
+    authStatus: "authenticated",
+    isLoggedIn: true,
+    user: { id: "1", trial_user: true },
+    userId: "1",
+    login: jest.fn(),
+    logout: jest.fn(),
+    deleteUser: jest.fn(),
+    error: null,
+    ...over,
+  }) as AuthValue;
+
+const writeDream = (text: string) => {
+  fireEvent.change(
+    screen.getByPlaceholderText("今朝見た夢を書いてみてください..."),
+    { target: { value: text } }
+  );
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedUseAuth.mockReturnValue(makeAuth());
+  mockedCreateDream.mockResolvedValue({ id: 1 } as Awaited<
+    ReturnType<typeof createDream>
+  >);
+  mockedPreviewAnalysis.mockResolvedValue({
+    analysis: "やさしい ゆめ だね",
+    emotion_tags: ["うれしい"],
+  });
+});
+
+describe("TrialPage: 体験版の夢をDBへ保存する", () => {
+  it("「記録だけする」でDBへ保存する（stateだけに積まない）", async () => {
+    render(<TrialPage />);
+    writeDream("青い扉の夢");
+
+    fireEvent.click(screen.getByRole("button", { name: /記録だけする/ }));
+
+    await waitFor(() => {
+      expect(mockedCreateDream).toHaveBeenCalledWith(
+        expect.objectContaining({ content: "青い扉の夢" })
+      );
+    });
+  });
+
+  it("「AIにきいてみる」でも分析結果ごとDBへ保存する", async () => {
+    render(<TrialPage />);
+    writeDream("空を飛ぶ夢");
+
+    fireEvent.click(screen.getByRole("button", { name: /AIにきいてみる/ }));
+
+    await waitFor(() => {
+      expect(mockedCreateDream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: "空を飛ぶ夢",
+          analysis_json: { analysis: "やさしい ゆめ だね", emotion_tags: ["うれしい"] },
+          analysis_status: "done",
+        })
+      );
+    });
+  });
+
+  it("タイトル未入力なら既定の名前で保存する", async () => {
+    render(<TrialPage />);
+    writeDream("なまえのない夢");
+
+    fireEvent.click(screen.getByRole("button", { name: /記録だけする/ }));
+
+    await waitFor(() => {
+      expect(mockedCreateDream).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "ゆめ 1" })
+      );
+    });
+  });
+
+  it("保存に失敗したら一覧へ足さず、エラーを表示する（画面が嘘をつかない）", async () => {
+    mockedCreateDream.mockRejectedValue(new Error("boom"));
+    render(<TrialPage />);
+    writeDream("ほぞんに しっぱいする ゆめ");
+
+    fireEvent.click(screen.getByRole("button", { name: /記録だけする/ }));
+
+    expect(
+      await screen.findByText("ゆめを のこせなかったよ。もういちど ためしてね。")
+    ).toBeInTheDocument();
+    // 保存できていないのに「記録した夢」へ増やさない
+    expect(screen.getByText(/記録した夢 \(0\/7\)/)).toBeInTheDocument();
+  });
+
+  it("未認証ならトライアルアカウントを作ってから保存する", async () => {
+    mockedUseAuth.mockReturnValue(
+      makeAuth({ authStatus: "unauthenticated", isLoggedIn: false, user: null })
+    );
+    mockedVerifyAuth.mockResolvedValue(null);
+    mockedPost.mockResolvedValue({ user: { id: 9 } } as never);
+
+    render(<TrialPage />);
+    writeDream("みとうろくの ゆめ");
+
+    fireEvent.click(screen.getByRole("button", { name: /記録だけする/ }));
+
+    await waitFor(() => {
+      expect(mockedPost).toHaveBeenCalledWith(
+        "/auth/trial_login",
+        expect.anything()
+      );
+    });
+    await waitFor(() => expect(mockedCreateDream).toHaveBeenCalled());
+  });
+});

--- a/frontend/app/trial/page.tsx
+++ b/frontend/app/trial/page.tsx
@@ -6,7 +6,7 @@ import MorpheusSmall from "@/app/components/MorpheusSmall";
 import apiClient from "@/lib/apiClient";
 import { useAuth } from "@/context/AuthContext";
 import { User } from "@/app/types";
-import { previewAnalysis, verifyAuth } from "@/lib/apiClient";
+import { createDream, previewAnalysis, verifyAuth } from "@/lib/apiClient";
 import { Sparkles, Loader2 } from "lucide-react";
 
 type AnalysisResult = {
@@ -35,11 +35,66 @@ export default function TrialPage() {
   const [analysisError, setAnalysisError] = useState("");
   const [analysisCount, setAnalysisCount] = useState(0);
   const [analysisLimitReached, setAnalysisLimitReached] = useState(false);
+  // 「記録だけする」でDBへ保存している最中かどうか（二重送信防止）
+  const [isSaving, setIsSaving] = useState(false);
 
   // checking中はボタンを無効化するためのフラグ
   const isAuthChecking = authStatus === "checking";
 
-  // トライアルログイン → AI分析の一連フロー
+  // トライアルセッションを確保する（未認証ならトライアルアカウントを自動作成）。
+  // 成功したら true、失敗したらエラー文言を立てて false を返す。
+  const ensureTrialSession = async (): Promise<boolean> => {
+    if (authStatus !== "unauthenticated") return true;
+
+    let verified: Awaited<ReturnType<typeof verifyAuth>>;
+    try {
+      verified = await verifyAuth();
+    } catch {
+      // verify が失敗したときは既存セッション保護を優先して中断する
+      setAnalysisError(
+        "ログインじょうたいの かくにんに しっぱい したよ。もういちど ためしてね。"
+      );
+      return false;
+    }
+
+    if (verified?.user) {
+      login(verified.user);
+      return true;
+    }
+
+    setIsLoggingIn(true);
+    try {
+      const timestamp = Date.now();
+      const res = await apiClient.post<{ user: User }>("/auth/trial_login", {
+        trial_user: {
+          email: `trial_${timestamp}@example.com`,
+          username: `trial_${timestamp}`,
+          password: "trial_password_123",
+          password_confirmation: "trial_password_123",
+        },
+      });
+      if (res?.user) {
+        login({ ...res.user, id: String(res.user.id) });
+      }
+      // Cookieが設定されるのを待つ
+      await new Promise((r) => setTimeout(r, 500));
+      return true;
+    } finally {
+      setIsLoggingIn(false);
+    }
+  };
+
+  // 体験版で書いた夢もDBへ保存する。
+  // 以前は React の state に積むだけだったため、画面には「記録した夢」と出るのに
+  // 再読み込みで消え、本登録しても引き継がれなかった（実データの損失）。
+  const persistDream = (analysis?: AnalysisResult) =>
+    createDream({
+      title: title.trim() || `ゆめ ${dreams.length + 1}`,
+      content: description.trim(),
+      ...(analysis ? { analysis_json: analysis, analysis_status: "done" } : {}),
+    });
+
+  // トライアルログイン → AI分析 → 保存の一連フロー
   const handleAnalyze = async () => {
     if (!description.trim()) {
       setAnalysisError("ゆめの おはなしを かいてね。");
@@ -61,49 +116,36 @@ export default function TrialPage() {
     setAnalysisError("");
 
     try {
-      // 未認証ならトライアルログインを行う
-      if (authStatus === "unauthenticated") {
-        let verified: Awaited<ReturnType<typeof verifyAuth>>;
-        try {
-          verified = await verifyAuth();
-        } catch {
-          // verify が失敗したときは既存セッション保護を優先して中断する
-          setAnalysisError(
-            "ログインじょうたいの かくにんに しっぱい したよ。もういちど ためしてね。"
-          );
-          return;
-        }
-
-        if (verified?.user) {
-          login(verified.user);
-        } else {
-          setIsLoggingIn(true);
-          const timestamp = Date.now();
-          const res = await apiClient.post<{ user: User }>("/auth/trial_login", {
-            trial_user: {
-              email: `trial_${timestamp}@example.com`,
-              username: `trial_${timestamp}`,
-              password: "trial_password_123",
-              password_confirmation: "trial_password_123",
-            },
-          });
-          if (res?.user) {
-            login({ ...res.user, id: String(res.user.id) });
-          }
-          setIsLoggingIn(false);
-          // Cookieが設定されるのを待つ
-          await new Promise((r) => setTimeout(r, 500));
-        }
-      }
+      if (!(await ensureTrialSession())) return;
 
       // AI分析を実行
-      const result = await previewAnalysis(description);
+      let result: AnalysisResult;
+      try {
+        result = await previewAnalysis(description);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : "";
+        if (message.includes("分析上限")) {
+          setAnalysisLimitReached(true);
+          setAnalysisError("");
+        } else {
+          setAnalysisError("ぶんせきに しっぱい しちゃった。もういちど ためしてね。");
+        }
+        return;
+      }
 
-      // 夢リストに分析結果付きで追加
+      // 分析結果ごとDBへ保存する。
+      // 保存に失敗したら夢は残らないので、リストにも積まない（画面が嘘をつかないようにする）。
+      try {
+        await persistDream(result);
+      } catch {
+        setAnalysisError("ゆめを のこせなかったよ。もういちど ためしてね。");
+        return;
+      }
+
       setDreams((prev) => [
         ...prev,
         {
-          title: title || `ゆめ ${prev.length + 1}`,
+          title: title.trim() || `ゆめ ${prev.length + 1}`,
           description,
           analysis: result,
         },
@@ -111,36 +153,46 @@ export default function TrialPage() {
       setAnalysisCount((prev) => prev + 1);
       setTitle("");
       setDescription("");
-    } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : "分析に失敗しました";
-      if (message.includes("分析上限")) {
-        setAnalysisLimitReached(true);
-        setAnalysisError("");
-      } else {
-        setAnalysisError("ぶんせきに しっぱい しちゃった。もういちど ためしてね。");
-      }
     } finally {
       setIsAnalyzing(false);
       setIsLoggingIn(false);
     }
   };
 
-  // 分析なしで記録だけ
-  const addDreamWithoutAnalysis = () => {
-    if (!title && !description) {
+  // 分析なしで記録する（DBへ保存する）
+  const addDreamWithoutAnalysis = async () => {
+    if (!description.trim()) {
+      setAnalysisError("ゆめの おはなしを かいてね。");
       return;
     }
     if (dreams.length >= MAX_TRIAL_DREAMS) {
       setAnalysisError("ここに かける ゆめは 7こ まで だよ。");
       return;
     }
-    setDreams((prev) => [
-      ...prev,
-      { title: title || `ゆめ ${prev.length + 1}`, description },
-    ]);
-    setTitle("");
-    setDescription("");
+    if (isAuthChecking) {
+      setAnalysisError("じゅんびちゅう... すこしまってね。");
+      return;
+    }
+
+    setIsSaving(true);
+    setAnalysisError("");
+
+    try {
+      if (!(await ensureTrialSession())) return;
+
+      await persistDream();
+
+      setDreams((prev) => [
+        ...prev,
+        { title: title.trim() || `ゆめ ${prev.length + 1}`, description },
+      ]);
+      setTitle("");
+      setDescription("");
+    } catch {
+      setAnalysisError("ゆめを のこせなかったよ。もういちど ためしてね。");
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   return (
@@ -201,6 +253,7 @@ export default function TrialPage() {
             onClick={handleAnalyze}
             disabled={
               isAnalyzing ||
+              isSaving ||
               isAuthChecking ||
               analysisLimitReached ||
               dreams.length >= MAX_TRIAL_DREAMS ||
@@ -234,7 +287,11 @@ export default function TrialPage() {
             type="button"
             onClick={addDreamWithoutAnalysis}
             disabled={
-              dreams.length >= MAX_TRIAL_DREAMS || !description.trim()
+              isAnalyzing ||
+              isSaving ||
+              isAuthChecking ||
+              dreams.length >= MAX_TRIAL_DREAMS ||
+              !description.trim()
             }
             className="
               inline-flex items-center justify-center px-5 py-2.5
@@ -244,7 +301,7 @@ export default function TrialPage() {
               transition-all duration-200
             "
           >
-            記録だけする（分析なし）
+            {isSaving ? "のこしているよ…" : "記録だけする（分析なし）"}
           </button>
 
           {/* 残り回数バッジ */}

--- a/frontend/app/trial/page.tsx
+++ b/frontend/app/trial/page.tsx
@@ -6,7 +6,13 @@ import MorpheusSmall from "@/app/components/MorpheusSmall";
 import apiClient from "@/lib/apiClient";
 import { useAuth } from "@/context/AuthContext";
 import { User } from "@/app/types";
-import { createDream, previewAnalysis, verifyAuth } from "@/lib/apiClient";
+import {
+  ApiError,
+  createDream,
+  previewAnalysis,
+  updateDream,
+  verifyAuth,
+} from "@/lib/apiClient";
 import { Sparkles, Loader2 } from "lucide-react";
 
 type AnalysisResult = {
@@ -87,12 +93,18 @@ export default function TrialPage() {
   // 体験版で書いた夢もDBへ保存する。
   // 以前は React の state に積むだけだったため、画面には「記録した夢」と出るのに
   // 再読み込みで消え、本登録しても引き継がれなかった（実データの損失）。
-  const persistDream = (analysis?: AnalysisResult) =>
+  const persistDream = () =>
     createDream({
       title: title.trim() || `ゆめ ${dreams.length + 1}`,
       content: description.trim(),
-      ...(analysis ? { analysis_json: analysis, analysis_status: "done" } : {}),
     });
+
+  // 保存の失敗理由は、件数上限などバックエンドが日本語で返してくれるものがあるため、
+  // 取得できるならそれをそのまま見せる。
+  const saveErrorMessage = (err: unknown) =>
+    err instanceof ApiError && err.message
+      ? err.message
+      : "ゆめを のこせなかったよ。もういちど ためしてね。";
 
   // トライアルログイン → AI分析 → 保存の一連フロー
   const handleAnalyze = async () => {
@@ -118,8 +130,19 @@ export default function TrialPage() {
     try {
       if (!(await ensureTrialSession())) return;
 
-      // AI分析を実行
-      let result: AnalysisResult;
+      // 先に保存してから分析する。
+      // 逆順にすると、保存が失敗したときに「3回しかないAI分析だけ消費して、
+      // 夢も分析結果も残らない」という一番損な結果になる。
+      let saved: Awaited<ReturnType<typeof persistDream>>;
+      try {
+        saved = await persistDream();
+      } catch (err: unknown) {
+        setAnalysisError(saveErrorMessage(err));
+        return;
+      }
+
+      // ここから先が失敗しても、夢はすでに保存されているので失われない。
+      let result: AnalysisResult | undefined;
       try {
         result = await previewAnalysis(description);
       } catch (err: unknown) {
@@ -128,18 +151,22 @@ export default function TrialPage() {
           setAnalysisLimitReached(true);
           setAnalysisError("");
         } else {
-          setAnalysisError("ぶんせきに しっぱい しちゃった。もういちど ためしてね。");
+          setAnalysisError("ぶんせきは できなかったけど、ゆめは のこして あるよ。");
         }
-        return;
       }
 
-      // 分析結果ごとDBへ保存する。
-      // 保存に失敗したら夢は残らないので、リストにも積まない（画面が嘘をつかないようにする）。
-      try {
-        await persistDream(result);
-      } catch {
-        setAnalysisError("ゆめを のこせなかったよ。もういちど ためしてね。");
-        return;
+      if (result) {
+        // 分析結果を保存済みの夢へ紐づける。
+        // 失敗しても夢そのものは残っているので、画面の表示は続ける。
+        try {
+          await updateDream(saved.id, {
+            analysis_json: result,
+            analysis_status: "done",
+          });
+        } catch {
+          // 紐づけだけの失敗。夢は保存済みなので黙って表示を続ける
+        }
+        setAnalysisCount((prev) => prev + 1);
       }
 
       setDreams((prev) => [
@@ -150,9 +177,12 @@ export default function TrialPage() {
           analysis: result,
         },
       ]);
-      setAnalysisCount((prev) => prev + 1);
       setTitle("");
       setDescription("");
+    } catch {
+      // ensureTrialSession（trial_login）の失敗など、上で拾えなかった例外。
+      // ここが無いと未処理のPromise拒否になり、画面に何も出ないまま終わる。
+      setAnalysisError("いま うまく つながらなかったよ。もういちど ためしてね。");
     } finally {
       setIsAnalyzing(false);
       setIsLoggingIn(false);
@@ -188,8 +218,8 @@ export default function TrialPage() {
       ]);
       setTitle("");
       setDescription("");
-    } catch {
-      setAnalysisError("ゆめを のこせなかったよ。もういちど ためしてね。");
+    } catch (err: unknown) {
+      setAnalysisError(saveErrorMessage(err));
     } finally {
       setIsSaving(false);
     }

--- a/frontend/e2e/trial-flow.spec.ts
+++ b/frontend/e2e/trial-flow.spec.ts
@@ -26,6 +26,19 @@ test.describe("トライアルページ：お試し体験フロー", () => {
       });
     });
 
+    // 「記録だけする」も保存前にトライアルセッションを確保するようになったため、
+    // AI分析を使わないテストでも trial_login が必要になった。
+    // 個別テストで上書きしたい場合は、テスト内で後から route を登録すればよい。
+    await page.route("**/auth/trial_login", async (route) => {
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          user: { id: 99, email: "trial_test@example.com", username: "trial_99" },
+        }),
+      });
+    });
+
     // 体験版の夢もDBへ保存するようになったため、保存APIをモックする。
     // ここを外すと保存が失敗し、夢が一覧に追加されない（＝仕様どおりの挙動）ので、
     // 分析結果の表示を確認するテストが落ちる。

--- a/frontend/e2e/trial-flow.spec.ts
+++ b/frontend/e2e/trial-flow.spec.ts
@@ -53,6 +53,21 @@ test.describe("トライアルページ：お試し体験フロー", () => {
         body: JSON.stringify({ id: 1 }),
       });
     });
+
+    // 分析結果は保存済みの夢へ後から紐づける（PATCH /dreams/:id）。
+    // 失敗しても画面表示は続く実装だが、実ネットワークへ出さないようモックする。
+    // preview_analysis も **/dreams/* に一致するため、PATCH以外は次のhandlerへ渡す。
+    await page.route("**/dreams/*", async (route) => {
+      if (!["PATCH", "PUT"].includes(route.request().method())) {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ id: 1 }),
+      });
+    });
   });
 
   test("ページが表示され残りAI分析回数バッジが初期3回を示す", async ({

--- a/frontend/e2e/trial-flow.spec.ts
+++ b/frontend/e2e/trial-flow.spec.ts
@@ -25,6 +25,21 @@ test.describe("トライアルページ：お試し体験フロー", () => {
         body: JSON.stringify({ error: "Unauthorized" }),
       });
     });
+
+    // 体験版の夢もDBへ保存するようになったため、保存APIをモックする。
+    // ここを外すと保存が失敗し、夢が一覧に追加されない（＝仕様どおりの挙動）ので、
+    // 分析結果の表示を確認するテストが落ちる。
+    await page.route("**/dreams", async (route) => {
+      if (route.request().method() !== "POST") {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ id: 1 }),
+      });
+    });
   });
 
   test("ページが表示され残りAI分析回数バッジが初期3回を示す", async ({

--- a/frontend/lib/apiClient.ts
+++ b/frontend/lib/apiClient.ts
@@ -391,6 +391,17 @@ export async function createDream(dream: DreamInput): Promise<Dream> {
   });
 }
 
+// 保存済みの夢を部分更新する（体験版で分析結果を後から紐づける用途）。
+export async function updateDream(
+  id: number,
+  dream: Partial<DreamInput>
+): Promise<Dream> {
+  return apiFetch<Dream>(`/dreams/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ dream }),
+  });
+}
+
 export async function previewAnalysis(
   content: string
 ): Promise<{ analysis: string; emotion_tags: string[] }> {


### PR DESCRIPTION
## 背景

`/trial`の2つのボタンは、どちらも**APIを一切呼ばずReactのstateに積むだけ**でした。

```js
const addDreamWithoutAnalysis = () => {
  setDreams((prev) => [...prev, { title: ..., description }]);  // これだけ
};
```

localStorageすら使っていないため、**ページを再読み込みしただけで消えます**。それなのに画面は3か所で「記録」と表示します。

| 場所 | 文言 |
|---|---|
| ボタン | 記録**だけする**（分析なし） |
| 見出し | **記録した夢** (n/7) |
| 空状態 | まだ**記録**がありません |

### 実害

Trial P3の本番QAが**2026-07-22と2026-08-02の2回、この誤解で無効化**されています。「保存した」と思って本登録したが、そもそもDBに夢が無かったためです。2回目は、ランブックに注意書きを書いた本人が引っかかっています。注意書きで防げなかった以上、UIで解決すべき問題と判断しました。

実ユーザーも同様に、ランディングページの主要CTA（「まず試す」「今朝の夢を入れてみる」）から`/trial`へ入り、夢を書いて失う状態でした。

## 変更内容

- トライアルセッション確保を`ensureTrialSession()`へ抽出し、「記録だけする」からも使えるようにした（従来はAI分析側にのみ存在）
- 両方の導線で`createDream()`を呼び、実際にDBへ保存する
- AI分析した場合は`analysis_json`も一緒に保存する
- **保存に失敗したら一覧へ追加せずエラーを表示**する（画面が嘘をつかないようにする）
- 保存中はボタンを無効化して二重送信を防ぐ

これによりボタン名「記録だけする」が実動作と一致します。件数上限（7件）はバックエンドの`TRIAL_DREAM_LIMIT`と元から同じ値で、齟齬はありません。

## テスト

`frontend/__tests__/app/trial/page.test.tsx` を新規追加（5ケース）。

- 「記録だけする」でDBへ保存する
- 「AIにきいてみる」でも分析結果ごと保存する
- タイトル未入力なら既定名で保存する
- **保存失敗時は一覧へ足さずエラーを出す**（退行防止の要）
- 未認証ならトライアルアカウントを作ってから保存する

```
Test Suites: 68 passed, 68 total
Tests:       488 passed, 488 total
```

## スコープ外

UI/UX監査で挙がった他の項目（メール再送の状態表示、夢プロフィールの明示、ホーム情報配置など）は別PRとします。特にメール再送は**未着の原因が未確定**のため、原因特定後に着手します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)