### PR TITLE
fix: /homeでプロフィールを素早く切り替えたときのレース条件を修正

### DIFF
--- a/frontend/__tests__/app/home/page.profile-switch-race.test.tsx
+++ b/frontend/__tests__/app/home/page.profile-switch-race.test.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import HomePage from "@/app/home/page";
+import type { Dream, DreamProfile } from "@/app/types";
+
+// searchParamsを可変にし、router.pushで書き換えたうえで再レンダーすることで、
+// 「プロフィールを素早く切り替えたときの検索パラメータ変化」を模倣する。
+let currentSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn((url: string) => {
+      const queryString = url.includes("?") ? url.split("?")[1] : "";
+      currentSearchParams = new URLSearchParams(queryString);
+    }),
+    refresh: jest.fn(),
+  }),
+  useSearchParams: () => currentSearchParams,
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}));
+
+const mockGet = jest.fn();
+jest.mock("@/lib/apiClient", () => ({
+  __esModule: true,
+  default: { get: (...args: unknown[]) => mockGet(...args) },
+  getEmotions: jest.fn().mockResolvedValue([]),
+  getAnalysisQuota: jest
+    .fn()
+    .mockResolvedValue({ unlimited: true, used: null, limit: null, remaining: null }),
+  getDreamProfiles: jest.fn().mockResolvedValue([
+    { id: 1, name: "A", avatar_emoji: "🐱", color: "#f97316", relationship: "self", active: true, position: 0, archived: false, created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T00:00:00Z" } as DreamProfile,
+    { id: 2, name: "B", avatar_emoji: "🐶", color: "#22c55e", relationship: "child", active: true, position: 1, archived: false, created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T00:00:00Z" } as DreamProfile,
+  ]),
+}));
+
+jest.mock("@/app/components/WeeklyDreamNewsWidget", () => ({
+  __esModule: true,
+  default: () => <div>WeeklyDreamNewsWidget</div>,
+}));
+jest.mock("@/app/components/MorpheusHero", () => ({ __esModule: true, default: () => <div>MorpheusHero</div> }));
+jest.mock("@/app/components/DreamEntryLauncher", () => ({ __esModule: true, default: () => <div>DreamEntryLauncher</div> }));
+jest.mock("@/app/components/TrialBanner", () => ({ __esModule: true, default: () => <div>TrialBanner</div> }));
+jest.mock("@/app/components/EmailVerificationBanner", () => ({ __esModule: true, default: () => <div>EmailVerificationBanner</div> }));
+jest.mock("@/app/components/DreamAdventurePanel", () => ({ __esModule: true, default: () => <div>DreamAdventurePanel</div> }));
+jest.mock("@/app/components/forest/ForestPreviewWidget", () => ({ __esModule: true, default: () => <div>ForestPreviewWidget</div> }));
+jest.mock("@/app/components/SearchBar", () => ({ __esModule: true, default: () => <div>SearchBar</div> }));
+jest.mock("@/app/components/ProfileFilterChips", () => ({ __esModule: true, default: () => <div>ProfileFilterChips</div> }));
+jest.mock("@/app/components/DreamList", () => ({
+  __esModule: true,
+  default: ({ dreams }: { dreams: Dream[] }) => (
+    <div data-testid="dream-list-ids">{dreams.map((d) => d.id).join(",")}</div>
+  ),
+}));
+jest.mock("@/app/components/DreamCardSkeleton", () => ({ __esModule: true, DreamListSkeleton: () => <div>DreamListSkeleton</div> }));
+jest.mock("@/app/components/DreamStatsWidget", () => ({ __esModule: true, default: () => <div>DreamStatsWidget</div> }));
+jest.mock("@/app/components/DreamStreakBadge", () => ({
+  __esModule: true,
+  default: () => <div>DreamStreakBadge</div>,
+  calculateDreamStreak: () => ({ current: 0, longest: 0 }),
+}));
+jest.mock("@/app/components/MorpheusGuide", () => ({ __esModule: true, MorpheusGuideHome: () => <div>MorpheusGuideHome</div> }));
+jest.mock("@/app/components/MorpheusLoginRequired", () => ({ __esModule: true, default: () => <div>MorpheusLoginRequired</div> }));
+jest.mock("../../../app/loading", () => ({ __esModule: true, default: () => <div>Loading</div> }));
+
+function dream(id: number): Dream {
+  return {
+    id,
+    title: `夢${id}`,
+    userId: 1,
+    created_at: "2026-07-10T00:00:00Z",
+    updated_at: "2026-07-10T00:00:00Z",
+  } as Dream;
+}
+
+// URLに応じて手動で解決タイミングを制御できるPromiseを返す
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("HomePage: プロフィール切り替え時のレース条件", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    currentSearchParams = new URLSearchParams();
+    mockUseAuth.mockReturnValue({
+      authStatus: "authenticated",
+      user: { id: "1", username: "テストユーザー", premium: true },
+    });
+  });
+
+  it("プロフィールAの取得が遅延している間にBへ切り替えても、後から届くAの結果でBの表示が上書きされない", async () => {
+    const deferredByProfile: Record<string, ReturnType<typeof deferred<Dream[]>>> = {
+      "1": deferred<Dream[]>(),
+      "2": deferred<Dream[]>(),
+    };
+
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes("dream_profile_id=1")) return deferredByProfile["1"].promise;
+      if (url.includes("dream_profile_id=2")) return deferredByProfile["2"].promise;
+      // ニュース専用取得など他の呼び出しは即座に空配列で返す
+      return Promise.resolve([]);
+    });
+
+    const { rerender } = render(<HomePage />);
+
+    // プロフィールAを選択（1件目のfetchが発火し、まだ解決していない）
+    await act(async () => {
+      currentSearchParams = new URLSearchParams("dream_profile_id=1");
+      rerender(<HomePage />);
+    });
+
+    // Aの応答が届く前にプロフィールBへ切り替える（2件目のfetchが発火）
+    await act(async () => {
+      currentSearchParams = new URLSearchParams("dream_profile_id=2");
+      rerender(<HomePage />);
+    });
+
+    // Bの応答が先に届く
+    await act(async () => {
+      deferredByProfile["2"].resolve([dream(200)]);
+    });
+
+    // その後、遅れてAの応答が届く（ネットワーク遅延で順序が逆転したケースを模倣）
+    await act(async () => {
+      deferredByProfile["1"].resolve([dream(100)]);
+    });
+
+    // 現在選択中はBのはずなので、画面にはBの夢だけが残っていてほしい
+    expect(screen.getByTestId("dream-list-ids")).toHaveTextContent("200");
+  });
+});

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { LayoutGrid, List } from "lucide-react";
@@ -140,10 +140,18 @@ export default function HomePage() {
   const [weeklyNewsError, setWeeklyNewsError] = useState(false);
   const [dreamViewMode, setDreamViewMode] = useState<DreamViewMode>("grid");
 
+  // プロフィール切り替え等で検索条件が短時間に変わると、複数のfetchが同時に
+  // 飛ぶことがある。ネットワーク遅延で応答が逆転すると、古い（今は選ばれていない）
+  // 条件の結果で新しい結果を上書きしてしまうため、常に「最後に発行したリクエスト」の
+  // 結果だけを反映するようにする。
+  const latestFetchIdRef = useRef(0);
+
   const fetchDreams = useCallback(async () => {
     if (authStatus !== "authenticated") {
       return;
     }
+
+    const fetchId = ++latestFetchIdRef.current;
 
     setLoading(true);
     setErrorMessage(null);
@@ -168,14 +176,24 @@ export default function HomePage() {
       const url = queryString ? `/dreams?${queryString}` : "/dreams";
       const dreamsData = await apiClient.get<Dream[]>(url);
 
+      // 待っている間に、より新しい条件でのfetchが発行されていたら、この結果は捨てる
+      if (fetchId !== latestFetchIdRef.current) {
+        return;
+      }
+
       setDreams(dreamsData);
     } catch (error) {
+      if (fetchId !== latestFetchIdRef.current) {
+        return;
+      }
       console.error("Error fetching dreams:", error);
       setErrorMessage(
         "データの取得に失敗しました。ページを再読み込みしてください。"
       );
     } finally {
-      setLoading(false);
+      if (fetchId === latestFetchIdRef.current) {
+        setLoading(false);
+      }
     }
   }, [authStatus, searchParams]);
 


### PR DESCRIPTION
## Problem
`/home`でdream profileを素早く切り替える（例: A→B）と、Aの`GET /dreams`応答がBより後に届いた場合、Bへ切り替えた後にAの夢一覧が表示されてしまう競合状態があった。

## Cause
`fetchDreams`は`searchParams`が変わるたびに新しいリクエストを発行するが、応答の到着順を制御していなかった。ネットワーク遅延で古いリクエスト（A）の応答が新しいリクエスト（B）より後に届くと、`setDreams`が無条件に上書きするため、選択中のプロフィールと表示内容が食い違う。

## Fix
`fetchDreams`呼び出しごとにインクリメントする`useRef`カウンタで「自分が最後に発行したリクエストか」を判定し、待っている間により新しいリクエストが発行されていた場合は、その応答を画面に反映しない（`setDreams`/エラー表示/`setLoading(false)`をスキップ）ようにした。

## Test
- 新規テスト `frontend/__tests__/app/home/page.profile-switch-race.test.tsx`: プロフィールAの取得が遅延している間にBへ切り替え、Bの応答が先着・Aの応答が後着した場合でも表示がBのままであることを確認。修正前のコードに対して実行すると失敗する（Aの夢で上書きされる）ことを確認済み
- `npx jest __tests__/app/home/` — 6 examples, 0 failures
- `npx jest`（frontend全体）— 521 examples, 0 failures
- `npx next build` — ビルド成功、TypeScriptエラーなし
- `git diff --check` — 問題なし
- `next lint`はこの環境では`eslint.config.js`が存在せずNext.js 16の`next lint`自体が動作しない（CIにもlintステップは存在しない）ため、この変更に起因しないプリ既存の問題として今回は対象外とした

## Risk
`fetchDreams`のガード条件追加のみ。既存の呼び出し箇所・APIコール自体は変更していない。

## Manual QA needed
実機/ブラウザでプロフィールチップを素早く連打して切り替えた際に、表示が正しいプロフィールの夢のままであることの確認（自動テストで再現・修正確認済みのため必須ではないが、念のため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)