### PR TITLE
fix: 誰の夢として保存するかを、読み上げと保存ボタンにも示す

### DIFF
--- a/frontend/__tests__/components/DreamFormProfileSelection.test.tsx
+++ b/frontend/__tests__/components/DreamFormProfileSelection.test.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DreamForm from "@/app/components/DreamForm";
+import { getDreamProfiles, getEmotions } from "@/lib/apiClient";
+
+// 「誰の夢として保存するか」を取り違えるとデータの質が壊れる。
+// 選択状態が色だけで示され、読み上げにも伝わっていなかった問題の回帰テスト。
+jest.mock("framer-motion", () => {
+  const React = require("react");
+  const motion = new Proxy(
+    {},
+    {
+      get: (_, tag) =>
+        // eslint-disable-next-line react/display-name
+        React.forwardRef(({ children, ...props }: any, ref: any) => {
+          const {
+            initial, animate, exit, transition, variants, whileHover, whileTap,
+            whileFocus, whileDrag, whileInView, drag, dragConstraints,
+            layoutId, layout, onAnimationStart, onAnimationComplete,
+            viewport, custom, style, ...rest
+          } = props;
+          return React.createElement(tag, { ...rest, ref, style }, children);
+        }),
+    }
+  );
+  return { motion, AnimatePresence: ({ children }: any) => children };
+});
+
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: () => ({ user: { id: "1", email: "teruo@example.com" } }),
+}));
+
+jest.mock("@/lib/apiClient", () => ({
+  __esModule: true,
+  getEmotions: jest.fn(),
+  getDreamProfiles: jest.fn(),
+  previewAnalysis: jest.fn(),
+  resendVerificationEmail: jest.fn(),
+  isEmailVerificationRequiredError: () => false,
+  ApiError: class ApiError extends Error {},
+}));
+
+jest.mock("@/lib/toast", () => ({ toast: { error: jest.fn(), success: jest.fn() } }));
+
+const mockedGetProfiles = getDreamProfiles as jest.Mock;
+const mockedGetEmotions = getEmotions as jest.Mock;
+
+const profile = (id: number, name: string) => ({
+  id,
+  name,
+  avatar_emoji: "😴",
+  color: "#6366f1",
+  relationship: id === 1 ? "self" : "child",
+  active: true,
+  position: id,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGetEmotions.mockResolvedValue([]);
+});
+
+describe("DreamForm: 誰の夢として保存するか", () => {
+  it("選択中のプロフィールが読み上げにも伝わる（aria-pressed）", async () => {
+    mockedGetProfiles.mockResolvedValue([profile(1, "自分"), profile(2, "テル")]);
+
+    render(<DreamForm onSubmit={jest.fn()} />);
+
+    // 「自分」は保存ボタン（自分の ゆめを のこす）にも含まれるため、
+    // 選択グループの中に絞ってから探す。
+    const group = await screen.findByRole("group", { name: "誰の夢？" });
+    const self = within(group).getByRole("button", { name: /自分/ });
+    const teru = within(group).getByRole("button", { name: /テル/ });
+
+    // 新規作成時は self が既定で選ばれる
+    expect(self).toHaveAttribute("aria-pressed", "true");
+    expect(teru).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("切り替えると aria-pressed も入れ替わる", async () => {
+    mockedGetProfiles.mockResolvedValue([profile(1, "自分"), profile(2, "テル")]);
+    const user = userEvent.setup();
+
+    render(<DreamForm onSubmit={jest.fn()} />);
+
+    const group = await screen.findByRole("group", { name: "誰の夢？" });
+    const teru = within(group).getByRole("button", { name: /テル/ });
+    await user.click(teru);
+
+    await waitFor(() => expect(teru).toHaveAttribute("aria-pressed", "true"));
+    expect(
+      within(group).getByRole("button", { name: /自分/ })
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("保存ボタンに、誰の夢として残すかを出す", async () => {
+    mockedGetProfiles.mockResolvedValue([profile(1, "自分"), profile(2, "テル")]);
+    const user = userEvent.setup();
+
+    render(<DreamForm onSubmit={jest.fn()} />);
+
+    expect(
+      await screen.findByRole("button", { name: "自分の ゆめを のこす" })
+    ).toBeInTheDocument();
+
+    const group = screen.getByRole("group", { name: "誰の夢？" });
+    await user.click(within(group).getByRole("button", { name: /テル/ }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "テルの ゆめを のこす" })
+      ).toBeInTheDocument()
+    );
+  });
+
+  it("プロフィールが1つだけなら、わざわざ名乗らない", async () => {
+    mockedGetProfiles.mockResolvedValue([profile(1, "自分")]);
+
+    render(<DreamForm onSubmit={jest.fn()} />);
+
+    expect(
+      await screen.findByRole("button", { name: "ゆめを のこす" })
+    ).toBeInTheDocument();
+    // 選択UI自体も出さない
+    expect(screen.queryByRole("group", { name: "誰の夢？" })).not.toBeInTheDocument();
+  });
+
+  it("選択グループに名前がついている", async () => {
+    mockedGetProfiles.mockResolvedValue([profile(1, "自分"), profile(2, "テル")]);
+
+    render(<DreamForm onSubmit={jest.fn()} />);
+
+    expect(
+      await screen.findByRole("group", { name: "誰の夢？" })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/components/DreamFormProfileSelection.test.tsx
+++ b/frontend/__tests__/components/DreamFormProfileSelection.test.tsx
@@ -127,6 +127,40 @@ describe("DreamForm: 誰の夢として保存するか", () => {
     expect(screen.queryByRole("group", { name: "誰の夢？" })).not.toBeInTheDocument();
   });
 
+  // アーカイブ済みプロフィールは選択肢から外れるため、編集時に持ち主が
+  // 引けなくなる。保存時は selectedProfileId をそのまま送るので、
+  // 「持ち主が選択肢に無いとき」こそ名前を出す必要がある（Codexレビュー指摘）。
+  it("アーカイブ済みプロフィールの夢を編集するときも、持ち主の名前を出す", async () => {
+    mockedGetProfiles.mockResolvedValue([profile(1, "自分")]);
+
+    render(
+      <DreamForm
+        onSubmit={jest.fn()}
+        initialData={
+          {
+            id: 10,
+            title: "むかしの ゆめ",
+            content: "ないよう",
+            dream_profile_id: 99,
+            dream_profile: {
+              id: 99,
+              name: "そつぎょうした テル",
+              avatar_emoji: "😴",
+              color: "#6366f1",
+              active: false,
+            },
+          } as never
+        }
+      />
+    );
+
+    expect(
+      await screen.findByRole("button", {
+        name: "そつぎょうした テルの ゆめを のこす",
+      })
+    ).toBeInTheDocument();
+  });
+
   it("選択グループに名前がついている", async () => {
     mockedGetProfiles.mockResolvedValue([profile(1, "自分"), profile(2, "テル")]);
 

--- a/frontend/app/components/DreamForm.tsx
+++ b/frontend/app/components/DreamForm.tsx
@@ -262,11 +262,25 @@ export default function DreamForm({
   // 保存ボタンに「誰の夢として残すか」を出す。
   // 複数プロフィールがあるときの取り違えは、押す直前に名前が見えていれば防げる。
   // プロフィールが1つだけのときは、わざわざ名乗らない。
-  const selectedProfile = profiles.find((p) => p.id === selectedProfileId);
-  const submitLabel =
-    profiles.length > 1 && selectedProfile
-      ? `${selectedProfile.name}の ゆめを のこす`
-      : "ゆめを のこす";
+  //
+  // アーカイブ済みプロフィールの夢を編集する場合、そのプロフィールは
+  // fetchProfiles で除外されるため profiles から引けない。
+  // 保存時は selectedProfileId をそのまま送るので、名前だけ出ないと
+  // 「持ち主が選択肢に無いとき」に限って確認できなくなる。
+  // 夢詳細APIが dream_profile を返しているので、そちらを控えに使う。
+  const activeSelectedProfile = profiles.find((p) => p.id === selectedProfileId);
+  const archivedSelectedName =
+    !activeSelectedProfile &&
+    initialData?.dream_profile?.id === selectedProfileId
+      ? initialData?.dream_profile?.name
+      : undefined;
+  // 名前を出すのは「選ぶ余地があるとき」か「持ち主が選択肢に無いとき」。
+  const selectedProfileName =
+    archivedSelectedName ??
+    (profiles.length > 1 ? activeSelectedProfile?.name : undefined);
+  const submitLabel = selectedProfileName
+    ? `${selectedProfileName}の ゆめを のこす`
+    : "ゆめを のこす";
 
   return (
     <form

--- a/frontend/app/components/DreamForm.tsx
+++ b/frontend/app/components/DreamForm.tsx
@@ -259,6 +259,15 @@ export default function DreamForm({
     });
   };
 
+  // 保存ボタンに「誰の夢として残すか」を出す。
+  // 複数プロフィールがあるときの取り違えは、押す直前に名前が見えていれば防げる。
+  // プロフィールが1つだけのときは、わざわざ名乗らない。
+  const selectedProfile = profiles.find((p) => p.id === selectedProfileId);
+  const submitLabel =
+    profiles.length > 1 && selectedProfile
+      ? `${selectedProfile.name}の ゆめを のこす`
+      : "ゆめを のこす";
+
   return (
     <form
       onSubmit={handleSubmit}
@@ -276,10 +285,17 @@ export default function DreamForm({
         }
       >
         {profiles.length > 1 && (
-          <div className="mb-5">
-          <label className="block mb-2 font-semibold text-card-foreground text-sm">
+          <div
+            className="mb-5"
+            role="group"
+            aria-labelledby="dream-profile-group-label"
+          >
+          <span
+            id="dream-profile-group-label"
+            className="block mb-2 font-semibold text-card-foreground text-sm"
+          >
             誰の夢？
-          </label>
+          </span>
           <div className="flex flex-wrap gap-2">
             {profiles.map((p) => {
               const isSelected = selectedProfileId === p.id;
@@ -287,6 +303,10 @@ export default function DreamForm({
                 <button
                   key={p.id}
                   type="button"
+                  // 選択状態を読み上げにも伝える。
+                  // これが無いと、枠線と背景の色でしか選択が分からず、
+                  // スクリーンリーダーではどれを選んでいるか判別できない。
+                  aria-pressed={isSelected}
                   onClick={() => setSelectedProfileId(p.id)}
                   className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border-2 transition-all ${
                     isSelected
@@ -295,6 +315,12 @@ export default function DreamForm({
                   }`}
                   style={isSelected ? { borderColor: p.color } : {}}
                 >
+                  {/* 色だけで選択を示さない（色の見分けがつきにくい人にも分かるように） */}
+                  {isSelected && (
+                    <span aria-hidden="true" className="font-bold">
+                      ✓
+                    </span>
+                  )}
                   <span>{p.avatar_emoji}</span>
                   <span>{p.name}</span>
                 </button>
@@ -654,7 +680,7 @@ export default function DreamForm({
         }`}
         disabled={isLoading}
       >
-        {isLoading ? "モルペウスが かんがえています..." : "ゆめを のこす"}
+        {isLoading ? "モルペウスが かんがえています..." : submitLabel}
       </button>
     </form>
   );


### PR DESCRIPTION
## 背景

複数プロフィールを使う家族利用では「**誰の夢か**」の取り違えがデータの質を直接壊します。ところが選択状態は**枠線と背景の色でしか示されていません**でした。

```tsx
<button
  onClick={() => setSelectedProfileId(p.id)}
  className={isSelected ? "bg-primary/10 text-primary" : "..."}
  style={isSelected ? { borderColor: p.color } : {}}
>
```

`aria-pressed`も`role="radio"`も無いため、**スクリーンリーダーではどれを選んでいるか判別できません**。保存ボタンも「ゆめを のこす」だけで、誰の夢として残るのか押す直前に確認できませんでした。

## 変更内容

- プロフィール選択ボタンに **`aria-pressed`** を追加（WCAG 4.1.2 Name, Role, Value）
- 選択中に**チェックマーク**を添え、色だけに頼らないようにした（WCAG 1.4.1 Use of Color）
- 選択群を `role="group"` + `aria-labelledby` で「誰の夢？」と名付けた（`htmlFor`の無い`label`をやめる）
- 保存ボタンを「**テルの ゆめを のこす**」にして、押す直前の最終確認になるようにした

プロフィールが1つだけのユーザーには影響しません（選択UIは元々`profiles.length > 1`のときだけ表示され、保存ボタンも従来どおり「ゆめを のこす」のままです）。

## テスト

この領域は`getDreamProfiles`が未モックで**既存テストの対象外**だったため、専用のテストファイルを新規追加しました（5ケース）。

- 選択中が`aria-pressed="true"`、非選択が`"false"`
- 切り替えると入れ替わる
- 保存ボタンが「自分の ゆめを のこす」→「テルの ゆめを のこす」に変わる
- プロフィールが1つなら名乗らず、選択UIも出さない
- 選択群に「誰の夢？」という名前がついている

```
Test Suites: 69 passed, 69 total
Tests:       508 passed, 508 total
```

「自分」が保存ボタン（`自分の ゆめを のこす`）にも含まれて曖昧になるため、テストでは`within(group)`で選択群に絞り込んでいます。E2E側は保存ボタン名をセレクタに使っていないことを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)