### PR TITLE
test: dream_profile_idの他人プロフィール指定に対する回帰テストを追加

### DIFF
--- a/backend/spec/models/dream_spec.rb
+++ b/backend/spec/models/dream_spec.rb
@@ -34,10 +34,16 @@ RSpec.describe Dream, type: :model do
       expect(dream.errors[:dream_profile_id]).to include('は自分のプロフィールを指定してください')
     end
 
-    it 'dream_profile_idが未指定でも保存できる' do
+    it 'dream_profile_idが未指定だとRailsのバリデーションは通るが、DBのNOT NULL制約で保存に失敗する' do
+      # dreams.dream_profile_id は schema.rb で null: false。
+      # モデルにpresenceバリデーションはないため valid? はtrueになるが、
+      # 実際の保存は失敗する（このギャップがあるため、実際に夢を作る唯一の経路である
+      # DreamsController#create は self_dream_profile_id へのフォールバックで必ず埋めている。
+      # 下のrequest specでそのフォールバックを確認している）。
       dream = build(:dream, user: user, dream_profile: nil)
 
       expect(dream).to be_valid
+      expect { dream.save!(validate: false) }.to raise_error(ActiveRecord::NotNullViolation)
     end
   end
 

--- a/backend/spec/models/dream_spec.rb
+++ b/backend/spec/models/dream_spec.rb
@@ -16,6 +16,31 @@ RSpec.describe Dream, type: :model do
     it { should have_many(:emotions).through(:dream_emotions) }
   end
 
+  describe 'dream_profile_id のバリデーション' do
+    let(:other_user) { create(:user) }
+
+    it '自分のdream_profileなら保存できる' do
+      profile = create(:dream_profile, user: user)
+      dream = build(:dream, user: user, dream_profile: profile)
+
+      expect(dream).to be_valid
+    end
+
+    it '他人のdream_profileを指定すると無効になる' do
+      other_profile = create(:dream_profile, user: other_user)
+      dream = build(:dream, user: user, dream_profile: other_profile)
+
+      expect(dream).not_to be_valid
+      expect(dream.errors[:dream_profile_id]).to include('は自分のプロフィールを指定してください')
+    end
+
+    it 'dream_profile_idが未指定でも保存できる' do
+      dream = build(:dream, user: user, dream_profile: nil)
+
+      expect(dream).to be_valid
+    end
+  end
+
   describe 'スコープ' do
     let!(:dream_with_image) do
       create(:dream, user: user, generated_image_url: 'https://example.com/image.png', image_generated_at: Time.current)

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -120,10 +120,23 @@ RSpec.describe 'Dreams API', type: :request do
       it '内容が1000文字を超える場合失敗する' do
         long_content = 'あ' * 1001
         params = valid_dream_params.merge(dream: { title: 'タイトル', content: long_content })
-        
+
         authenticated_post('/dreams', user, params: params)
-        
+
         expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it '他人のdream_profile_idを指定すると夢を作成できない' do
+        other_profile = create(:dream_profile, user: other_user)
+        params = valid_dream_params.deep_merge(dream: { dream_profile_id: other_profile.id })
+
+        expect {
+          authenticated_post('/dreams', user, params: params)
+        }.not_to change(Dream, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        json_response = JSON.parse(response.body)
+        expect(json_response['error'].join).to include('自分のプロフィール')
       end
     end
 
@@ -268,6 +281,21 @@ RSpec.describe 'Dreams API', type: :request do
         authenticated_put('/dreams/99999', user, params: update_params)
 
         expect(response).to have_http_status(:not_found)
+      end
+
+      it '自分の夢を他人のdream_profile_idへ付け替えられない' do
+        other_profile = create(:dream_profile, user: other_user)
+        original_profile_id = user_dream.dream_profile_id
+        params = update_params.deep_merge(dream: { dream_profile_id: other_profile.id })
+
+        authenticated_put("/dreams/#{user_dream.id}", user, params: params)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        json_response = JSON.parse(response.body)
+        expect(json_response['error'].join).to include('自分のプロフィール')
+        # 更新は丸ごと失敗しなければならない（dream_profile_idだけでなくtitle等も一切変わらない）
+        expect(user_dream.reload.dream_profile_id).to eq(original_profile_id)
+        expect(user_dream.title).to eq('元のタイトル')
       end
     end
 

--- a/backend/spec/requests/dreams_spec.rb
+++ b/backend/spec/requests/dreams_spec.rb
@@ -96,6 +96,15 @@ RSpec.describe 'Dreams API', type: :request do
         expect(created_dream.emotions.count).to eq(2)
       end
 
+      it 'dream_profile_idを指定しない場合、自分のselfプロフィールへフォールバックする' do
+        expect(valid_dream_params[:dream]).not_to have_key(:dream_profile_id)
+
+        authenticated_post('/dreams', user, params: valid_dream_params)
+
+        expect(response).to have_http_status(:created)
+        expect(Dream.last.dream_profile_id).to eq(user.self_dream_profile_id)
+      end
+
       it '無効なパラメーターで夢作成に失敗する' do
         expect {
           authenticated_post('/dreams', user, params: invalid_dream_params)


### PR DESCRIPTION
## Problem
Must③監査（dream_profiles導入後の主要画面・authorization確認）の一環として調査したところ、`Dream`モデルには`dream_profile_belongs_to_user`バリデーション（他ユーザーの`dream_profile`を指定すると保存できない）が既に実装されているが、これを確認するテストが`POST /dreams`・`PUT /dreams/:id`のRequest Spec・Dream Model Specのどこにも存在しなかった。

## Cause
実装漏れではなく、テストカバレッジの漏れ。`DreamsController#dream_params`は`:dream_profile_id`をユーザー入力から直接permitしているため、モデル層のバリデーションだけがこの経路を守っている状態だった。

## Fix
コード変更なし。以下の回帰テストを追加し、既存の防御が実際に機能していることを確認した。
- `backend/spec/models/dream_spec.rb`: 他人の`dream_profile`を指定すると`invalid`になることのモデル単体テスト
- `backend/spec/requests/dreams_spec.rb`:
  - `POST /dreams`で他人の`dream_profile_id`を指定すると422・件数増えないことを確認
  - `PUT /dreams/:id`で自分の夢を他人の`dream_profile_id`へ付け替えようとすると422になり、`dream_profile_id`・他の属性も一切変更されないことを確認

## Test
- `bundle exec rspec spec/models/dream_spec.rb spec/requests/dreams_spec.rb spec/requests/dream_profiles_spec.rb` — 133 examples, 0 failures
- `bundle exec rspec`（backend全体）— 447 examples, 0 failures
- `git diff --check` — 問題なし

## Risk
テスト追加のみ。プロダクションコードの変更なし。

## Manual QA needed
なし（既存の防御を確認する回帰テストのため、追加の実機QAは不要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)