### PR TITLE
fix: associate demo dreams with self profiles in seeds

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -15,21 +15,36 @@ def ensure_demo_user(email:, username:, password:)
   user
 end
 
+# dreams.dream_profile_id は NOT NULL のため、実際の登録導線（UsersController#create）と
+# 同じ形で「自分」プロフィールを用意してから夢を作る。
+def ensure_self_profile(user)
+  user.dream_profiles.find_or_create_by!(relationship: "self") do |profile|
+    profile.name = "自分"
+    profile.avatar_emoji = "😴"
+    profile.color = "#6366f1"
+    profile.active = true
+    profile.position = 0
+  end
+end
+
 family_demo = ensure_demo_user(
   email: 'family_demo@example.com',
   username: '家族デモ',
   password: 'password123'
 )
+family_self_profile = ensure_self_profile(family_demo)
 
 child_demo = ensure_demo_user(
   email: 'child_demo@example.com',
   username: 'こどもデモ',
   password: 'password123'
 )
+child_self_profile = ensure_self_profile(child_demo)
 
-def ensure_dream(user:, title:, content:, emotion_names:, emotion_cache:)
+def ensure_dream(user:, dream_profile:, title:, content:, emotion_names:, emotion_cache:)
   dream = user.dreams.find_or_initialize_by(title: title)
   dream.content = content
+  dream.dream_profile = dream_profile
   dream.save!
 
   emotions = emotion_names.filter_map { |name| emotion_cache[name] }
@@ -64,6 +79,7 @@ family_dreams = [
 family_dreams.each do |dream_attrs|
   ensure_dream(
     user: family_demo,
+    dream_profile: family_self_profile,
     title: dream_attrs[:title],
     content: dream_attrs[:content],
     emotion_names: dream_attrs[:emotion_names],
@@ -97,6 +113,7 @@ child_dreams = [
 child_dreams.each do |dream_attrs|
   ensure_dream(
     user: child_demo,
+    dream_profile: child_self_profile,
     title: dream_attrs[:title],
     content: dream_attrs[:content],
     emotion_names: dream_attrs[:emotion_names],

--- a/backend/spec/db/seeds_spec.rb
+++ b/backend/spec/db/seeds_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+# backend/db/seeds.rb の回帰テスト。
+#
+# 経緯: ensure_dream が dream_profile_id を設定せずに Dream を作成しており、
+# dreams.dream_profile_id の NOT NULL 制約（#413）に反して db:seed が失敗していた。
+# 実際の登録導線（UsersController#create）と同じ形で「自分」プロフィールを
+# 用意してから夢を作るよう修正したが、db:seed 自体はCIで一度も実行されないため、
+# 同種の書き忘れが再発してもCIでは検知できない。このspecは
+# Rails.application.load_seed を直接呼び、その完走と結果を検証することで
+# db:seed の健全性だけをCIで守る。
+RSpec.describe 'db:seed (backend/db/seeds.rb)' do
+  DEMO_EMAILS = %w[family_demo@example.com child_demo@example.com].freeze
+
+  # db/seeds.rb は 'Seeding of emotions and demo users completed.' を
+  # puts するため、テスト出力を汚さないよう stdout を抑制する。
+  def run_seed
+    original = $stdout
+    $stdout = StringIO.new
+    Rails.application.load_seed
+  ensure
+    $stdout = original
+  end
+
+  def demo_users
+    User.where(email: DEMO_EMAILS)
+  end
+
+  it '例外なく完走する' do
+    expect { run_seed }.not_to raise_error
+  end
+
+  it '対象デモユーザーが2件作成される' do
+    run_seed
+    expect(demo_users.count).to eq(2)
+  end
+
+  it '対象デモユーザーごとに relationship: "self" のプロフィールが1件だけ存在する' do
+    run_seed
+
+    demo_users.find_each do |user|
+      expect(user.dream_profiles.where(relationship: 'self').count).to eq(1)
+    end
+  end
+
+  it '対象となるすべてのデモ夢に dream_profile_id が設定される' do
+    run_seed
+
+    dreams = Dream.where(user: demo_users)
+    expect(dreams).to be_present
+    expect(dreams.pluck(:dream_profile_id)).to all(be_present)
+  end
+
+  it '各デモ夢の user_id と、その dream_profile の user_id が一致する' do
+    run_seed
+
+    Dream.where(user: demo_users).includes(:dream_profile).find_each do |dream|
+      expect(dream.dream_profile).to be_present
+      expect(dream.dream_profile.user_id).to eq(dream.user_id)
+    end
+  end
+
+  it '2回実行しても、対象デモユーザー・selfプロフィール・デモ夢の件数が増えない' do
+    run_seed
+
+    before_user_count = demo_users.count
+    before_self_profile_count = DreamProfile.where(user: demo_users, relationship: 'self').count
+    before_dream_count = Dream.where(user: demo_users).count
+
+    expect { run_seed }.not_to raise_error
+
+    expect(demo_users.count).to eq(before_user_count)
+    expect(DreamProfile.where(user: demo_users, relationship: 'self').count).to eq(before_self_profile_count)
+    expect(Dream.where(user: demo_users).count).to eq(before_dream_count)
+  end
+end


### PR DESCRIPTION
## 概要

- `dream_profile_id`が必須になった後も、デモ夢作成時にプロフィールが渡されていなかった問題を修正
- デモユーザーごとに`relationship: "self"`のDreamProfileを作成または再利用
- デモ夢を対応するselfプロフィールへ関連付け
- seedを繰り返し実行しても重複しない設計を維持

## 原因

- `ensure_dream`がデモ夢作成時に`dream_profile_id`を設定していなかった
- 新規DBなど既存デモ夢がない環境では、NOT NULL制約により`db:seed`が失敗していた

## 追加した回帰テスト

`backend/spec/db/seeds_spec.rb`で以下を確認:

- `Rails.application.load_seed`が例外なく完走する
- 対象デモユーザーごとにselfプロフィールが1件だけ存在する
- 全デモ夢に`dream_profile_id`が設定される
- 夢とプロフィールの所有ユーザーが一致する
- seedを2回実行しても、デモユーザー・selfプロフィール・デモ夢が増えない

## 検証結果

```
修正版のseed Spec:
6 examples, 0 failures

修正前へ一時的に戻した回帰検知:
6 examples, 6 failures
PG::NotNullViolationを検知

新規Spec + 既存関連Spec:
78 examples, 0 failures
```

## テスト環境上の注意

- `RAILS_ENV=test`でも、コンテナの`DATABASE_URL`が優先されると開発DBへ接続する可能性があった
- 最終検証では`DATABASE_URL`の影響を除外し、`app_test`へ正しく接続して確認した