### PR TITLE
feat: パスワード変更成功後にログイン画面へ自動遷移する

### DIFF
--- a/frontend/__tests__/app/password-reset/[token]/page.test.tsx
+++ b/frontend/__tests__/app/password-reset/[token]/page.test.tsx
@@ -1,11 +1,12 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 
 import PasswordResetPage from "@/app/(auth)/password-reset/[token]/page";
 import { confirmPasswordReset, ApiError } from "@/lib/apiClient";
 
 jest.mock("next/navigation", () => ({
   useParams: jest.fn(),
+  useRouter: jest.fn(),
 }));
 
 jest.mock("@/lib/apiClient", () => {
@@ -20,8 +21,10 @@ jest.mock("@/lib/apiClient", () => {
 });
 
 const mockedUseParams = useParams as jest.MockedFunction<typeof useParams>;
+const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
 const mockedConfirmPasswordReset =
   confirmPasswordReset as jest.MockedFunction<typeof confirmPasswordReset>;
+const mockedReplace = jest.fn();
 
 const fillPasswords = (password: string, confirmation: string) => {
   fireEvent.change(
@@ -46,6 +49,9 @@ beforeEach(() => {
   mockedUseParams.mockReturnValue({
     token: "abc123token",
   } as ReturnType<typeof useParams>);
+  mockedUseRouter.mockReturnValue({
+    replace: mockedReplace,
+  } as unknown as ReturnType<typeof useRouter>);
 });
 
 describe("PasswordResetPage", () => {
@@ -64,7 +70,7 @@ describe("PasswordResetPage", () => {
     });
   });
 
-  it("成功時は成功メッセージとログイン画面へのリンクを表示する", async () => {
+  it("成功時は成功メッセージと今すぐ進むリンクを表示する", async () => {
     mockedConfirmPasswordReset.mockResolvedValue({ message: "ok" });
     render(<PasswordResetPage />);
 
@@ -75,8 +81,45 @@ describe("PasswordResetPage", () => {
       await screen.findByText(/パスワードを変更しました/)
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "ログイン画面へ" })
+      screen.getByRole("link", { name: "今すぐログイン画面へ進む" })
     ).toHaveAttribute("href", "/login");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "3秒後にログイン画面へ移動します。"
+    );
+  });
+
+  it("成功から3秒後にログイン画面へ自動遷移する", async () => {
+    jest.useFakeTimers({ advanceTimers: true });
+    mockedConfirmPasswordReset.mockResolvedValue({ message: "ok" });
+    render(<PasswordResetPage />);
+
+    fillPasswords("newpass123", "newpass123");
+    submit();
+    await screen.findByText(/パスワードを変更しました/);
+
+    expect(mockedReplace).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(3000);
+    expect(mockedReplace).toHaveBeenCalledWith("/login");
+
+    jest.useRealTimers();
+  });
+
+  it("「今すぐ進む」を待たずクリックしても、後から自動遷移が重複しない（アンマウントでタイマー解除）", async () => {
+    jest.useFakeTimers({ advanceTimers: true });
+    mockedConfirmPasswordReset.mockResolvedValue({ message: "ok" });
+    const { unmount } = render(<PasswordResetPage />);
+
+    fillPasswords("newpass123", "newpass123");
+    submit();
+    await screen.findByText(/パスワードを変更しました/);
+
+    // リンククリック相当（実際の画面遷移はNext.jsが担うため、ここではアンマウントで代替する）
+    unmount();
+    jest.advanceTimersByTime(3000);
+
+    expect(mockedReplace).not.toHaveBeenCalled();
+
+    jest.useRealTimers();
   });
 
   it("パスワードが一致しない場合はAPIを呼ばずエラーを表示する", async () => {

--- a/frontend/app/(auth)/password-reset/[token]/page.tsx
+++ b/frontend/app/(auth)/password-reset/[token]/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Link from "next/link";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { confirmPasswordReset, ApiError } from "@/lib/apiClient";
 
 const defaultResetError =
@@ -10,8 +10,14 @@ const defaultResetError =
 const invalidTokenError =
   "リンクが正しくないみたい。もう一度メールのリンクを確認してね。";
 
+// 成功表示のまま留まり、手動でリンクをクリックしないとログイン画面へ
+// 進めない問題への対応。自動遷移までの猶予を数秒設け、その間に
+// メッセージを読めるようにする。
+const AUTO_REDIRECT_DELAY_MS = 3000;
+
 export default function PasswordResetPage() {
   const params = useParams();
+  const router = useRouter();
   const rawToken = params?.token;
   const token = typeof rawToken === "string" ? rawToken : "";
 
@@ -74,6 +80,14 @@ export default function PasswordResetPage() {
     }
   };
 
+  useEffect(() => {
+    if (!successMessage) return;
+    const timer = setTimeout(() => {
+      router.replace("/login");
+    }, AUTO_REDIRECT_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [successMessage, router]);
+
   return (
     <div className="flex items-center justify-center min-h-screen bg-background text-foreground px-4 sm:px-6 lg:px-8">
       <form
@@ -86,19 +100,20 @@ export default function PasswordResetPage() {
         </h2>
 
         {successMessage ? (
-          <>
-            <p className="text-green-600 text-center" aria-live="polite">
-              {successMessage}
+          <div role="status" aria-live="polite">
+            <p className="text-green-600 text-center">{successMessage}</p>
+            <p className="mt-2 text-center text-sm text-muted-foreground">
+              3秒後にログイン画面へ移動します。
             </p>
             <div className="mt-6 text-center text-sm">
               <Link
                 href="/login"
                 className="font-medium text-primary hover:underline"
               >
-                ログイン画面へ
+                今すぐログイン画面へ進む
               </Link>
             </div>
-          </>
+          </div>
         ) : (
           <>
             {!token && (


### PR DESCRIPTION
## Summary
- パスワードリセット成功画面が、手動でリンクをクリックしないとログイン画面へ進めない問題に対応（8月計画の持ち越し項目）
- 成功表示から3秒後に`router.replace("/login")`で自動遷移。「今すぐログイン画面へ進む」リンクも残し、待ちたくないユーザーはすぐ進める
- コンポーネントのアンマウント時に`clearTimeout`でタイマーを解除（多重遷移・メモリリーク防止）
- 成功メッセージ全体を`role="status"` `aria-live="polite"`でラップし、スクリーンリーダーにも伝わるようにした

## Test plan
- [x] Jest: 新規3ケース（3秒後の自動遷移／アンマウントでタイマー解除されること／今すぐ進むリンクとroleステータス表示）を含む8ケースすべてpass
- [x] Jest全体: 69 suites / 511 tests すべてpass（既存分含む、回帰なし）
- [x] ローカルdevサーバー＋fetchモックで実ブラウザ操作を確認：送信→成功表示→3秒後に`/login`へ自動遷移することを目視確認（スクリーンショット取得済み）