### PR TITLE
fix: Stripe決済の冪等性とWebhook競合を強化

### DIFF
--- a/backend/app/controllers/checkout_controller.rb
+++ b/backend/app/controllers/checkout_controller.rb
@@ -36,7 +36,8 @@ class CheckoutController < ApplicationController
           frontend_url: frontend_url,
           customer_id: customer_id,
           premium_price_id: premium_price_id
-        )
+        ),
+        idempotency_key: SecureRandom.uuid
       )
 
       PaymentsObservability.increment('checkout.session.created', user_id: current_user.id)

--- a/backend/app/controllers/webhooks_controller.rb
+++ b/backend/app/controllers/webhooks_controller.rb
@@ -261,7 +261,14 @@ class WebhooksController < ApplicationController
     if existing
       existing.with_lock { block.call(existing) }
     else
-      block.call(Subscription.new(stripe_subscription_id: stripe_subscription_id))
+      # 新規INSERTだけをsavepointに隔離する。ここでRecordNotUnique（DBの一意制約違反）が
+      # 発生した場合、Railsはこのsavepointだけをロールバックして例外を再送出するため、
+      # StripeWebhookEventProcessor#call が開いている外側トランザクションはabortしない。
+      # 隔離しないと、外側トランザクションごとabort状態になり、下のrescueで再試行する
+      # find_byがPG::InFailedSqlTransactionで失敗してしまう。
+      ApplicationRecord.transaction(requires_new: true) do
+        block.call(Subscription.new(stripe_subscription_id: stripe_subscription_id))
+      end
     end
   rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
     raise if attempts >= 2 || !duplicate_stripe_subscription_id_error?(e)

--- a/backend/app/controllers/webhooks_controller.rb
+++ b/backend/app/controllers/webhooks_controller.rb
@@ -203,46 +203,76 @@ class WebhooksController < ApplicationController
     Rails.logger.info("[Webhook] サブスク解約 user_id=#{user.id} sub_id=#{stripe_subscription_id}")
   end
 
+  # 同じ subscription に対する複数のWebhookイベント（checkout.session.completed /
+  # invoice.payment_succeeded / customer.subscription.deleted）がほぼ同時に届いても、
+  # 行ロックと一意制約違反時の再試行により最終的な状態が競合で壊れないようにする。
   def sync_subscription!(stripe_subscription, preferred_user: nil, fallback_customer_id: nil, fallback_current_period_end: nil)
     stripe_subscription_id = extract_object_id(stripe_subscription)
-    subscription = Subscription.find_or_initialize_by(stripe_subscription_id: stripe_subscription_id)
-    stripe_customer_id =
-      if stripe_subscription.respond_to?(:customer)
-        extract_object_id(stripe_subscription.customer).presence
-      end
-    stripe_customer_id ||= fallback_customer_id
-    stripe_customer_id ||= subscription.stripe_customer_id
+    raise InvalidCheckoutSessionPayloadError, 'Stripe subscription is missing id' if stripe_subscription_id.blank?
 
     status = stripe_subscription.respond_to?(:status) ? stripe_subscription.status.to_s : nil
-    current_period_end =
-      if stripe_subscription.respond_to?(:current_period_end)
-        timestamp_to_time(stripe_subscription.current_period_end)
-      end
-    current_period_end ||= fallback_current_period_end
-
-    raise InvalidCheckoutSessionPayloadError, 'Stripe subscription is missing id' if stripe_subscription_id.blank?
-    raise InvalidCheckoutSessionPayloadError, 'Stripe subscription is missing customer id' if stripe_customer_id.blank?
     unless Subscription::STATUSES.include?(status)
       raise InvalidCheckoutSessionPayloadError, "Unsupported Stripe subscription status: #{status.presence || 'missing'}"
     end
 
-    user = preferred_user || subscription.user || User.find_by(stripe_customer_id: stripe_customer_id)
-    raise UnresolvedWebhookDataError, 'Subscription user could not be resolved' unless user
+    stripe_customer_id_from_source =
+      if stripe_subscription.respond_to?(:customer)
+        extract_object_id(stripe_subscription.customer).presence
+      end
+    current_period_end_from_source =
+      if stripe_subscription.respond_to?(:current_period_end)
+        timestamp_to_time(stripe_subscription.current_period_end)
+      end
 
-    subscription.assign_attributes(
-      user: user,
-      stripe_customer_id: stripe_customer_id,
-      status: status,
-      current_period_end: current_period_end
-    )
-    subscription.save!
+    subscription, user = upsert_subscription_with_retry!(stripe_subscription_id) do |subscription|
+      stripe_customer_id = stripe_customer_id_from_source || fallback_customer_id || subscription.stripe_customer_id
+      raise InvalidCheckoutSessionPayloadError, 'Stripe subscription is missing customer id' if stripe_customer_id.blank?
 
-    user.update!(
-      stripe_customer_id: stripe_customer_id,
-      premium: user.premium_active_subscription?
-    )
+      user = preferred_user || subscription.user || User.find_by(stripe_customer_id: stripe_customer_id)
+      raise UnresolvedWebhookDataError, 'Subscription user could not be resolved' unless user
+
+      subscription.assign_attributes(
+        user: user,
+        stripe_customer_id: stripe_customer_id,
+        status: status,
+        current_period_end: current_period_end_from_source || fallback_current_period_end
+      )
+      subscription.save!
+
+      [subscription, user]
+    end
+
+    user.with_lock do
+      user.update!(
+        stripe_customer_id: subscription.stripe_customer_id,
+        premium: user.premium_active_subscription?
+      )
+    end
 
     [subscription, user]
+  end
+
+  # 既存のsubscription行があれば with_lock で排他制御しつつ更新する。
+  # 未作成の場合は新規作成を試み、一意制約違反（別イベントが先に作成した）を検知したら
+  # 既存行として取得し直して再試行する。
+  def upsert_subscription_with_retry!(stripe_subscription_id, attempts: 0, &block)
+    existing = Subscription.find_by(stripe_subscription_id: stripe_subscription_id)
+
+    if existing
+      existing.with_lock { block.call(existing) }
+    else
+      block.call(Subscription.new(stripe_subscription_id: stripe_subscription_id))
+    end
+  rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+    raise if attempts >= 2 || !duplicate_stripe_subscription_id_error?(e)
+
+    upsert_subscription_with_retry!(stripe_subscription_id, attempts: attempts + 1, &block)
+  end
+
+  def duplicate_stripe_subscription_id_error?(error)
+    return true if error.is_a?(ActiveRecord::RecordNotUnique)
+
+    error.record.errors[:stripe_subscription_id].present?
   end
 
   def resolve_user_from_session(session)

--- a/backend/spec/requests/checkout_spec.rb
+++ b/backend/spec/requests/checkout_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Checkout API', type: :request do
             mode: 'payment',
             success_url: "#{frontend_url}/donation/success",
             cancel_url: "#{frontend_url}/donation/cancel"
-          ))
+          ), hash_including(idempotency_key: a_kind_of(String)))
           .and_return(checkout_session)
 
         authenticated_post('/checkout', user)
@@ -95,7 +95,7 @@ RSpec.describe 'Checkout API', type: :request do
             mode: 'payment',
             success_url: "#{frontend_url}/donation/success",
             cancel_url: "#{frontend_url}/donation/cancel"
-          ))
+          ), hash_including(idempotency_key: a_kind_of(String)))
           .and_return(checkout_session)
 
         authenticated_post('/checkout', user)
@@ -117,7 +117,7 @@ RSpec.describe 'Checkout API', type: :request do
             line_items: [hash_including(price: premium_price_id, quantity: 1)],
             success_url: "#{frontend_url}/subscription/success?session_id={CHECKOUT_SESSION_ID}",
             cancel_url: "#{frontend_url}/subscription/cancel"
-          ))
+          ), hash_including(idempotency_key: a_kind_of(String)))
           .and_return(checkout_session)
 
         authenticated_post('/checkout', user, params: { plan: 'premium' })
@@ -154,6 +154,27 @@ RSpec.describe 'Checkout API', type: :request do
 
         expect(response).to have_http_status(:internal_server_error)
         expect(JSON.parse(response.body)['error']).to include('プレミアム決済')
+      end
+
+      it '毎回異なる idempotency_key を Stripe に渡す' do
+        user = create(:user, stripe_customer_id: 'cus_existing_123')
+        allow(Stripe::Customer).to receive(:retrieve).with('cus_existing_123').and_return(double('StripeCustomer'))
+        headers = auth_headers(user)
+
+        captured_keys = []
+        allow(Stripe::Checkout::Session).to receive(:create) do |_params, opts|
+          captured_keys << opts[:idempotency_key]
+          checkout_session
+        end
+
+        post '/checkout', params: {}, headers: headers, as: :json
+        expect(response).to have_http_status(:ok)
+        post '/checkout', params: {}, headers: headers, as: :json
+        expect(response).to have_http_status(:ok)
+
+        expect(captured_keys.size).to eq(2)
+        expect(captured_keys).to all(be_a(String))
+        expect(captured_keys.uniq.size).to eq(2)
       end
 
       it 'Priceがlive modeならCustomerやCheckout Sessionを作成しない' do
@@ -201,7 +222,7 @@ RSpec.describe 'Checkout API', type: :request do
             payment_method_types: ['card'],
             success_url: "#{frontend_url}/subscription/success?session_id={CHECKOUT_SESSION_ID}",
             cancel_url:  "#{frontend_url}/subscription/cancel"
-          ))
+          ), hash_including(idempotency_key: a_kind_of(String)))
           .and_return(subscription_session)
 
         authenticated_post('/checkout', user, params: { plan: 'premium' })

--- a/backend/spec/requests/webhooks_spec.rb
+++ b/backend/spec/requests/webhooks_spec.rb
@@ -723,6 +723,49 @@ RSpec.describe 'Webhooks API', type: :request do
             end
           end.to change(Subscription, :count).by(1)
         end
+
+        # 実スレッドでの競合再現はGVL・ローカルDBの高速な往復でウィンドウが狭すぎて
+        # 安定的に踏めないため（spec/services/auth_service_spec.rb と同じ判断）、
+        # find_by が「未作成」を返した直後に別イベントが先に作成済みにする状況を
+        # 確定的に作り出し、一意制約違反時の再試行が機能することを直接検証する。
+        it '一意制約違反（別イベントが先に作成済み）を検知して再試行し、Subscriptionを1件に保つ' do
+          user = create(:user, email: customer_email, stripe_customer_id: 'cus_test_123')
+          allow(Stripe::Webhook).to receive(:construct_event)
+            .and_return(stripe_event_subscription_completed)
+
+          call_count = 0
+          allow(Subscription).to receive(:find_by)
+            .with({ stripe_subscription_id: 'sub_test_123' })
+            .and_wrap_original do |original, *args|
+              call_count += 1
+              if call_count == 1
+                Subscription.create!(
+                  stripe_subscription_id: 'sub_test_123',
+                  user: user,
+                  stripe_customer_id: 'cus_test_123',
+                  status: 'past_due'
+                )
+                nil
+              else
+                original.call(*args)
+              end
+            end
+
+          expect do
+            post '/webhooks/stripe',
+              params: payload,
+              headers: {
+                'Content-Type' => 'application/json',
+                'Stripe-Signature' => sig_header,
+                'HOST' => 'backend'
+              }
+          end.to change(Subscription, :count).by(1)
+
+          expect(response).to have_http_status(:ok)
+          subscription = Subscription.find_by!(stripe_subscription_id: 'sub_test_123')
+          expect(subscription.status).to eq('active')
+          expect(user.reload.premium).to be true
+        end
       end
 
       context 'invoice.payment_succeeded の場合' do

--- a/backend/spec/requests/webhooks_spec.rb
+++ b/backend/spec/requests/webhooks_spec.rb
@@ -766,6 +766,61 @@ RSpec.describe 'Webhooks API', type: :request do
           expect(subscription.status).to eq('active')
           expect(user.reload.premium).to be true
         end
+
+        # Codex #490 P2指摘の回帰防止テスト。
+        # 上のテストは Subscription.find_by の直前に横入りする形で「先着」レコードを
+        # 作成しているため、Railsのuniquenessバリデーション（事前SELECT）がそれを検出し、
+        # ActiveRecord::RecordInvalid になる（DBの一意制約までは到達しない）。
+        # しかし実際の同時webhookレースでは、両者のバリデーションSELECTが
+        # どちらも「衝突なし」と判定した後にINSERTが競合するため、
+        # 検証すべきは ActiveRecord::RecordNotUnique（真のDB一意制約違反）である。
+        # ここではuniquenessバリデーションを無効化し、その状況を確定的に再現したうえで、
+        # StripeWebhookEventProcessorが開く外側トランザクションがabortせず、
+        # 再試行のfind_byがPG::InFailedSqlTransactionにならないことをDB-backedで検証する。
+        it '真のDB一意制約違反（RecordNotUnique）が発生しても外側トランザクションを壊さず再試行できる' do
+          stripe_subscription_id = 'sub_savepoint_test_123'
+          user = create(:user, stripe_customer_id: 'cus_savepoint_test')
+          controller = WebhooksController.new
+
+          allow_any_instance_of(ActiveRecord::Validations::UniquenessValidator)
+            .to receive(:validate_each)
+
+          call_count = 0
+          allow(Subscription).to receive(:find_by)
+            .with({ stripe_subscription_id: stripe_subscription_id })
+            .and_wrap_original do |original, *args|
+              call_count += 1
+              if call_count == 1
+                Subscription.create!(
+                  stripe_subscription_id: stripe_subscription_id,
+                  user: user,
+                  stripe_customer_id: 'cus_savepoint_test',
+                  status: 'past_due'
+                )
+                nil
+              else
+                original.call(*args)
+              end
+            end
+
+          ApplicationRecord.transaction(requires_new: true) do
+            subscription, resolved_user = controller.send(
+              :upsert_subscription_with_retry!,
+              stripe_subscription_id
+            ) do |sub|
+              sub.assign_attributes(user: user, stripe_customer_id: 'cus_savepoint_test', status: 'active')
+              sub.save!
+              [sub, user]
+            end
+
+            expect(subscription.status).to eq('active')
+            expect(resolved_user).to eq(user)
+            expect(Subscription.where(stripe_subscription_id: stripe_subscription_id).count).to eq(1)
+
+            # 外側トランザクションがabortしていれば、ここで PG::InFailedSqlTransaction になる
+            expect(Subscription.find_by(stripe_subscription_id: stripe_subscription_id)).to be_present
+          end
+        end
       end
 
       context 'invoice.payment_succeeded の場合' do


### PR DESCRIPTION
## Summary
- `Stripe::Checkout::Session.create` に `idempotency_key`（`SecureRandom.uuid`）を付与し、Stripe SDKの自動ネットワークリトライによるCheckout Session二重作成を防ぐ
- `WebhooksController#sync_subscription!` に行ロック（`with_lock`）と一意制約違反時の再試行を追加。同一 `stripe_subscription_id` に対する複数のWebhookイベント（`checkout.session.completed` / `invoice.payment_succeeded` / `customer.subscription.deleted`）がほぼ同時に届いても、Subscriptionレコードが重複作成されたり中途半端な状態になったりしないようにする
- `User#premium` の更新も `with_lock` で排他制御し、複数subscriptionを持つユーザーのpremiumフラグ計算の競合を防ぐ
- **（Codexレビュー対応）** `upsert_subscription_with_retry!` の新規INSERTを `ApplicationRecord.transaction(requires_new: true)` のsavepointで隔離。DBレベルの真の一意制約違反（`RecordNotUnique`）が発生しても、`StripeWebhookEventProcessor` が開く外側トランザクションを壊さず再試行できるようにした

## Background
PR #464 で `ProcessedWebhookEvent` による同一 `stripe_event_id` の重複処理防止は実装済みだったが、**異なる event_id** が同じsubscriptionに対してほぼ同時に届くケース（例: `checkout.session.completed` と `invoice.payment_succeeded` が近接して届く）への排他制御はなかった。理論上の二重課金・データ不整合リスクへの対応として、低〜中優先度のフォローアップとして着手。

## Test plan
- [x] `bundle exec rspec spec/requests/checkout_spec.rb spec/requests/webhooks_spec.rb` — 47 examples, 0 failures
- [x] `bundle exec rspec`（全体）— 445 examples, 0 failures
- [x] 新規テスト: idempotency_keyが呼び出しごとに異なることを確認
- [x] 新規テスト: `find_by` が「未作成」を返した直後に別イベントが先にSubscriptionを作成済みにするレースを確定的に再現し、一意制約違反からの再試行でSubscriptionが1件に保たれることを確認（実スレッドでの再現は `spec/services/auth_service_spec.rb` と同じ理由で不採用、確定的シミュレーションを採用）
- [x] **新規テスト（Codex #490 P2指摘の回帰防止）**: Railsのuniquenessバリデーションを無効化し、実PostgreSQL上でDBレベルの真の `RecordNotUnique` を発生させたうえで、`requires_new` savepointにより外側トランザクションが継続利用できること（`PG::InFailedSqlTransaction` にならないこと）をDB-backedで検証。修正前のコードに対して実行し、指摘どおり `PG::InFailedSqlTransaction` で失敗することを確認済み

マージ判断は後ほどお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
