### PR TITLE
fix: プロフィール詳細ページを素早く切り替えたときのレース条件を修正

### DIFF
--- a/frontend/__tests__/app/forest/ForestProfilePage.race.test.tsx
+++ b/frontend/__tests__/app/forest/ForestProfilePage.race.test.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import ForestProfilePage from "@/app/forest/[profileId]/page";
+import type { Dream, DreamProfile } from "@/app/types";
+
+// useParamsを可変にし、値を書き換えたうえで再レンダーすることで、
+// 「別のプロフィール詳細ページへ素早く切り替えたときのパラメータ変化」を模倣する。
+let currentProfileId = "1";
+// load()の依存配列にrouterが含まれるため、モックが毎回新しいオブジェクトを返すと
+// useCallbackの同一性が壊れて無限に再fetchし続けてしまう。安定した参照を1つだけ使い回す。
+const stableRouter = { push: jest.fn(), replace: jest.fn(), refresh: jest.fn() };
+
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ profileId: currentProfileId }),
+  useRouter: () => stableRouter,
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}));
+
+const mockGetDreamProfiles = jest.fn();
+const mockGetDreamsForProfile = jest.fn();
+jest.mock("@/lib/apiClient", () => ({
+  __esModule: true,
+  getDreamProfiles: (...args: unknown[]) => mockGetDreamProfiles(...args),
+  getDreamsForProfile: (...args: unknown[]) => mockGetDreamsForProfile(...args),
+}));
+
+jest.mock("@/app/components/forest/ForestTree", () => ({
+  __esModule: true,
+  default: () => <div>ForestTree</div>,
+}));
+jest.mock("@/app/components/forest/PastDreamsList", () => ({
+  __esModule: true,
+  default: () => <div>PastDreamsList</div>,
+}));
+jest.mock("@/app/components/forest/ForestGuide", () => ({
+  __esModule: true,
+  default: () => <div>ForestGuide</div>,
+}));
+jest.mock("@/app/components/forest/SeasonalParticles", () => ({
+  __esModule: true,
+  default: () => <div>SeasonalParticles</div>,
+}));
+jest.mock("@/app/components/forest/FruitLegend", () => ({
+  __esModule: true,
+  default: () => <div>FruitLegend</div>,
+}));
+jest.mock("@/app/components/forest/ParticleField", () => ({
+  __esModule: true,
+  default: () => <div>ParticleField</div>,
+}));
+jest.mock("@/app/loading", () => ({
+  __esModule: true,
+  default: () => <div>Loading</div>,
+}));
+
+function profile(overrides: Partial<DreamProfile> = {}): DreamProfile {
+  return {
+    id: 1,
+    name: "自分",
+    avatar_emoji: "😴",
+    color: "#6366f1",
+    relationship: "self",
+    active: true,
+    position: 0,
+    archived: false,
+    created_at: "2026-06-24T00:00:00Z",
+    updated_at: "2026-06-24T00:00:00Z",
+    ...overrides,
+  } as DreamProfile;
+}
+
+function dream(id: number): Dream {
+  return {
+    id,
+    title: `夢${id}`,
+    userId: 1,
+    created_at: "2026-06-24T00:00:00Z",
+    updated_at: "2026-06-24T00:00:00Z",
+  } as Dream;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("ForestProfilePage: プロフィール詳細ページを素早く切り替えたときのレース条件", () => {
+  beforeEach(() => {
+    mockGetDreamProfiles.mockReset();
+    mockGetDreamsForProfile.mockReset();
+    currentProfileId = "1";
+    mockUseAuth.mockReturnValue({ authStatus: "authenticated" });
+  });
+
+  it("プロフィール1の取得が遅延している間にプロフィール2へ切り替えても、後から届く1の結果で2の表示が上書きされない", async () => {
+    const profiles = [profile({ id: 1, name: "いちろう" }), profile({ id: 2, name: "じろう" })];
+    const dreamsDeferred: Record<string, ReturnType<typeof deferred<Dream[]>>> = {
+      "1": deferred<Dream[]>(),
+      "2": deferred<Dream[]>(),
+    };
+
+    mockGetDreamProfiles.mockResolvedValue(profiles);
+    mockGetDreamsForProfile.mockImplementation((profileId: number) => {
+      return dreamsDeferred[String(profileId)].promise;
+    });
+
+    const { rerender } = render(<ForestProfilePage />);
+
+    // プロフィール1の詳細を開く（1件目のfetchが発火し、まだ解決していない）
+    await act(async () => {
+      currentProfileId = "1";
+      rerender(<ForestProfilePage />);
+    });
+
+    // 1の応答が届く前にプロフィール2の詳細へ切り替える（2件目のfetchが発火）
+    await act(async () => {
+      currentProfileId = "2";
+      rerender(<ForestProfilePage />);
+    });
+
+    // 2の応答が先に届く
+    await act(async () => {
+      dreamsDeferred["2"].resolve([dream(200)]);
+    });
+
+    // その後、遅れて1の応答が届く（ネットワーク遅延で順序が逆転したケースを模倣）
+    await act(async () => {
+      dreamsDeferred["1"].resolve([dream(100)]);
+    });
+
+    // 現在開いているのはプロフィール2の詳細のはずなので、見出しは「じろう」であってほしい
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("じろう");
+  });
+});

--- a/frontend/__tests__/app/room/RoomProfilePage.race.test.tsx
+++ b/frontend/__tests__/app/room/RoomProfilePage.race.test.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import DreamRoomPage from "@/app/room/[profileId]/page";
+import type { Dream, DreamProfile } from "@/app/types";
+
+// useParamsを可変にし、値を書き換えたうえで再レンダーすることで、
+// 「別のプロフィールの部屋へ素早く切り替えたときのパラメータ変化」を模倣する。
+let currentProfileId = "1";
+// loadRoomの依存配列にrouterが含まれるため、モックが毎回新しいオブジェクトを返すと
+// useCallbackの同一性が壊れて無限に再fetchし続けてしまう。安定した参照を1つだけ使い回す。
+const stableRouter = { push: jest.fn(), replace: jest.fn(), refresh: jest.fn() };
+
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ profileId: currentProfileId }),
+  useRouter: () => stableRouter,
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock("@/context/AuthContext", () => ({
+  __esModule: true,
+  useAuth: () => mockUseAuth(),
+}));
+
+const mockGetDreamProfiles = jest.fn();
+const mockGetDreamsForProfile = jest.fn();
+jest.mock("@/lib/apiClient", () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+  getDreamProfiles: (...args: unknown[]) => mockGetDreamProfiles(...args),
+  getDreamsForProfile: (...args: unknown[]) => mockGetDreamsForProfile(...args),
+}));
+
+function profile(overrides: Partial<DreamProfile> = {}): DreamProfile {
+  return {
+    id: 1,
+    name: "自分",
+    avatar_emoji: "😴",
+    color: "#6366f1",
+    relationship: "self",
+    active: true,
+    position: 0,
+    archived: false,
+    created_at: "2026-06-24T00:00:00Z",
+    updated_at: "2026-06-24T00:00:00Z",
+    ...overrides,
+  } as DreamProfile;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("DreamRoomPage: プロフィールの部屋を素早く切り替えたときのレース条件", () => {
+  beforeEach(() => {
+    mockGetDreamProfiles.mockReset();
+    mockGetDreamsForProfile.mockReset();
+    currentProfileId = "1";
+    mockUseAuth.mockReturnValue({ authStatus: "authenticated" });
+  });
+
+  it("プロフィール1の取得が遅延している間にプロフィール2へ切り替えても、後から届く1の結果で2の表示が上書きされない", async () => {
+    const profiles = [profile({ id: 1, name: "いちろう" }), profile({ id: 2, name: "じろう" })];
+    const dreamsDeferred: Record<string, ReturnType<typeof deferred<Dream[]>>> = {
+      "1": deferred<Dream[]>(),
+      "2": deferred<Dream[]>(),
+    };
+
+    mockGetDreamProfiles.mockResolvedValue(profiles);
+    mockGetDreamsForProfile.mockImplementation((profileId: number) => {
+      return dreamsDeferred[String(profileId)].promise;
+    });
+
+    const { rerender } = render(<DreamRoomPage />);
+
+    // プロフィール1の部屋を開く（1件目のfetchが発火し、まだ解決していない）
+    await act(async () => {
+      currentProfileId = "1";
+      rerender(<DreamRoomPage />);
+    });
+
+    // 1の応答が届く前にプロフィール2の部屋へ切り替える（2件目のfetchが発火）
+    await act(async () => {
+      currentProfileId = "2";
+      rerender(<DreamRoomPage />);
+    });
+
+    // 2の応答が先に届く（夢は0件でRoomEmptyState分岐に入る）
+    await act(async () => {
+      dreamsDeferred["2"].resolve([]);
+    });
+
+    // その後、遅れて1の応答が届く（ネットワーク遅延で順序が逆転したケースを模倣）
+    await act(async () => {
+      dreamsDeferred["1"].resolve([]);
+    });
+
+    // 現在開いているのはプロフィール2の部屋のはずなので、見出しは「じろう」であってほしい
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("じろう");
+  });
+});

--- a/frontend/app/forest/[profileId]/page.tsx
+++ b/frontend/app/forest/[profileId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { ChevronLeft } from "lucide-react";
@@ -132,7 +132,13 @@ export default function ForestProfilePage() {
   const cel = getCelestial(phase);
   const haze = HAZE[phase];
 
+  // 別のプロフィール詳細（別のprofileId）へ素早く切り替えると、古いprofileIdの
+  // 応答が新しい方より後に届くことがある。その古い応答で表示を上書きしないよう、
+  // 「自分が最後に発行したloadか」をrefで判定する。
+  const latestLoadIdRef = useRef(0);
+
   const load = useCallback(async () => {
+    const loadId = ++latestLoadIdRef.current;
     setIsLoading(true);
     if (!isValidForestProfileId(profileId)) {
       console.error("Invalid forest profileId", rawProfileId);
@@ -146,6 +152,9 @@ export default function ForestProfilePage() {
         getDreamProfiles(),
         getDreamsForProfile(profileId),
       ]);
+
+      if (loadId !== latestLoadIdRef.current) return;
+
       const allProfiles = normalizeDreamProfilesResponse(profilesResponse);
       if (!allProfiles) {
         router.replace("/forest");
@@ -161,11 +170,14 @@ export default function ForestProfilePage() {
       setProfile(found);
       setDreams(profileDreams);
     } catch (error) {
+      if (loadId !== latestLoadIdRef.current) return;
       console.error("Failed to load forest profile detail", error);
       toast.error("きを よみこめませんでした。");
       router.replace("/forest");
     } finally {
-      setIsLoading(false);
+      if (loadId === latestLoadIdRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [profileId, rawProfileId, router]);
 

--- a/frontend/app/room/[profileId]/page.tsx
+++ b/frontend/app/room/[profileId]/page.tsx
@@ -49,8 +49,14 @@ export default function DreamRoomPage() {
   const [frames, setFrames] = useState<Frame[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const frameAbortRef = useRef<AbortController | null>(null);
+  // 別のプロフィールの部屋へ素早く切り替えると、古いprofileIdの応答が新しい方より
+  // 後に届くことがある。その古い応答で表示を上書きしないよう、「自分が最後に発行した
+  // loadRoomか」をrefで判定する。
+  const latestRoomLoadIdRef = useRef(0);
 
   const loadRoom = useCallback(async () => {
+    const loadId = ++latestRoomLoadIdRef.current;
+
     if (!Number.isInteger(profileId) || profileId <= 0) {
       router.replace("/forest");
       setIsLoading(false);
@@ -63,6 +69,9 @@ export default function DreamRoomPage() {
         getDreamProfiles(),
         getDreamsForProfile(profileId),
       ]);
+
+      if (loadId !== latestRoomLoadIdRef.current) return;
+
       const selectedProfile = Array.isArray(profiles)
         ? profiles.find((candidate) =>
             candidate.id === profileId && !candidate.archived
@@ -77,10 +86,13 @@ export default function DreamRoomPage() {
       setProfile(selectedProfile);
       setDreams(profileDreams);
     } catch (error) {
+      if (loadId !== latestRoomLoadIdRef.current) return;
       console.error("Failed to load dream room", error);
       router.replace("/forest");
     } finally {
-      setIsLoading(false);
+      if (loadId === latestRoomLoadIdRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [profileId, router]);
 


### PR DESCRIPTION
## Problem
#493で修正した「/homeでプロフィールを素早く切り替えると旧レスポンスが新表示を上書きする」のと同じ根本原因が、`/forest/[profileId]`（森の詳細）と`/room/[profileId]`（夢の部屋）にも残っていた。

## Cause
両ページとも`load`/`loadRoom`が`profileId`（URLの動的セグメント）に依存して`getDreamProfiles()` + `getDreamsForProfile(profileId)`をfetchするが、応答の到着順を制御していなかった。別のプロフィール詳細へ素早く切り替える（例: 一覧から連続してタップする）と、旧`profileId`の応答が新しい方より後に届いた場合、新しい表示が古いプロフィールのデータで上書きされる。

## Fix
`load`/`loadRoom`呼び出しごとにインクリメントする`useRef`カウンタで「自分が最後に発行したリクエストか」を判定し、待っている間により新しいリクエストが発行されていた場合は結果を反映しない（`#493`と同じ最小パターン）。

## 横断監査の結果
`selectedProfile`/`dreamProfile`/`profileId`/`currentProfile`等を依存値とする非同期処理を洗い出し、以下は個別に確認した：
- `useRecentDream`（`/forest`一覧のプレビュー）: 既に`cancelled`フラグでガード済み（このバグクラスへの既存の正しい対策）
- `/forest`一覧・`/profiles`: プロフィール一覧の単発取得のみで、選択切替時に再fetchしない設計のためrace不成立
- `DreamForm`・`SearchBar`: プロフィール一覧取得は初回のみ、選択はローカルstateのためrace不成立
- `useDream`（`/dream/[id]`）: `dreamId`切り替えに対する同種の構造的ギャップを発見したが、トリガーが「プロフィール切替」ではなく「夢ID切替」であり、今回の対象範囲（profile依存fetch）とは異なるためこのPRには含めていない（別途フォローアップ候補として報告）

## Test
- 新規テスト2件（`ForestProfilePage.race.test.tsx`・`RoomProfilePage.race.test.tsx`）: それぞれ修正前のコードに対して実行し、レースが再現して失敗することを確認したうえで、修正後にgreenになることを確認
- `npx jest`（frontend全体）— 522 examples, 0 failures
- `npx next build` — ビルド成功、TypeScriptエラーなし
- `git diff --check` — 問題なし

## Risk
`load`/`loadRoom`へのガード条件追加のみ。既存の呼び出し箇所・APIコール自体・レンダリング内容は変更していない。

## Manual QA needed
実機/ブラウザで森の一覧から複数のプロフィールを素早く連続してタップした際に、開いた詳細ページの表示が正しいプロフィールのままであることの確認（自動テストで再現・修正確認済みのため必須ではないが、念のため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)