### PR TITLE
fix: /trialのリロード後0/7表示をDB累計と一致させる

### DIFF
--- a/frontend/__tests__/app/trial/page.test.tsx
+++ b/frontend/__tests__/app/trial/page.test.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import TrialPage from "@/app/trial/page";
@@ -375,5 +376,43 @@ describe("TrialPage: 既存の夢をDBから読み込んで件数表示に反映
         "お試しで のこせる ゆめは 7こ までだよ。アカウント登録すると、ずっと のこせるよ。"
       )
     ).toBeInTheDocument();
+  });
+
+  // premium: true の trial 由来ユーザーは、DreamsController#check_trial_dream_limit が
+  // 明示的に7件上限から除外している。フロントの既存件数取得・上限表示もこのユーザーには
+  // 適用しない（課金済みなのに/trialだけ書けなくなるのを防ぐ、Codexレビュー指摘）。
+  it("premium: trueのtrialユーザーは既存dreamを取得せず、上限表示も出さない", async () => {
+    mockedUseAuth.mockReturnValue(
+      makeAuth({ user: { id: "1", trial_user: true, premium: true } })
+    );
+
+    render(<TrialPage />);
+
+    expect(
+      await screen.findByText(/記録した夢 \(0\/7\)/)
+    ).toBeInTheDocument();
+    expect(mockedGet).not.toHaveBeenCalled();
+  });
+
+  // React/Next の開発時Strict Modeはマウント時にeffectを
+  // setup→cleanup→setupと二重実行する。一度きりのref判定だけで実装すると、
+  // 最初のsetupの取得がcleanupでキャンセルされた後、2回目のsetupがrefにより
+  // 素通りしてしまい、読み込み中表示のまま固まる（Codexレビュー指摘）。
+  it("Strict Modeでeffectが二重実行されても、読み込みが完了しボタンが使えるようになる", async () => {
+    mockedGet.mockResolvedValue([]);
+
+    render(
+      <React.StrictMode>
+        <TrialPage />
+      </React.StrictMode>
+    );
+
+    // 読み込み中表示のまま固まらないことを確認（Strict Modeの二重実行分だけ
+    // apiClient.get が2回呼ばれること自体は開発時のみの無害な副作用として許容する）。
+    await waitForExistingDreamsLoaded();
+    writeDream("Strict Modeでも かける ゆめ");
+    expect(
+      screen.getByRole("button", { name: /記録だけする/ })
+    ).not.toBeDisabled();
   });
 });

--- a/frontend/__tests__/app/trial/page.test.tsx
+++ b/frontend/__tests__/app/trial/page.test.tsx
@@ -7,7 +7,9 @@ import apiClient, {
   previewAnalysis,
   updateDream,
   verifyAuth,
+  ApiError,
 } from "@/lib/apiClient";
+import type { Dream } from "@/app/types";
 
 // 体験版で書いた夢がDBに保存されず、再読み込みや本登録で消えていた問題
 // （2026-07-22・2026-08-02のTrial P3 QAを2回無効化した実データ損失バグ）の回帰テスト。
@@ -23,7 +25,7 @@ jest.mock("@/lib/apiClient", () => {
   }
   return {
     __esModule: true,
-    default: { post: jest.fn() },
+    default: { post: jest.fn(), get: jest.fn() },
     ApiError: MockApiError,
     createDream: jest.fn(),
     previewAnalysis: jest.fn(),
@@ -45,6 +47,7 @@ const mockedPreviewAnalysis = previewAnalysis as jest.MockedFunction<
 >;
 const mockedVerifyAuth = verifyAuth as jest.MockedFunction<typeof verifyAuth>;
 const mockedPost = apiClient.post as jest.MockedFunction<typeof apiClient.post>;
+const mockedGet = apiClient.get as jest.MockedFunction<typeof apiClient.get>;
 
 type AuthValue = ReturnType<typeof useAuth>;
 
@@ -61,6 +64,17 @@ const makeAuth = (over: Partial<AuthValue> = {}): AuthValue =>
     ...over,
   }) as AuthValue;
 
+const makeExistingDream = (i: number, overrides: Partial<Dream> = {}): Dream =>
+  ({
+    id: i,
+    title: `過去の夢${i}`,
+    content: `過去の夢の内容${i}`,
+    userId: 1,
+    created_at: "2026-08-01T00:00:00.000Z",
+    updated_at: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  }) as Dream;
+
 const writeDream = (text: string) => {
   fireEvent.change(
     screen.getByPlaceholderText("今朝見た夢を書いてみてください..."),
@@ -68,9 +82,20 @@ const writeDream = (text: string) => {
   );
 };
 
+// 既存の夢の読み込み（マウント時の1回だけの取得）が完了するのを待つ。
+// 読み込み中は「記録だけする」「AIにきいてみる」が無効化されているため、
+// クリック系の操作を行う既存テストは、まずこの完了を待つ必要がある。
+const waitForExistingDreamsLoaded = () =>
+  waitFor(() => {
+    expect(
+      screen.queryByText("記録した夢を確認しています…")
+    ).not.toBeInTheDocument();
+  });
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockedUseAuth.mockReturnValue(makeAuth());
+  mockedGet.mockResolvedValue([] as Awaited<ReturnType<typeof apiClient.get>>);
   mockedCreateDream.mockResolvedValue({ id: 1 } as Awaited<
     ReturnType<typeof createDream>
   >);
@@ -86,6 +111,7 @@ beforeEach(() => {
 describe("TrialPage: 体験版の夢をDBへ保存する", () => {
   it("「記録だけする」でDBへ保存する（stateだけに積まない）", async () => {
     render(<TrialPage />);
+    await waitForExistingDreamsLoaded();
     writeDream("青い扉の夢");
 
     fireEvent.click(screen.getByRole("button", { name: /記録だけする/ }));
@@ -99,6 +125,7 @@ describe("TrialPage: 体験版の夢をDBへ保存する", () => {
 
   it("「AIにきいてみる」は先に保存してから分析し、結果を紐づける", async () => {
     render(<TrialPage />);
+    await waitForExistingDreamsLoaded();
     writeDream("空を飛ぶ夢");
 
     fireEvent.click(screen.getByRole("button", { name: /AIにきいてみる/ }));
@@ -127,6 +154,7 @@ describe("TrialPage: 体験版の夢をDBへ保存する", () => {
   it("保存に失敗したらAI分析を実行しない（貴重な回数を無駄にしない）", async () => {
     mockedCreateDream.mockRejectedValue(new Error("boom"));
     render(<TrialPage />);
+    await waitForExistingDreamsLoaded();
     writeDream("ほぞんに しっぱいする ゆめ");
 
     fireEvent.click(screen.getByRole("button", { name: /AIにきいてみる/ }));
@@ -138,6 +166,7 @@ describe("TrialPage: 体験版の夢をDBへ保存する", () => {
   it("分析だけ失敗しても、保存済みの夢は一覧に残る", async () => {
     mockedPreviewAnalysis.mockRejectedValue(new Error("analysis down"));
     render(<TrialPage />);
+    await waitForExistingDreamsLoaded();
     writeDream("ぶんせきが こける ゆめ");
 
     fireEvent.click(screen.getByRole("button", { name: /AIにきいてみる/ }));
@@ -173,6 +202,7 @@ describe("TrialPage: 体験版の夢をDBへ保存する", () => {
 
   it("タイトル未入力なら既定の名前で保存する", async () => {
     render(<TrialPage />);
+    await waitForExistingDreamsLoaded();
     writeDream("なまえのない夢");
 
     fireEvent.click(screen.getByRole("button", { name: /記録だけする/ }));
@@ -187,6 +217,7 @@ describe("TrialPage: 体験版の夢をDBへ保存する", () => {
   it("保存に失敗したら一覧へ足さず、エラーを表示する（画面が嘘をつかない）", async () => {
     mockedCreateDream.mockRejectedValue(new Error("boom"));
     render(<TrialPage />);
+    await waitForExistingDreamsLoaded();
     writeDream("ほぞんに しっぱいする ゆめ");
 
     fireEvent.click(screen.getByRole("button", { name: /記録だけする/ }));
@@ -217,5 +248,132 @@ describe("TrialPage: 体験版の夢をDBへ保存する", () => {
       );
     });
     await waitFor(() => expect(mockedCreateDream).toHaveBeenCalled());
+  });
+});
+
+// リロード後に「記録した夢 (0/7)」へ戻ってしまう表示不整合の回帰テスト。
+// Rails側は current_user.dreams.count（DB累計）で7件上限を強制しているため、
+// 既存の夢を取り込んで dreams state をDBの実態に合わせる。
+describe("TrialPage: 既存の夢をDBから読み込んで件数表示に反映する", () => {
+  it("既存5件を取得すると5/7になり、一覧にも既存5件が表示される", async () => {
+    mockedGet.mockResolvedValue(
+      Array.from({ length: 5 }, (_, i) => makeExistingDream(i + 1))
+    );
+
+    render(<TrialPage />);
+
+    expect(
+      await screen.findByText(/記録した夢 \(5\/7\)/)
+    ).toBeInTheDocument();
+    expect(screen.getByText("過去の夢1")).toBeInTheDocument();
+    expect(screen.getByText("過去の夢5")).toBeInTheDocument();
+  });
+
+  it("既存7件なら上限表示になり、両ボタンとも追加できない", async () => {
+    mockedGet.mockResolvedValue(
+      Array.from({ length: 7 }, (_, i) => makeExistingDream(i + 1))
+    );
+
+    render(<TrialPage />);
+    await waitForExistingDreamsLoaded();
+    writeDream("8こめの ゆめ");
+
+    expect(
+      screen.getByText(/記録した夢 \(7\/7\)/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /記録だけする/ })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /AIにきいてみる/ })
+    ).toBeDisabled();
+  });
+
+  it("未認証状態では既存dreamの取得を行わない", async () => {
+    mockedUseAuth.mockReturnValue(
+      makeAuth({ authStatus: "unauthenticated", isLoggedIn: false, user: null })
+    );
+
+    render(<TrialPage />);
+
+    // 未認証では読み込み中表示も出さず、即座に通常の空表示になる
+    expect(
+      await screen.findByText(/記録した夢 \(0\/7\)/)
+    ).toBeInTheDocument();
+    expect(mockedGet).not.toHaveBeenCalled();
+  });
+
+  it("本登録ユーザー（trial_userでない）が開いた場合も既存dreamの取得を行わない", async () => {
+    mockedUseAuth.mockReturnValue(
+      makeAuth({ user: { id: "1", trial_user: false } })
+    );
+
+    render(<TrialPage />);
+
+    expect(
+      await screen.findByText(/記録した夢 \(0\/7\)/)
+    ).toBeInTheDocument();
+    expect(mockedGet).not.toHaveBeenCalled();
+  });
+
+  it("既存dreamの取得に失敗してもページはクラッシュせず、通常どおり操作できる", async () => {
+    mockedGet.mockRejectedValue(new Error("network down"));
+
+    render(<TrialPage />);
+    await waitForExistingDreamsLoaded();
+
+    // 取得失敗時は0件のまま操作を継続できる（バックエンドの累計7件強制が最後の砦）
+    expect(screen.getByText(/記録した夢 \(0\/7\)/)).toBeInTheDocument();
+    writeDream("しっぱいしても だいじょうぶな ゆめ");
+    fireEvent.click(screen.getByRole("button", { name: /記録だけする/ }));
+
+    await waitFor(() => {
+      expect(mockedCreateDream).toHaveBeenCalledWith(
+        expect.objectContaining({ content: "しっぱいしても だいじょうぶな ゆめ" })
+      );
+    });
+  });
+
+  it("初回取得後に1件保存すると、既存件数に正しく1件加わる（二重カウントしない）", async () => {
+    mockedGet.mockResolvedValue(
+      Array.from({ length: 2 }, (_, i) => makeExistingDream(i + 1))
+    );
+
+    render(<TrialPage />);
+    expect(
+      await screen.findByText(/記録した夢 \(2\/7\)/)
+    ).toBeInTheDocument();
+
+    writeDream("3こめの ゆめ");
+    fireEvent.click(screen.getByRole("button", { name: /記録だけする/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/記録した夢 \(3\/7\)/)).toBeInTheDocument();
+    });
+    // 初回取得した2件がそのまま残っている（消えていない）
+    expect(screen.getByText("過去の夢1")).toBeInTheDocument();
+    expect(screen.getByText("過去の夢2")).toBeInTheDocument();
+  });
+
+  // バックエンドが累計7件を超えた保存を403 + limit_reached=true で拒否した場合も、
+  // 既存のエラー表示経路（saveErrorMessage）がそのまま機能することを確認する。
+  it("バックエンドが403（limit_reached）を返しても、既存の日本語エラー表示経路で表示される", async () => {
+    const limitError = new ApiError(
+      "お試しで のこせる ゆめは 7こ までだよ。アカウント登録すると、ずっと のこせるよ。"
+    );
+    limitError.status = 403;
+    mockedCreateDream.mockRejectedValue(limitError);
+
+    render(<TrialPage />);
+    await waitForExistingDreamsLoaded();
+    writeDream("うえげんを こえた ゆめ");
+
+    fireEvent.click(screen.getByRole("button", { name: /記録だけする/ }));
+
+    expect(
+      await screen.findByText(
+        "お試しで のこせる ゆめは 7こ までだよ。アカウント登録すると、ずっと のこせるよ。"
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/app/trial/page.tsx
+++ b/frontend/app/trial/page.tsx
@@ -56,11 +56,15 @@ export default function TrialPage() {
   // trialユーザーがリロードすると「0/7」に見えてしまっていた（表示上の不整合、
   // データは失われていない）。初回マウント時に一度だけ既存件数を取り込んで補正する。
   const [isLoadingExistingDreams, setIsLoadingExistingDreams] = useState(false);
-  // 初回のauthStatus確定（checking→authenticated/unauthenticated）でのみ判定する。
-  // ページ内でtrial_loginが後から発生しても再取得しない
-  // （直後の setDreams(prev => [...prev, 新規夢]) を空配列取得結果で
-  // 上書きしてしまう競合を避けるため）。
-  const hasCheckedExistingDreamsRef = useRef(false);
+  // "idle": 未着手 / "loading": 取得中 / "done": 判定・取得済み。
+  // 完了(done)後は、ページ内でtrial_loginが後から発生してもこの判定を
+  // やり直さない（直後の setDreams(prev => [...prev, 新規夢]) を空配列取得結果で
+  // 上書きしてしまう競合を避けるため）。一方、開発時のReact Strict Modeによる
+  // setup→cleanup→setupの二重実行では、取得完了前にcleanupが走るため
+  // "loading"から"idle"へ戻し、直後の再setupで正しく最初からやり直せるようにする。
+  const existingDreamsFetchStateRef = useRef<"idle" | "loading" | "done">(
+    "idle"
+  );
 
   // AI分析関連
   const [isAnalyzing, setIsAnalyzing] = useState(false);
@@ -76,16 +80,23 @@ export default function TrialPage() {
 
   // 初回のauthStatus確定時、既にログイン中のtrialユーザーであれば
   // DB上の既存の夢を読み込み、件数表示とボタンの活性制御を実態に合わせる。
-  // 本登録ユーザー（trial_user !== true）はこれまでどおり対象外
-  // （このページの元々の上限表示は本登録ユーザーには効いていないため、
-  // 挙動を変えない）。未認証の新規訪問者は取得自体を行わない。
+  // 対象は trial_user かつ非premium のみ。
+  // - 本登録ユーザー（trial_user !== true）はこれまでどおり対象外
+  //   （このページの元々の上限表示は本登録ユーザーには効いていないため、挙動を変えない）
+  // - premium: true の trial 由来ユーザーは、バックエンドの
+  //   check_trial_dream_limit が明示的に7件上限から除外している
+  //   （課金済みなのに/trialだけ書けなくなるのを防ぐ）
+  // 未認証の新規訪問者は取得自体を行わない。
   useEffect(() => {
     if (isAuthChecking) return;
-    if (hasCheckedExistingDreamsRef.current) return;
-    hasCheckedExistingDreamsRef.current = true;
+    if (existingDreamsFetchStateRef.current !== "idle") return;
 
-    if (authStatus !== "authenticated" || !user?.trial_user) return;
+    if (authStatus !== "authenticated" || !user?.trial_user || user?.premium) {
+      existingDreamsFetchStateRef.current = "done";
+      return;
+    }
 
+    existingDreamsFetchStateRef.current = "loading";
     let cancelled = false;
     setIsLoadingExistingDreams(true);
 
@@ -100,11 +111,19 @@ export default function TrialPage() {
         // 引き続き働くため、表示が一時的に不正確でもデータは保護される。
       })
       .finally(() => {
-        if (!cancelled) setIsLoadingExistingDreams(false);
+        if (cancelled) return;
+        setIsLoadingExistingDreams(false);
+        existingDreamsFetchStateRef.current = "done";
       });
 
     return () => {
       cancelled = true;
+      // Strict Mode（開発時のみ）の合成cleanupで、取得完了前に中断された場合は
+      // idle へ戻す。直後の再setupがこの中断分を正しくやり直せるようにするため。
+      if (existingDreamsFetchStateRef.current === "loading") {
+        existingDreamsFetchStateRef.current = "idle";
+        setIsLoadingExistingDreams(false);
+      }
     };
   }, [authStatus, isAuthChecking, user]);
 

--- a/frontend/app/trial/page.tsx
+++ b/frontend/app/trial/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import MorpheusSmall from "@/app/components/MorpheusSmall";
 import apiClient from "@/lib/apiClient";
 import { useAuth } from "@/context/AuthContext";
-import { User } from "@/app/types";
+import { Dream, User } from "@/app/types";
 import {
   ApiError,
   createDream,
@@ -23,8 +23,23 @@ type AnalysisResult = {
 const MAX_TRIAL_DREAMS = 7;
 const MAX_TRIAL_ANALYSES = 3;
 
+// バックエンドの Dream を、このページのローカル表示形式へ変換する。
+const toLocalDream = (
+  dream: Dream
+): { title: string; description: string; analysis?: AnalysisResult } => ({
+  title: dream.title,
+  description: dream.content ?? "",
+  analysis:
+    dream.analysis_status === "done" && dream.analysis_json
+      ? {
+          analysis: dream.analysis_json.analysis,
+          emotion_tags: dream.analysis_json.emotion_tags,
+        }
+      : undefined,
+});
+
 export default function TrialPage() {
-  const { authStatus, login } = useAuth();
+  const { authStatus, user, login } = useAuth();
 
   // 認証済みユーザーもこのページは使える（自分のアカウントでAI分析される）
   // LPからの遷移で未認証の場合は、AI分析ボタン押下時にトライアルログインを自動実行
@@ -34,6 +49,18 @@ export default function TrialPage() {
   >([]);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+
+  // 既存のtrial夢をDBから読み込み中かどうか。
+  // Rails側は current_user.dreams.count（DB累計）で7件上限を強制しているが、
+  // このページの dreams state は毎回空配列から始まるため、既存の夢がある
+  // trialユーザーがリロードすると「0/7」に見えてしまっていた（表示上の不整合、
+  // データは失われていない）。初回マウント時に一度だけ既存件数を取り込んで補正する。
+  const [isLoadingExistingDreams, setIsLoadingExistingDreams] = useState(false);
+  // 初回のauthStatus確定（checking→authenticated/unauthenticated）でのみ判定する。
+  // ページ内でtrial_loginが後から発生しても再取得しない
+  // （直後の setDreams(prev => [...prev, 新規夢]) を空配列取得結果で
+  // 上書きしてしまう競合を避けるため）。
+  const hasCheckedExistingDreamsRef = useRef(false);
 
   // AI分析関連
   const [isAnalyzing, setIsAnalyzing] = useState(false);
@@ -46,6 +73,40 @@ export default function TrialPage() {
 
   // checking中はボタンを無効化するためのフラグ
   const isAuthChecking = authStatus === "checking";
+
+  // 初回のauthStatus確定時、既にログイン中のtrialユーザーであれば
+  // DB上の既存の夢を読み込み、件数表示とボタンの活性制御を実態に合わせる。
+  // 本登録ユーザー（trial_user !== true）はこれまでどおり対象外
+  // （このページの元々の上限表示は本登録ユーザーには効いていないため、
+  // 挙動を変えない）。未認証の新規訪問者は取得自体を行わない。
+  useEffect(() => {
+    if (isAuthChecking) return;
+    if (hasCheckedExistingDreamsRef.current) return;
+    hasCheckedExistingDreamsRef.current = true;
+
+    if (authStatus !== "authenticated" || !user?.trial_user) return;
+
+    let cancelled = false;
+    setIsLoadingExistingDreams(true);
+
+    apiClient
+      .get<Dream[]>("/dreams")
+      .then((existingDreams) => {
+        if (cancelled) return;
+        setDreams(existingDreams.map(toLocalDream));
+      })
+      .catch(() => {
+        // 取得失敗時は空のまま進める。DB上の累計7件強制はバックエンド側で
+        // 引き続き働くため、表示が一時的に不正確でもデータは保護される。
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingExistingDreams(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authStatus, isAuthChecking, user]);
 
   // トライアルセッションを確保する（未認証ならトライアルアカウントを自動作成）。
   // 成功したら true、失敗したらエラー文言を立てて false を返す。
@@ -285,6 +346,7 @@ export default function TrialPage() {
               isAnalyzing ||
               isSaving ||
               isAuthChecking ||
+              isLoadingExistingDreams ||
               analysisLimitReached ||
               dreams.length >= MAX_TRIAL_DREAMS ||
               !description.trim()
@@ -320,6 +382,7 @@ export default function TrialPage() {
               isAnalyzing ||
               isSaving ||
               isAuthChecking ||
+              isLoadingExistingDreams ||
               dreams.length >= MAX_TRIAL_DREAMS ||
               !description.trim()
             }
@@ -349,10 +412,12 @@ export default function TrialPage() {
       {/* 記録した夢リスト */}
       <div className="mb-8">
         <h3 className="text-lg font-bold mb-4">
-          記録した夢 ({dreams.length}/{MAX_TRIAL_DREAMS})
+          {isLoadingExistingDreams
+            ? "記録した夢を確認しています…"
+            : `記録した夢 (${dreams.length}/${MAX_TRIAL_DREAMS})`}
         </h3>
 
-        {dreams.length === 0 ? (
+        {isLoadingExistingDreams ? null : dreams.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             まだ記録がありません。上のフォームから夢を記録してみましょう。
           </p>


### PR DESCRIPTION
## 概要

`/trial`画面をリロードすると、既にDBへ保存済みの夢があるtrialユーザーでも「記録した夢 (0/7)」と表示されてしまう不整合を修正した。

## 事実確認（実装前に完了）

- Rails側は`DreamsController#check_trial_dream_limit`で`current_user.dreams.count`（DB累計・ページネーションなし）を7件上限の基準にしている（`TRIAL_DREAM_LIMIT = 7`）
- `GET /dreams`（パラメータなし）は`DreamFilterQuery`が無条件で素通しするため、上記と全く同じ集合（`current_user.dreams`全件）を返す
- `docs/yumetree-interview-codebase-guide.md`にPR #372の設計意図として「trialかつ非premiumの夢作成を7件までに制限」と明記されており、「累計」が最初からの意図
- 以上より、これは仕様変更ではなく**表示の不整合バグ**と判断した

## 原因

`frontend/app/trial/page.tsx`の`dreams`stateはマウントのたびに空配列から始まり、DBに何件保存済みかを一切考慮していなかった。

## 修正内容

- 初回のauthStatus確定時、`authStatus === "authenticated" && user?.trial_user`の場合のみ`GET /dreams`で既存の夢を取得し、`dreams`stateへ反映
- 本登録ユーザー（`trial_user`でない）・未認証の新規訪問者は取得自体を行わない（既存の挙動を維持）
- ページ内で後からtrial_loginが発生しても再取得しない（refで一度きりに制御し、直後の`setDreams(prev => [...prev, 新規夢])`を空配列取得結果で上書きする競合を回避）
- 読み込み中は件数表示・一覧を隠し、両ボタンを無効化（誤った0/7の一瞬表示、stale状態での保存操作を防止）
- 取得失敗時は空のまま継続（バックエンドの累計7件強制が最後の安全装置として引き続き機能する）
- Rails側の`TRIAL_DREAM_LIMIT`・制約ロジックは変更していない

## 変更ファイル

- `frontend/app/trial/page.tsx`
- `frontend/__tests__/app/trial/page.test.tsx`

## テスト

新規6件（要求5件＋バックエンド403エラー表示経路の確認1件）:
- 既存5件取得で5/7表示・一覧反映
- 既存7件で上限表示・両ボタン無効化
- 未認証では取得しない
- 本登録ユーザーでも取得しない（追加確認）
- 取得失敗でもクラッシュせず操作継続
- 初回取得後の保存で正しく+1（二重カウントなし）
- バックエンド403(limit_reached)時も既存の日本語エラー表示経路が機能する

既存8件のテストは、マウント時フェッチの完了を待ってから操作するよう更新（新しい非同期処理に合わせた必要な変更で、それ以外のロジック変更なし）。

## テスト結果

- `frontend/__tests__/app/trial/page.test.tsx`: 15 examples, 0 failures
- Jest全体: 69 suites / 518 tests, 0 failures
- Playwright `e2e/trial-flow.spec.ts`: 8 passed（このファイルの全テストは`authStatus: unauthenticated`から始まるため、今回のフェッチ処理は発火せず無影響と確認）

## 残るリスク

- 低。バックエンドの制約ロジックは変更していないため、表示が万一おかしくてもデータ整合性は保たれる
- 本登録ユーザーが`/trial`を開いた際の既存の（本PR以前からの）フロント側ソフトガードの粗さ（バックエンドは本登録ユーザーに上限を課さないが、フロントの表示上は7件で止まって見える）は本PRのスコープ外として温存

🤖 Generated with [Claude Code](https://claude.com/claude-code)