### PR TITLE
feat: 確認メール再送の結果と次に送れる時刻を画面に出す

### DIFF
--- a/frontend/__tests__/components/DreamForm.test.js
+++ b/frontend/__tests__/components/DreamForm.test.js
@@ -27,6 +27,13 @@ jest.mock("framer-motion", () => {
   return { motion, AnimatePresence: ({ children }) => children };
 });
 
+// EmailVerificationBanner が送信先アドレスを伏せ字で出すために useAuth を使う。
+// DreamForm 自体は認証状態を見ないが、埋め込んでいるバナーが必要とする。
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: () => ({ user: { id: "1", email: "teruo@example.com" } }),
+}));
+
 // Mocks
 jest.mock("@/lib/apiClient", () => ({
   getEmotions: jest.fn(),

--- a/frontend/__tests__/components/EmailVerificationBanner.test.tsx
+++ b/frontend/__tests__/components/EmailVerificationBanner.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import EmailVerificationBanner, {
   formatRemaining,
   maskEmail,
+  resendDeadlineStorageKey,
   RESEND_COOLDOWN_SECONDS,
 } from "@/app/components/EmailVerificationBanner";
 import { resendVerificationEmail, ApiError } from "@/lib/apiClient";
@@ -30,6 +31,7 @@ const mockedUseAuth = useAuth as jest.Mock;
 describe("EmailVerificationBanner", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    window.localStorage.clear();
     mockedUseAuth.mockReturnValue({ user: { id: "1", email: "teruo@gmail.com" } });
   });
 
@@ -131,6 +133,46 @@ describe("EmailVerificationBanner", () => {
     // 失敗時はクールダウンに入れず、すぐ再試行できる
     expect(
       screen.getByRole("button", { name: "かくにんメールを もういちど おくる" })
+    ).toBeEnabled();
+  });
+
+  // バナーは /home・/dream/new・/dream/[id] にあり、移動のたびに作り直される。
+  // component-local な state だけで持つと「もう送れます」の顔に戻ってしまい、
+  // 押すと429で弾かれる（Codexレビュー指摘）。
+  it("画面を移動して作り直されても、クールダウンを引き継ぐ", async () => {
+    const until = Date.now() + 120_000; // あと2分
+    window.localStorage.setItem(resendDeadlineStorageKey("1"), String(until));
+
+    render(<EmailVerificationBanner />);
+
+    const button = await screen.findByRole("button", { name: /で おくれるよ$/ });
+    expect(button).toBeDisabled();
+  });
+
+  it("保存された時刻がすでに過ぎていれば、ふつうに送れる", async () => {
+    const past = Date.now() - 1000;
+    window.localStorage.setItem(resendDeadlineStorageKey("1"), String(past));
+
+    render(<EmailVerificationBanner />);
+
+    expect(
+      await screen.findByRole("button", {
+        name: "かくにんメールを もういちど おくる",
+      })
+    ).toBeEnabled();
+  });
+
+  it("クールダウンはユーザーごとに分ける（別アカウントに持ち越さない）", async () => {
+    const until = Date.now() + 120_000;
+    window.localStorage.setItem(resendDeadlineStorageKey("1"), String(until));
+    mockedUseAuth.mockReturnValue({ user: { id: "2", email: "other@gmail.com" } });
+
+    render(<EmailVerificationBanner />);
+
+    expect(
+      await screen.findByRole("button", {
+        name: "かくにんメールを もういちど おくる",
+      })
     ).toBeEnabled();
   });
 

--- a/frontend/__tests__/components/EmailVerificationBanner.test.tsx
+++ b/frontend/__tests__/components/EmailVerificationBanner.test.tsx
@@ -1,8 +1,13 @@
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import EmailVerificationBanner from "@/app/components/EmailVerificationBanner";
+import EmailVerificationBanner, {
+  formatRemaining,
+  maskEmail,
+  RESEND_COOLDOWN_SECONDS,
+} from "@/app/components/EmailVerificationBanner";
 import { resendVerificationEmail, ApiError } from "@/lib/apiClient";
+import { useAuth } from "@/context/AuthContext";
 
 jest.mock("@/lib/apiClient", () => {
   class ApiError extends Error {
@@ -14,11 +19,18 @@ jest.mock("@/lib/apiClient", () => {
   };
 });
 
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: jest.fn(),
+}));
+
 const mockResend = resendVerificationEmail as jest.Mock;
+const mockedUseAuth = useAuth as jest.Mock;
 
 describe("EmailVerificationBanner", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedUseAuth.mockReturnValue({ user: { id: "1", email: "teruo@gmail.com" } });
   });
 
   it("メール未確認のお知らせと再送ボタンを表示する", () => {
@@ -48,7 +60,7 @@ describe("EmailVerificationBanner", () => {
     ).toBeInTheDocument();
   });
 
-  it("再送ボタンを押すと送信中表示になり、成功したら完了メッセージに切り替わる", async () => {
+  it("送信に成功したら、送り先のアドレスと届かないときの案内を表示する", async () => {
     const user = userEvent.setup();
     mockResend.mockResolvedValue({ message: "確認メールを送りました" });
 
@@ -58,16 +70,51 @@ describe("EmailVerificationBanner", () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByText("かくにんメールを おくったよ。うけとりボックスを みてね。")
-      ).toBeInTheDocument();
+      expect(screen.getByText("かくにんメールを おくったよ。")).toBeInTheDocument();
     });
+    // どのアドレスへ送ったかを伏せ字で示す
+    expect(screen.getByText("te***@gmail.com を みてね。")).toBeInTheDocument();
+    // 届かないときの手がかりを出す
+    expect(
+      screen.getByText("めいわくメールの フォルダを みてね")
+    ).toBeInTheDocument();
     expect(mockResend).toHaveBeenCalledTimes(1);
+  });
+
+  // 「押したけど何も起きない」を無くすのがこの改修の目的。
+  // 次に送れるまでの残り時間を出し、その間はボタンを無効化する。
+  it("送信後は次に送れるまでの残り時間を表示し、ボタンを無効化する", async () => {
+    const user = userEvent.setup();
+    mockResend.mockResolvedValue({ message: "確認メールを送りました" });
+
+    render(<EmailVerificationBanner />);
+    await user.click(
+      screen.getByRole("button", { name: "かくにんメールを もういちど おくる" })
+    );
+
+    const button = await screen.findByRole("button", { name: /で おくれるよ$/ });
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent("あと 5ふん00びょう で おくれるよ");
+  });
+
+  it("送信結果はスクリーンリーダーにも伝わる（role=status）", async () => {
+    const user = userEvent.setup();
+    mockResend.mockResolvedValue({ message: "確認メールを送りました" });
+
+    render(<EmailVerificationBanner />);
+    await user.click(
+      screen.getByRole("button", { name: "かくにんメールを もういちど おくる" })
+    );
+
+    const status = await screen.findByRole("status");
+    expect(status).toHaveTextContent("かくにんメールを おくったよ。");
   });
 
   it("送信に失敗したらエラーメッセージを表示し、再送ボタンに戻る", async () => {
     const user = userEvent.setup();
-    const error = new ApiError("確認メールを送信済みです。少し待ってからもう一度お試しください。");
+    const error = new ApiError(
+      "確認メールを送信済みです。少し待ってからもう一度お試しください。"
+    );
     error.status = 429;
     mockResend.mockRejectedValue(error);
 
@@ -81,8 +128,54 @@ describe("EmailVerificationBanner", () => {
         screen.getByText("確認メールを送信済みです。少し待ってからもう一度お試しください。")
       ).toBeInTheDocument();
     });
+    // 失敗時はクールダウンに入れず、すぐ再試行できる
     expect(
       screen.getByRole("button", { name: "かくにんメールを もういちど おくる" })
-    ).toBeInTheDocument();
+    ).toBeEnabled();
+  });
+
+  it("メールアドレスが取れないときは伏せ字行を出さない", async () => {
+    mockedUseAuth.mockReturnValue({ user: { id: "1" } });
+    const user = userEvent.setup();
+    mockResend.mockResolvedValue({ message: "確認メールを送りました" });
+
+    render(<EmailVerificationBanner />);
+    await user.click(
+      screen.getByRole("button", { name: "かくにんメールを もういちど おくる" })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("かくにんメールを おくったよ。")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/を みてね。$/)).not.toBeInTheDocument();
+  });
+});
+
+describe("maskEmail", () => {
+  it("ローカル部の先頭2文字だけ残す", () => {
+    expect(maskEmail("teruo@gmail.com")).toBe("te***@gmail.com");
+  });
+
+  it("短いローカル部でも最低1文字は伏せる", () => {
+    expect(maskEmail("ab@example.com")).toBe("ab*@example.com");
+  });
+
+  it("+付きアドレスでもドメインは保つ", () => {
+    expect(maskEmail("teruo+trial@gmail.com")).toBe("te*********@gmail.com");
+  });
+
+  it("@が無い値はそのまま返す（壊さない）", () => {
+    expect(maskEmail("not-an-email")).toBe("not-an-email");
+  });
+});
+
+describe("formatRemaining", () => {
+  it("分と秒で表示する", () => {
+    expect(formatRemaining(RESEND_COOLDOWN_SECONDS)).toBe("5ふん00びょう");
+    expect(formatRemaining(65)).toBe("1ふん05びょう");
+  });
+
+  it("1分未満は秒だけ", () => {
+    expect(formatRemaining(42)).toBe("42びょう");
   });
 });

--- a/frontend/app/components/EmailVerificationBanner.tsx
+++ b/frontend/app/components/EmailVerificationBanner.tsx
@@ -1,11 +1,41 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Mail } from "lucide-react";
 import { resendVerificationEmail } from "@/lib/apiClient";
 import { ApiError } from "@/lib/apiClient";
+import { useAuth } from "@/context/AuthContext";
 
 type SendState = "idle" | "sending" | "sent";
+
+// backend の User::EMAIL_VERIFICATION_RESEND_INTERVAL（5分）と揃える。
+// ここを実際より短く書くと「もう送れます」と嘘をつくことになり、
+// 押しても429で弾かれる、という分かりにくい状態を作ってしまう。
+export const RESEND_COOLDOWN_SECONDS = 5 * 60;
+
+/**
+ * メールアドレスを伏せ字にする（例: teruo@gmail.com → te***@gmail.com）。
+ * どのアドレス宛に送ったかは確認できるが、肩越しに全部は読まれないようにする。
+ */
+export function maskEmail(email: string): string {
+  const atIndex = email.lastIndexOf("@");
+  if (atIndex <= 0) return email;
+
+  const local = email.slice(0, atIndex);
+  const domain = email.slice(atIndex);
+  const head = local.slice(0, 2);
+  return `${head}${"*".repeat(Math.max(local.length - head.length, 1))}${domain}`;
+}
+
+/** 残り時間を子どもにも読める形にする（例: 4ふん05びょう / 42びょう）。 */
+export function formatRemaining(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const rest = seconds % 60;
+  if (minutes > 0) {
+    return `${minutes}ふん${rest.toString().padStart(2, "0")}びょう`;
+  }
+  return `${rest}びょう`;
+}
 
 type EmailVerificationBannerProps = {
   // AI分析や画像生成がゲートで拒否された場面など、文脈に合わせて文言を差し替える
@@ -16,13 +46,30 @@ type EmailVerificationBannerProps = {
 /**
  * メールアドレス未確認ユーザー向けのお知らせバナー。
  * 確認メールの再送ボタンを備える（backend側で5分間隔の再送制限あり）。
+ *
+ * 「押したあと何が起きたのか分からない」状態を作らないよう、
+ * 送信中・送信結果・次に送れるまでの残り時間をすべて画面に出し、
+ * スクリーンリーダーにも role="status" で伝える。
  */
 export default function EmailVerificationBanner({
   title = "メールアドレスの かくにんが まだだよ",
   description = "とどいた メールの リンクを ひらいて、かくにんを かんりょうしてね。",
 }: EmailVerificationBannerProps) {
+  const { user } = useAuth();
   const [state, setState] = useState<SendState>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [remaining, setRemaining] = useState(0);
+
+  // 再送できるまでの残り時間を1秒ずつ減らす。
+  // setTimeoutの連鎖にして、アンマウント時に確実に止める。
+  useEffect(() => {
+    if (remaining <= 0) return;
+    const timer = setTimeout(
+      () => setRemaining((prev) => Math.max(prev - 1, 0)),
+      1000
+    );
+    return () => clearTimeout(timer);
+  }, [remaining]);
 
   const handleResend = async () => {
     setState("sending");
@@ -30,15 +77,20 @@ export default function EmailVerificationBanner({
     try {
       await resendVerificationEmail();
       setState("sent");
+      setRemaining(RESEND_COOLDOWN_SECONDS);
     } catch (err) {
       setState("idle");
       setErrorMessage(
-        err instanceof ApiError
+        err instanceof ApiError && err.message
           ? err.message
           : "かくにんメールを おくれなかったよ。もういちど ためしてね。"
       );
     }
   };
+
+  const isSending = state === "sending";
+  const isCoolingDown = remaining > 0;
+  const maskedEmail = user?.email ? maskEmail(user.email) : null;
 
   return (
     <div
@@ -53,24 +105,43 @@ export default function EmailVerificationBanner({
 
       <p className="text-sm text-muted-foreground mb-3">{description}</p>
 
-      {state === "sent" ? (
-        <p className="text-sm font-bold text-primary">
-          かくにんメールを おくったよ。うけとりボックスを みてね。
-        </p>
-      ) : (
-        <button
-          type="button"
-          onClick={handleResend}
-          disabled={state === "sending"}
-          className="inline-flex min-h-11 items-center gap-2 rounded-xl bg-primary px-5 py-2.5 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-60"
-        >
-          {state === "sending" ? "おくっているよ…" : "かくにんメールを もういちど おくる"}
-        </button>
-      )}
+      {/* 送信結果とエラーは、目でもスクリーンリーダーでも分かるようにする */}
+      <div role="status" aria-live="polite">
+        {state === "sent" && (
+          <div className="mb-3">
+            <p className="text-sm font-bold text-primary">
+              かくにんメールを おくったよ。
+            </p>
+            {maskedEmail && (
+              <p className="mt-1 text-sm text-foreground">
+                {maskedEmail} を みてね。
+              </p>
+            )}
+            <p className="mt-2 text-sm text-muted-foreground">とどかないとき:</p>
+            <ul className="mt-1 list-disc pl-5 text-sm text-muted-foreground">
+              <li>めいわくメールの フォルダを みてね</li>
+              <li>メールアドレスが あっているか たしかめてね</li>
+            </ul>
+          </div>
+        )}
 
-      {errorMessage && (
-        <p className="mt-2 text-sm text-destructive">{errorMessage}</p>
-      )}
+        {errorMessage && (
+          <p className="mb-3 text-sm text-destructive">{errorMessage}</p>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={handleResend}
+        disabled={isSending || isCoolingDown}
+        className="inline-flex min-h-11 items-center gap-2 rounded-xl bg-primary px-5 py-2.5 text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-60"
+      >
+        {isSending
+          ? "おくっているよ…"
+          : isCoolingDown
+            ? `あと ${formatRemaining(remaining)} で おくれるよ`
+            : "かくにんメールを もういちど おくる"}
+      </button>
     </div>
   );
 }

--- a/frontend/app/components/EmailVerificationBanner.tsx
+++ b/frontend/app/components/EmailVerificationBanner.tsx
@@ -14,6 +14,16 @@ type SendState = "idle" | "sending" | "sent";
 export const RESEND_COOLDOWN_SECONDS = 5 * 60;
 
 /**
+ * 再送できるようになる時刻の保存先。
+ * バナーは /home・/dream/new・/dream/[id] の3か所にあり、画面を移動するたびに
+ * 作り直される。コンポーネント内の state だけで持つと、移動した瞬間に
+ * 「もう送れます」の顔に戻ってしまい、押すと429で弾かれる。
+ * サーバー側のクールダウンはユーザー単位なので、キーもユーザー単位にする。
+ */
+export const resendDeadlineStorageKey = (userId?: string) =>
+  `yumetree:verification-resend-until:${userId ?? "anonymous"}`;
+
+/**
  * メールアドレスを伏せ字にする（例: teruo@gmail.com → te***@gmail.com）。
  * どのアドレス宛に送ったかは確認できるが、肩越しに全部は読まれないようにする。
  */
@@ -58,18 +68,37 @@ export default function EmailVerificationBanner({
   const { user } = useAuth();
   const [state, setState] = useState<SendState>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [remaining, setRemaining] = useState(0);
+  // 再送できるようになる時刻（epoch ms）。残り秒数ではなく時刻で持つ。
+  const [deadline, setDeadline] = useState<number | null>(null);
+  const [now, setNow] = useState<number>(() => Date.now());
 
-  // 再送できるまでの残り時間を1秒ずつ減らす。
-  // setTimeoutの連鎖にして、アンマウント時に確実に止める。
+  const storageKey = resendDeadlineStorageKey(user?.id);
+
+  // 画面を移動して作り直されても、前に送った時刻を引き継ぐ。
   useEffect(() => {
-    if (remaining <= 0) return;
-    const timer = setTimeout(
-      () => setRemaining((prev) => Math.max(prev - 1, 0)),
-      1000
-    );
-    return () => clearTimeout(timer);
-  }, [remaining]);
+    const stored = Number(window.localStorage.getItem(storageKey));
+    if (Number.isFinite(stored) && stored > Date.now()) {
+      setDeadline(stored);
+      setNow(Date.now());
+    }
+  }, [storageKey]);
+
+  // 残り時間は必ず実時間（Date.now）から計算する。
+  // 1秒ずつ引き算すると、タブが止まっている間はカウントが進まず、
+  // サーバーが再送を許可した後もボタンが無効のままになる。
+  useEffect(() => {
+    if (deadline === null) return;
+
+    const timer = setInterval(() => {
+      const current = Date.now();
+      setNow(current);
+      if (current >= deadline) {
+        setDeadline(null);
+        window.localStorage.removeItem(storageKey);
+      }
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [deadline, storageKey]);
 
   const handleResend = async () => {
     setState("sending");
@@ -77,7 +106,10 @@ export default function EmailVerificationBanner({
     try {
       await resendVerificationEmail();
       setState("sent");
-      setRemaining(RESEND_COOLDOWN_SECONDS);
+      const until = Date.now() + RESEND_COOLDOWN_SECONDS * 1000;
+      window.localStorage.setItem(storageKey, String(until));
+      setDeadline(until);
+      setNow(Date.now());
     } catch (err) {
       setState("idle");
       setErrorMessage(
@@ -89,6 +121,8 @@ export default function EmailVerificationBanner({
   };
 
   const isSending = state === "sending";
+  const remaining =
+    deadline === null ? 0 : Math.max(Math.ceil((deadline - now) / 1000), 0);
   const isCoolingDown = remaining > 0;
   const maskedEmail = user?.email ? maskEmail(user.email) : null;
 


### PR DESCRIPTION
## 背景

本番QAで「**再送ボタンを押したが、何が起きたのか分からない**」状態になりました。押した結果（成功/失敗）も、次にいつ送れるのかも画面に出ていなかったため、**届かないのか待つべきなのか判断できません**でした。

実際、この情報が出ていれば原因の切り分けが数秒で済んだ場面でした。バックエンドには5分の再送クールダウンがあり、本登録直後に押すと429で弾かれます（＝仕様どおりの正常動作）が、画面からはそれが読み取れませんでした。

## 変更内容

`EmailVerificationBanner` は `/home`・`/dream/[id]`・`DreamForm` の3か所で使われているため、コンポーネント側の改修だけで全体に効きます。

- 送信成功時に、**送り先アドレスを伏せ字で表示**（`te***@gmail.com`）。どのアドレスに送ったか確認できる一方、肩越しに全部は読まれない
- **届かないときの手がかり**（迷惑メールフォルダ・アドレス確認）を併記
- **次に送れるまでの残り時間をカウントダウン表示**し、その間はボタンを無効化（`あと 4ふん32びょう で おくれるよ`）
- 送信結果・エラーを `role="status"` / `aria-live="polite"` で**スクリーンリーダーにも伝える**

## 意図的に変えた点

改善案では「60秒後にもう一度送信できます」となっていましたが、**実際の5分**（`User::EMAIL_VERIFICATION_RESEND_INTERVAL`）を表示しています。60秒と書くと「もう送れます」と嘘をつくことになり、押しても429で弾かれるという**新しい分かりにくさを作ってしまう**ためです。この改修の目的は表示と実動作を一致させることなので、そこは崩しません。

## テスト

`EmailVerificationBanner.test.tsx` を拡充（13ケース）。

- 送信先アドレスの伏せ字表示と、届かないときの案内
- **クールダウン中はボタンが無効で残り時間を表示**
- `role="status"` で結果が伝わる
- 失敗時はクールダウンに入れず、すぐ再試行できる
- `maskEmail` / `formatRemaining` の単体テスト（`+`付きアドレス、`@`なしの壊れた値も含む）

```
Test Suites: 67 passed, 67 total
Tests:       492 passed, 492 total
```

`DreamForm.test.js` はバナーが `useAuth` を使うようになったため、AuthContext のモックを同PR内で追加しています。

## スコープ外

**メールが届かない原因そのものは未解決**です。`MAIL_FROM` が `onboarding@resend.dev` のままだとResendは「アカウント本人のアドレス」にしか配信しないため、そちらの調査結果を待って別途対応します。本PRは「押した結果が分かる」ことだけを直します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)