### PR TITLE
docs: 公開前必須チェック「メール配信ドメイン」をランブックに追加

### DIFF
--- a/docs/2026-07-guard-must-runbook.md
+++ b/docs/2026-07-guard-must-runbook.md
@@ -102,7 +102,7 @@ bundle exec rails runner 'puts "NULL dreams = #{Dream.where(dream_profile_id: ni
 
 ## 公開前必須チェック：メール配信ドメイン（2026年8月4日追加）
 
-> 背景: Renderの`MAIL_FROM`が`YumeTree <onboarding@resend.dev>`のまま。Resendの`resend.dev`はテスト用ドメインで、**Resendアカウントに紐づくメールアドレスとは別のアドレス**へは、独自ドメインの追加・認証なしには送信できない（Resend公式ドキュメントに明記）。この状態では、新規に本登録した一般ユーザーはメール確認が完了せず、AI夢分析・分析プレビュー・画像生成・音声夢記録・Stripe Checkoutも利用できない（`require_verified_email`ガード。Trialユーザーと既存ユーザーは対象外）。詳細は`docs/sprint-plan-august-2026.md`の該当項目を参照。
+> 背景: Renderの`MAIL_FROM`が`YumeTree <onboarding@resend.dev>`のまま。Resendの`resend.dev`はテスト用ドメインで、**Resendアカウントに紐づくメールアドレスとは別のアドレス**へは、独自ドメインの追加・認証なしには送信できない（Resend公式ドキュメントに明記）。この状態では、新規に本登録した一般ユーザーはメール確認が完了せず、AI夢分析・分析プレビュー・画像生成・音声夢記録・Stripe Checkoutも利用できない（`require_verified_email`ガード。Trialユーザーと既存ユーザーは対象外）。公開判断は、下記の必須チェックをすべて満たした後に行う。
 
 - [ ] YumeTree用の独自ドメインを取得した（**未取得。取得先・ドメイン名は未定**）
 - [ ] Resendにそのドメイン（またはメール専用サブドメイン）を追加した

--- a/docs/2026-07-guard-must-runbook.md
+++ b/docs/2026-07-guard-must-runbook.md
@@ -100,6 +100,25 @@ bundle exec rails runner 'puts "NULL dreams = #{Dream.where(dream_profile_id: ni
 
 ---
 
+## 公開前必須チェック：メール配信ドメイン（2026年8月4日追加）
+
+> 背景: Renderの`MAIL_FROM`が`YumeTree <onboarding@resend.dev>`のまま。Resendの`resend.dev`はテスト用ドメインで、**Resendアカウントに紐づくメールアドレスとは別のアドレス**へは、独自ドメインの追加・認証なしには送信できない（Resend公式ドキュメントに明記）。この状態では、新規に本登録した一般ユーザーはメール確認が完了せず、AI夢分析・分析プレビュー・画像生成・音声夢記録・Stripe Checkoutも利用できない（`require_verified_email`ガード。Trialユーザーと既存ユーザーは対象外）。詳細は`docs/sprint-plan-august-2026.md`の該当項目を参照。
+
+- [ ] YumeTree用の独自ドメインを取得した（**未取得。取得先・ドメイン名は未定**）
+- [ ] Resendにそのドメイン（またはメール専用サブドメイン）を追加した
+- [ ] Resend画面に表示されたDNSレコードを、取得先のDNS設定へ**そのまま**（推測せず）登録した
+- [ ] Resendで**Verified**になったことを確認した
+- [ ] Renderの`MAIL_FROM`を検証済みドメインのアドレスへ変更した（例：`YumeTree <no-reply@mail.取得ドメイン>`）
+- [ ] **Resendアカウントに紐づくメールアドレスとは別のアドレス**で新規本登録し、確認メールが届いた
+- [ ] 同アドレスでパスワードリセットメールも届いた
+- [ ] メール内リンクから確認・再設定まで完走できた
+- [ ] Resendのメールログで、確認メール・パスワードリセットメールがともに**Delivered**であることを確認した
+- [ ] Sentryに`MailDeliveryJob`関連の新規エラーが出ていない
+
+🛑 上記が**すべて**チェックできるまで、一般公開はしない。
+
+---
+
 ## 完了後（KPI更新）
 
 7月OBLのKPI:


### PR DESCRIPTION
## Summary
- Resendの`resend.dev`サンドボックス制限（Resendアカウントに紐づくメールアドレス以外へは配信不可）により、独自ドメイン検証が完了するまで一般公開の判断を保留する旨をランブックに明記
- 公開前に確認すべき9項目のチェックリストを追加（ドメイン取得〜Resendメールログでの`Delivered`確認まで）
- 詳細な事実整理は`docs/sprint-plan-august-2026.md`（gitignore対象・別途ローカルで更新済み）に記載

## Test plan
- [x] ドキュメントのみの変更のため、テスト不要
- [x] Markdown構文を目視確認